### PR TITLE
Change all voxel_size parameters to FloatingPoint type.

### DIFF
--- a/voxblox/include/voxblox/core/esdf_map.h
+++ b/voxblox/include/voxblox/core/esdf_map.h
@@ -16,7 +16,7 @@ class EsdfMap {
   typedef std::shared_ptr<EsdfMap> Ptr;
 
   struct Config {
-    float esdf_voxel_size = 0.2;
+    FloatingPoint esdf_voxel_size = 0.2;
     size_t esdf_voxels_per_side = 16u;
   };
 

--- a/voxblox/include/voxblox/core/labeltsdf_map.h
+++ b/voxblox/include/voxblox/core/labeltsdf_map.h
@@ -16,8 +16,8 @@ class LabelTsdfMap {
   typedef std::shared_ptr<LabelTsdfMap> Ptr;
 
   struct Config {
-    float voxel_size = 0.2f;
-    size_t voxels_per_side = 16.0f;
+    FloatingPoint voxel_size = 0.2;
+    size_t voxels_per_side = 16u;
   };
 
   explicit LabelTsdfMap(Config config)

--- a/voxblox/include/voxblox/core/occupancy_map.h
+++ b/voxblox/include/voxblox/core/occupancy_map.h
@@ -16,7 +16,7 @@ class OccupancyMap {
   typedef std::shared_ptr<OccupancyMap> Ptr;
 
   struct Config {
-    float occupancy_voxel_size = 0.2;
+    FloatingPoint occupancy_voxel_size = 0.2;
     size_t occupancy_voxels_per_side = 16u;
   };
 

--- a/voxblox/include/voxblox/core/tsdf_map.h
+++ b/voxblox/include/voxblox/core/tsdf_map.h
@@ -16,7 +16,7 @@ class TsdfMap {
   typedef std::shared_ptr<TsdfMap> Ptr;
 
   struct Config {
-    float tsdf_voxel_size = 0.2;
+    FloatingPoint tsdf_voxel_size = 0.2;
     size_t tsdf_voxels_per_side = 16u;
   };
 

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -60,7 +60,7 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
   int voxels_per_side = config.tsdf_voxels_per_side;
   nh_private_.param("tsdf_voxel_size", voxel_size, voxel_size);
   nh_private_.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
-  config.tsdf_voxel_size = static_cast<float>(voxel_size);
+  config.tsdf_voxel_size = static_cast<FloatingPoint>(voxel_size);
   config.tsdf_voxels_per_side = voxels_per_side;
   tsdf_map_.reset(new TsdfMap(config));
 

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -247,7 +247,7 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
   int voxels_per_side = config.tsdf_voxels_per_side;
   nh_private_.param("tsdf_voxel_size", voxel_size, voxel_size);
   nh_private_.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
-  config.tsdf_voxel_size = static_cast<float>(voxel_size);
+  config.tsdf_voxel_size = static_cast<FloatingPoint>(voxel_size);
   config.tsdf_voxels_per_side = voxels_per_side;
   tsdf_map_.reset(new TsdfMap(config));
 


### PR DESCRIPTION
Can we change all `voxel_size` parameters to `FloatingPoint` type (which is a double)? For the moment, the voxel size parameter is first stored as a float (e.g. in the TSDF map config struct), and then converted to `FloatingPoint` when calling the layer constructor. I think this does not make much sense, or am I wrong?