### PR TITLE
Add lambertian color, fix bug with border voxels

### DIFF
--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -27,7 +27,7 @@ typedef AnyIndex BlockIndex;
 
 typedef std::pair<BlockIndex, VoxelIndex> VoxelKey;
 
-typedef std::vector<AnyIndex, Eigen::aligned_allocator<AnyIndex> > IndexVector;
+typedef std::vector<AnyIndex, Eigen::aligned_allocator<AnyIndex>> IndexVector;
 typedef IndexVector BlockIndexList;
 typedef IndexVector VoxelIndexList;
 
@@ -43,7 +43,7 @@ typedef std::vector<Label> Labels;
 typedef size_t VertexIndex;
 typedef std::vector<VertexIndex> VertexIndexList;
 typedef Eigen::Matrix<FloatingPoint, 3, 3> Triangle;
-typedef std::vector<Triangle, Eigen::aligned_allocator<Triangle> >
+typedef std::vector<Triangle, Eigen::aligned_allocator<Triangle>>
     TriangleVector;
 
 // Transformation type for defining sensor orientation.
@@ -115,9 +115,10 @@ struct Color {
 // near the grid cell boundaries.
 inline AnyIndex getGridIndexFromPoint(const Point& point,
                                       const FloatingPoint grid_size_inv) {
-  return AnyIndex(std::floor(point.x() * grid_size_inv),
-                  std::floor(point.y() * grid_size_inv),
-                  std::floor(point.z() * grid_size_inv));
+  const FloatingPoint kEpsilon = 1e-6;
+  return AnyIndex(std::floor(point.x() * grid_size_inv + kEpsilon),
+                 std::floor(point.y() * grid_size_inv + kEpsilon),
+                 std::floor(point.z() * grid_size_inv + kEpsilon));
 }
 
 // IMPORTANT NOTE: Due the limited accuracy of the FloatingPoint type, this

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -117,8 +117,8 @@ inline AnyIndex getGridIndexFromPoint(const Point& point,
                                       const FloatingPoint grid_size_inv) {
   const FloatingPoint kEpsilon = 1e-6;
   return AnyIndex(std::floor(point.x() * grid_size_inv + kEpsilon),
-                 std::floor(point.y() * grid_size_inv + kEpsilon),
-                 std::floor(point.z() * grid_size_inv + kEpsilon));
+                  std::floor(point.y() * grid_size_inv + kEpsilon),
+                  std::floor(point.z() * grid_size_inv + kEpsilon));
 }
 
 // IMPORTANT NOTE: Due the limited accuracy of the FloatingPoint type, this

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -276,26 +276,18 @@ class MeshIntegrator {
     for (size_t i = 0; i < mesh->vertices.size(); i++) {
       const Point& vertex = mesh->vertices[i];
       VoxelIndex voxel_index = block.computeVoxelIndexFromCoordinates(vertex);
-      const Point voxel_center =
-          block.computeCoordinatesFromVoxelIndex(voxel_index);
-
-      // Should be within half a voxel of the voxel center in all dimensions, or
-      // it belongs in the other one.
-      const Point dist_from_center = vertex - voxel_center;
-      for (unsigned int j = 0; j < 3; ++j) {
-        if (std::abs(dist_from_center(j)) > voxel_size_ / 2.0) {
-          voxel_index(j) += signum(dist_from_center(j));
-        }
-      }
-
       if (block.isValidVoxelIndex(voxel_index)) {
-        mesh->colors[i] = block.getVoxelByVoxelIndex(voxel_index).color;
+        const TsdfVoxel& voxel = block.getVoxelByVoxelIndex(voxel_index);
+
+        if (voxel.weight >= config_.min_weight) {
+          mesh->colors[i] = voxel.color;
+        }
       } else {
-        // Get the nearest block.
         const Block<TsdfVoxel>::ConstPtr neighbor_block =
             tsdf_layer_->getBlockPtrByCoordinates(vertex);
-        if (neighbor_block) {
-          mesh->colors[i] = neighbor_block->getVoxelByCoordinates(vertex).color;
+        const TsdfVoxel& voxel = neighbor_block->getVoxelByCoordinates(vertex);
+        if (voxel.weight >= config_.min_weight) {
+          mesh->colors[i] = voxel.color;
         }
       }
     }

--- a/voxblox/include/voxblox/simulation/simulation_world.h
+++ b/voxblox/include/voxblox/simulation/simulation_world.h
@@ -49,6 +49,12 @@ class SimulationWorld {
   FloatingPoint getDistanceToPoint(const Point& coords,
                                    FloatingPoint max_dist) const;
 
+  // Set and get the map generation and display bounds.
+  void setBounds(const Point& min_bound, const Point& max_bound) {
+    min_bound_ = min_bound;
+    max_bound_ = max_bound;
+  }
+
   Point getMinBound() const { return min_bound_; }
   Point getMaxBound() const { return max_bound_; }
 

--- a/voxblox/include/voxblox/simulation/simulation_world_inl.h
+++ b/voxblox/include/voxblox/simulation/simulation_world_inl.h
@@ -37,8 +37,13 @@ void SimulationWorld::generateSdfFromWorld(FloatingPoint max_dist,
         layer->allocateBlockPtrByIndex(block_index);
     for (size_t i = 0; i < block->num_voxels(); ++i) {
       VoxelType& voxel = block->getVoxelByLinearIndex(i);
-      Point coords =
-          block->computeCoordinatesFromLinearIndex(i);
+      Point coords = block->computeCoordinatesFromLinearIndex(i);
+      // Check that it's in bounds, otherwise skip it.
+      if (!(coords.x() >= min_bound_.x() && coords.x() <= max_bound_.x() &&
+            coords.y() >= min_bound_.y() && coords.y() <= max_bound_.y() &&
+            coords.z() >= min_bound_.z() && coords.z() <= max_bound_.z())) {
+        continue;
+      }
 
       // Iterate over all objects and get distances to this thing.
       FloatingPoint voxel_dist = max_dist;

--- a/voxblox/src/simulation/simulation_world.cc
+++ b/voxblox/src/simulation/simulation_world.cc
@@ -17,7 +17,19 @@ void SimulationWorld::addGroundLevel(FloatingPoint height) {
 void SimulationWorld::addPlaneBoundaries(FloatingPoint x_min,
                                          FloatingPoint x_max,
                                          FloatingPoint y_min,
-                                         FloatingPoint y_max) {}
+                                         FloatingPoint y_max) {
+  // X planes:
+  objects_.emplace_back(
+      new Plane(Point(x_min, 0.0, 0.0), Point(1.0, 0.0, 0.0)));
+  objects_.emplace_back(
+      new Plane(Point(x_max, 0.0, 0.0), Point(-1.0, 0.0, 0.0)));
+
+  // Y planes:
+  objects_.emplace_back(
+      new Plane(Point(0.0, y_min, 0.0), Point(0.0, 1.0, 0.0)));
+  objects_.emplace_back(
+      new Plane(Point(0.0, y_max, 0.0), Point(0.0, -1.0, 0.0)));
+}
 
 void SimulationWorld::clear() { objects_.clear(); }
 

--- a/voxblox_ros/include/voxblox_ros/mesh_vis.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_vis.h
@@ -205,6 +205,10 @@ inline void fillPointcloudWithMesh(
         case kLambert:
           lambertColorFromNormal(mesh->normals[i], &color_msg);
           break;
+        case kLambertColor:
+          lambertColorFromColorAndNormal(mesh->colors[i], mesh->normals[i],
+                                         &color_msg);
+          break;
         case kGray:
           color_msg.r = color_msg.g = color_msg.b = 0.5;
           break;

--- a/voxblox_ros/include/voxblox_ros/mesh_vis.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_vis.h
@@ -52,12 +52,13 @@ inline Point lambertShading(const Point& normal, const Point& light,
   return std::max<FloatingPoint>(normal.dot(light), 0.0f) * color;
 }
 
-inline void lambertColorFromNormal(const Point& normal,
-                                   std_msgs::ColorRGBA* color_msg) {
+inline void lambertColorFromColorAndNormal(const Color& color,
+                                           const Point& normal,
+                                           std_msgs::ColorRGBA* color_msg) {
   const Point light_dir = Point(0.8f, -0.2f, 0.7f).normalized();
   const Point light_dir2 = Point(-0.5f, 0.2f, 0.2f).normalized();
   const Point ambient(0.2f, 0.2f, 0.2f);
-  const Point color_pt(0.5, 0.5, 0.5);
+  const Point color_pt(color.r / 255.0, color.g / 255.0, color.b / 255.0);
 
   Point lambert = lambertShading(normal, light_dir, color_pt) +
                   lambertShading(normal, light_dir2, color_pt) + ambient;
@@ -68,21 +69,9 @@ inline void lambertColorFromNormal(const Point& normal,
   color_msg->a = 1.0;
 }
 
-inline void lambertColorFromColorAndNormal(const Color& color,
-                                           const Point& normal,
-                                           std_msgs::ColorRGBA* color_msg) {
-  const Point light_dir = Point(0.8f, -0.2f, 0.7f).normalized();
-  const Point light_dir2 = Point(-0.5f, 0.2f, 0.2f).normalized();
-  const Point ambient(0.2f, 0.2f, 0.2f);
-  const Point color_pt(color.r/255.0, color.g/255.0, color.b/255.0);
-
-  Point lambert = lambertShading(normal, light_dir, color_pt) +
-                  lambertShading(normal, light_dir2, color_pt) + ambient;
-
-  color_msg->r = std::min<FloatingPoint>(lambert.x(), 1.0);
-  color_msg->g = std::min<FloatingPoint>(lambert.y(), 1.0);
-  color_msg->b = std::min<FloatingPoint>(lambert.z(), 1.0);
-  color_msg->a = 1.0;
+inline void lambertColorFromNormal(const Point& normal,
+                                   std_msgs::ColorRGBA* color_msg) {
+  lambertColorFromColorAndNormal(Color(127, 127, 127), normal, color_msg);
 }
 
 inline void normalColorFromNormal(const Point& normal,

--- a/voxblox_ros/include/voxblox_ros/mesh_vis.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_vis.h
@@ -55,6 +55,8 @@ inline Point lambertShading(const Point& normal, const Point& light,
 inline void lambertColorFromColorAndNormal(const Color& color,
                                            const Point& normal,
                                            std_msgs::ColorRGBA* color_msg) {
+  // These are just some arbitrary light directions, I believe taken from
+  // OpenChisel.
   const Point light_dir = Point(0.8f, -0.2f, 0.7f).normalized();
   const Point light_dir2 = Point(-0.5f, 0.2f, 0.2f).normalized();
   const Point ambient(0.2f, 0.2f, 0.2f);

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -53,6 +53,10 @@ class TsdfServer {
 
   std::shared_ptr<TsdfMap> getTsdfMapPtr() { return tsdf_map_; }
 
+  // Accessors for setting and getting parameters.
+  double getSliceLevel() const { return slice_level_; }
+  void setSliceLevel(double slice_level) { slice_level_ = slice_level; }
+
  protected:
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -33,7 +33,8 @@ class TsdfServer {
   TsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
   virtual ~TsdfServer() {}
 
-  virtual void insertPointcloud(const sensor_msgs::PointCloud2::Ptr& pointcloud);
+  virtual void insertPointcloud(
+      const sensor_msgs::PointCloud2::Ptr& pointcloud);
   virtual void newPoseCallback(const Transformation& new_pose) {}
 
   void publishAllUpdatedTsdfVoxels();
@@ -45,10 +46,12 @@ class TsdfServer {
                        voxblox_msgs::FilePath::Response& response);  // NOLINT
   bool loadMapCallback(voxblox_msgs::FilePath::Request& request,     // NOLINT
                        voxblox_msgs::FilePath::Response& response);  // NOLINT
-  bool generateMeshCallback(std_srvs::Empty::Request& request,      // NOLINT
-                            std_srvs::Empty::Response& response);   // NOLINT
+  bool generateMeshCallback(std_srvs::Empty::Request& request,       // NOLINT
+                            std_srvs::Empty::Response& response);    // NOLINT
 
   virtual void updateMeshEvent(const ros::TimerEvent& event);
+
+  std::shared_ptr<TsdfMap> getTsdfMapPtr() { return tsdf_map_; }
 
  protected:
   ros::NodeHandle nh_;

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -96,7 +96,7 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
 
   // Mesh settings.
   nh_private_.param("mesh_filename", mesh_filename_, mesh_filename_);
-  std::string color_mode("lambert_color");
+  std::string color_mode("colors");
   nh_private_.param("color_mode", color_mode, color_mode);
   if (color_mode == "color" || color_mode == "colors") {
     color_mode_ = ColorMode::kColor;

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -96,7 +96,7 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
 
   // Mesh settings.
   nh_private_.param("mesh_filename", mesh_filename_, mesh_filename_);
-  std::string color_mode("color");
+  std::string color_mode("lambert_color");
   nh_private_.param("color_mode", color_mode, color_mode);
   if (color_mode == "color" || color_mode == "colors") {
     color_mode_ = ColorMode::kColor;
@@ -106,6 +106,8 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
     color_mode_ = ColorMode::kNormals;
   } else if (color_mode == "lambert") {
     color_mode_ = ColorMode::kLambert;
+  } else if (color_mode == "lambert_color") {
+    color_mode_ = ColorMode::kLambertColor;
   } else {  // Default case is gray.
     color_mode_ = ColorMode::kGray;
   }

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -96,7 +96,7 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
 
   // Mesh settings.
   nh_private_.param("mesh_filename", mesh_filename_, mesh_filename_);
-  std::string color_mode("colors");
+  std::string color_mode("color");
   nh_private_.param("color_mode", color_mode, color_mode);
   if (color_mode == "color" || color_mode == "colors") {
     color_mode_ = ColorMode::kColor;


### PR DESCRIPTION
Bug fixes:
 - Meshing getting invalid/unallocated voxel colors sometimes.
 - getting a block for a 3D point and then a voxel for 3D point would map to invalid voxels

Features:
 - Add a new color mode called lambert_color, which applies lambertian shading (view invariant) to the mesh color. Great for synthetic data.
 - Add a few accessors to TSDF maps.
  - Add a few more options to simulation environment.


@alexmillane @mfehr @ZacharyTaylor 