### PR TITLE
removeNaNFromPointCloud doesn't remove nans from pointcloud.

### DIFF
--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -449,9 +449,9 @@ void VoxbloxNode::insertPointcloudWithTf(
     points_C.reserve(pointcloud_pcl.size());
     colors.reserve(pointcloud_pcl.size());
     for (size_t i = 0; i < pointcloud_pcl.points.size(); ++i) {
-      if (isnan(pointcloud_pcl.points[i].x) ||
-          isnan(pointcloud_pcl.points[i].y) ||
-          isnan(pointcloud_pcl.points[i].z)) {
+      if (std::isnan(pointcloud_pcl.points[i].x) ||
+          std::isnan(pointcloud_pcl.points[i].y) ||
+          std::isnan(pointcloud_pcl.points[i].z)) {
         continue;
       }
 


### PR DESCRIPTION
Cause of @margaritaG's segfault issues.

Added an extra isnan check after calling pcl::removeNaNFromPointCloud because apparently making the function do what it's supposed to is too freakin' hard. Thanks PCL (other people also report this issue, based on architecture, etc.)
(Rest is autoformat).

@margaritaG @ffurrer 