### PR TITLE
added casts needed to allow FloatingPoint = float to compile

### DIFF
--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -8,9 +8,9 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Core>
 #include <glog/logging.h>
 #include <kindr/minimal/quat-transformation.h>
+#include <Eigen/Core>
 
 namespace voxblox {
 
@@ -47,8 +47,9 @@ typedef std::vector<Triangle, Eigen::aligned_allocator<Triangle> >
     TriangleVector;
 
 // Transformation type for defining sensor orientation.
-typedef kindr::minimal::QuatTransformation Transformation;
-typedef kindr::minimal::RotationQuaternion Rotation;
+typedef kindr::minimal::QuatTransformationTemplate<FloatingPoint>
+    Transformation;
+typedef kindr::minimal::RotationQuaternionTemplate<FloatingPoint> Rotation;
 
 // For alignment of layers / point clouds
 typedef Eigen::Matrix<FloatingPoint, 3, Eigen::Dynamic> PointsMatrix;

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -56,8 +56,8 @@ class TsdfIntegrator {
                               const Color& color,
                               const float truncation_distance,
                               const float weight, TsdfVoxel* tsdf_voxel) {
-    Eigen::Vector3d voxel_direction = point_G - voxel_center;
-    Eigen::Vector3d ray_direction = point_G - origin;
+    Point voxel_direction = point_G - voxel_center;
+    Point ray_direction = point_G - origin;
 
     float sdf = static_cast<float>(voxel_direction.norm());
     // Figure out if it's in front of the plane or behind.
@@ -80,8 +80,8 @@ class TsdfIntegrator {
 
   inline float computeDistance(const Point& origin, const Point& point_G,
                                const Point& voxel_center) {
-    Eigen::Vector3d voxel_direction = point_G - voxel_center;
-    Eigen::Vector3d ray_direction = point_G - origin;
+    Point voxel_direction = point_G - voxel_center;
+    Point ray_direction = point_G - origin;
 
     float sdf = static_cast<float>(voxel_direction.norm());
     // Figure out if it's in front of the plane or behind.

--- a/voxblox/src/core/esdf_map.cc
+++ b/voxblox/src/core/esdf_map.cc
@@ -6,7 +6,8 @@ bool EsdfMap::getDistanceAtPosition(const Eigen::Vector3d& position,
                                     double* distance) const {
   constexpr bool interpolate = true;
   FloatingPoint distance_fp;
-  bool success = interpolator_.getDistance(position, &distance_fp, interpolate);
+  bool success = interpolator_.getDistance(position.cast<FloatingPoint>(),
+                                           &distance_fp, interpolate);
   if (success) {
     *distance = static_cast<double>(distance_fp);
   }
@@ -20,7 +21,7 @@ bool EsdfMap::getDistanceAndGradientAtPosition(
   Point gradient_fp = Point::Zero();
 
   bool success = interpolator_.getAdaptiveDistanceAndGradient(
-      position, &distance_fp, &gradient_fp);
+      position.cast<FloatingPoint>(), &distance_fp, &gradient_fp);
 
   *distance = static_cast<double>(distance_fp);
   *gradient = gradient_fp.cast<double>();
@@ -31,9 +32,10 @@ bool EsdfMap::getDistanceAndGradientAtPosition(
 bool EsdfMap::isObserved(const Eigen::Vector3d& position) const {
   // Get the block.
   Block<EsdfVoxel>::Ptr block_ptr =
-      esdf_layer_->getBlockPtrByCoordinates(position);
+      esdf_layer_->getBlockPtrByCoordinates(position.cast<FloatingPoint>());
   if (block_ptr) {
-    const EsdfVoxel& voxel = block_ptr->getVoxelByCoordinates(position);
+    const EsdfVoxel& voxel =
+        block_ptr->getVoxelByCoordinates(position.cast<FloatingPoint>());
     return voxel.observed;
   }
   return false;

--- a/voxblox/src/voxblox.cc
+++ b/voxblox/src/voxblox.cc
@@ -28,7 +28,7 @@ int main(int argc, char* argv[]) {
                                     my_cool_map->getTsdfLayerPtr());
 
   Point sensor_origin(1, 0.4, 2.3);
-  Transformation transform(sensor_origin, Eigen::Quaterniond::Identity());
+  Transformation transform(sensor_origin, Rotation::Implementation::Identity());
 
   Pointcloud measurements;
   measurements.push_back(transform.inverse() * Point(4.4, 6.8, 1.11));

--- a/voxblox_ros/include/voxblox_ros/mesh_vis.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_vis.h
@@ -114,7 +114,7 @@ inline void fillMarkerWithMesh(const MeshLayer::ConstPtr& mesh_layer,
 
     for (size_t i = 0u; i < mesh->vertices.size(); i++) {
       geometry_msgs::Point point_msg;
-      tf::pointEigenToMsg(mesh->vertices[i], point_msg);
+      tf::pointEigenToMsg(mesh->vertices[i].cast<double>(), point_msg);
       marker->points.push_back(point_msg);
       std_msgs::ColorRGBA color_msg;
       switch (color_mode) {

--- a/voxblox_ros/src/voxblox_eval.cc
+++ b/voxblox_ros/src/voxblox_eval.cc
@@ -171,7 +171,7 @@ void VoxbloxEvaluator::evaluate() {
        it != gt_ptcloud_.end(); ++it) {
     Point point(it->x, it->y, it->z);
 
-    double distance = 0.0;
+    FloatingPoint distance = 0.0;
     float weight = 0.0;
     bool valid = false;
 


### PR DESCRIPTION
Note: to compile this also requires this pull request in minkindr_ros https://github.com/ethz-asl/minkindr_ros/pull/6

@helenol I noticed you explicitly use doubles in esdf map rather than the FloatingPoint and Point types, is there a reason for this?