### PR TITLE
Cylinder simulation and more raycasting bugfixes

### DIFF
--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -125,8 +125,10 @@ inline AnyIndex getGridIndexFromPoint(const Point& point,
 // function doesn't always compute the correct grid index for coordinates
 // near the grid cell boundaries.
 inline AnyIndex getGridIndexFromPoint(const Point& scaled_point) {
-  return AnyIndex(std::floor(scaled_point.x()), std::floor(scaled_point.y()),
-                  std::floor(scaled_point.z()));
+  const FloatingPoint kEpsilon = 1e-6;
+  return AnyIndex(std::floor(scaled_point.x() + kEpsilon),
+                  std::floor(scaled_point.y() + kEpsilon),
+                  std::floor(scaled_point.z() + kEpsilon));
 }
 
 inline AnyIndex getGridIndexFromOriginPoint(const Point& point,

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -108,6 +108,10 @@ struct Color {
   static const Color Pink() { return Color(255, 0, 127); }
 };
 
+// Constants used across the library.
+constexpr FloatingPoint kEpsilon = 1e-6;  // Used for coordinates.
+constexpr float kFloatEpsilon = 1e-6;     // Used for weights.
+
 // Grid <-> point conversion functions.
 
 // IMPORTANT NOTE: Due the limited accuracy of the FloatingPoint type, this
@@ -115,7 +119,6 @@ struct Color {
 // near the grid cell boundaries.
 inline AnyIndex getGridIndexFromPoint(const Point& point,
                                       const FloatingPoint grid_size_inv) {
-  const FloatingPoint kEpsilon = 1e-6;
   return AnyIndex(std::floor(point.x() * grid_size_inv + kEpsilon),
                   std::floor(point.y() * grid_size_inv + kEpsilon),
                   std::floor(point.z() * grid_size_inv + kEpsilon));
@@ -125,7 +128,6 @@ inline AnyIndex getGridIndexFromPoint(const Point& point,
 // function doesn't always compute the correct grid index for coordinates
 // near the grid cell boundaries.
 inline AnyIndex getGridIndexFromPoint(const Point& scaled_point) {
-  const FloatingPoint kEpsilon = 1e-6;
   return AnyIndex(std::floor(scaled_point.x() + kEpsilon),
                   std::floor(scaled_point.y() + kEpsilon),
                   std::floor(scaled_point.z() + kEpsilon));

--- a/voxblox/include/voxblox/core/esdf_map.h
+++ b/voxblox/include/voxblox/core/esdf_map.h
@@ -38,6 +38,9 @@ class EsdfMap {
 
   // Specific accessor functions for esdf maps.
   // Returns true if the point exists in the map AND is observed.
+  // These accessors use Vector3d and doubles explicitly rather than
+  // FloatingPoint to have a standard, cast-free interface to planning
+  // functions.
   bool getDistanceAtPosition(const Eigen::Vector3d& position,
                              double* distance) const;
 

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -116,6 +116,12 @@ class EsdfIntegrator {
     return dist_m < 0.0;
   }
 
+  void clear() {
+    updated_blocks_.clear();
+    open_.clear();
+    raise_ = std::queue<VoxelKey>();
+  }
+
  protected:
   // Convenience functions for planning.
   typedef BlockHashMapType<VoxelIndexList>::type BlockVoxelListMap;

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -116,6 +116,7 @@ class EsdfIntegrator {
     return dist_m < 0.0;
   }
 
+  // Clears the state of the integrator, in case robot pose clearance is used.
   void clear() {
     updated_blocks_.clear();
     open_.clear();

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -55,8 +55,15 @@ inline void castRay(
 
   // Distance to cross one grid cell along the ray in t.
   // Same as absolute inverse value of delta_coord.
-  Ray t_step_size =
-      ray_step_signs.cast<FloatingPoint>().cwiseQuotient(ray_scaled);
+  /* Ray t_step_size =
+      ray_step_signs.cast<FloatingPoint>().cwiseQuotient(ray_scaled); */
+  Ray t_step_size(
+      (std::abs(ray_scaled.x()) < kTolerance) ? 2.0 : ray_step_signs.x() /
+                                                          ray_scaled.x(),
+      (std::abs(ray_scaled.y()) < kTolerance) ? 2.0 : ray_step_signs.y() /
+                                                          ray_scaled.y(),
+      (std::abs(ray_scaled.z()) < kTolerance) ? 2.0 : ray_step_signs.z() /
+                                                          ray_scaled.z());
 
   AnyIndex curr_index = start_index;
   indices->push_back(curr_index);
@@ -69,6 +76,13 @@ inline void castRay(
 
     curr_index[t_min_idx] += ray_step_signs[t_min_idx];
     t_to_next_boundary[t_min_idx] += t_step_size[t_min_idx];
+
+    /* LOG(INFO) << "Start index: " << start_index.transpose()
+              << " current_index: " << curr_index.transpose()
+              << " end index: " << end_index.transpose()
+              << "\nt min index: " << t_min_idx
+              << " t_step_size: " << t_step_size.transpose()
+              << " ray scaled: " << ray_scaled.transpose(); */
 
     indices->push_back(curr_index);
   }

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -55,8 +55,6 @@ inline void castRay(
 
   // Distance to cross one grid cell along the ray in t.
   // Same as absolute inverse value of delta_coord.
-  /* Ray t_step_size =
-      ray_step_signs.cast<FloatingPoint>().cwiseQuotient(ray_scaled); */
   Ray t_step_size(
       (std::abs(ray_scaled.x()) < kTolerance) ? 2.0 : ray_step_signs.x() /
                                                           ray_scaled.x(),
@@ -76,13 +74,6 @@ inline void castRay(
 
     curr_index[t_min_idx] += ray_step_signs[t_min_idx];
     t_to_next_boundary[t_min_idx] += t_step_size[t_min_idx];
-
-    /* LOG(INFO) << "Start index: " << start_index.transpose()
-              << " current_index: " << curr_index.transpose()
-              << " end index: " << end_index.transpose()
-              << "\nt min index: " << t_min_idx
-              << " t_step_size: " << t_step_size.transpose()
-              << " ray scaled: " << ray_scaled.transpose(); */
 
     indices->push_back(curr_index);
   }

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -70,7 +70,7 @@ class TsdfIntegrator {
       return 1.0;
     }
     FloatingPoint dist_z = std::abs(point_C.z());
-    if (dist_z > 1e-6) {
+    if (dist_z > kEpsilon) {
       return 1.0 / (dist_z * dist_z);
     }
     return 0.0;

--- a/voxblox/include/voxblox/simulation/objects.h
+++ b/voxblox/include/voxblox/simulation/objects.h
@@ -16,7 +16,7 @@ namespace voxblox {
 class Object {
  public:
   // A wall is an infinite plane.
-  enum Type { kSphere = 0, kCube, kPlane };
+  enum Type { kSphere = 0, kCube, kPlane, kCylinder };
 
   Object(const Point& center, Type type)
       : Object(center, type, Color::White()) {}
@@ -240,6 +240,139 @@ class Plane : public Object {
 
  protected:
   Point normal_;
+};
+
+class Cylinder : public Object {
+ public:
+  Cylinder(const Point& center, FloatingPoint radius, FloatingPoint height)
+      : Object(center, Type::kCylinder), radius_(radius), height_(height) {}
+  Cylinder(const Point& center, FloatingPoint radius, FloatingPoint height,
+           const Color& color)
+      : Object(center, Type::kCylinder, color),
+        radius_(radius),
+        height_(height) {}
+
+  virtual FloatingPoint getDistanceToPoint(const Point& point) const {
+    // From: https://math.stackexchange.com/questions/2064745/
+    // 3 cases, depending on z of point.
+    // First case: in plane with the cylinder. This also takes care of inside
+    // case.
+    FloatingPoint distance = 0.0;
+
+    FloatingPoint min_z_limit = center_.z() - height_ / 2.0;
+    FloatingPoint max_z_limit = center_.z() + height_ / 2.0;
+    if (point.z() >= min_z_limit && point.z() <= max_z_limit) {
+      distance = (point.head<2>() - center_.head<2>()).norm() - radius_;
+    } else if (point.z() > max_z_limit) {
+      // Case 2: above the cylinder.
+      distance = std::sqrt(
+          std::max((point.head<2>() - center_.head<2>()).squaredNorm() -
+                       radius_ * radius_,
+                   0.0) +
+          (point.z() - max_z_limit) * (point.z() - max_z_limit));
+    } else {
+      // Case 3: below cylinder.
+      distance = std::sqrt(
+          std::max((point.head<2>() - center_.head<2>()).squaredNorm() -
+                       radius_ * radius_,
+                   0.0) +
+          (point.z() - min_z_limit) * (point.z() - min_z_limit));
+    }
+    return distance;
+  }
+
+  virtual bool getRayIntersection(const Point& ray_origin,
+                                  const Point& ray_direction,
+                                  FloatingPoint max_dist,
+                                  Point* intersect_point,
+                                  FloatingPoint* intersect_dist) const {
+    // From http://woo4.me/wootracer/cylinder-intersection/
+    // and http://www.cl.cam.ac.uk/teaching/1999/AGraphHCI/SMAG/node2.html
+    // Define ray as P = E + tD, where E is ray_origin and D is ray_direction.
+    // We define our cylinder as centered in the xy coordinate system, so
+    // E in this case is actually ray_origin - center_.
+    Point vector_E = ray_origin - center_;
+    Point vector_D = ray_direction;  // Axis aligned.
+
+    FloatingPoint a = vector_D.x() * vector_D.x() + vector_D.y() * vector_D.y();
+    FloatingPoint b =
+        2 * vector_E.x() * vector_D.x() + 2 * vector_E.y() * vector_D.y();
+    FloatingPoint c = vector_E.x() * vector_E.x() +
+                      vector_E.y() * vector_E.y() - radius_ * radius_;
+
+    // t = (-b +- sqrt(b^2 - 4ac))/2a
+    // t only has solutions if b^2 - 4ac >= 0
+    FloatingPoint t1 = -1.0;
+    FloatingPoint t2 = -1.0;
+
+    // Make sure we don't divide by 0.
+    if (std::abs(a) < 1e-6) {
+      return false;
+    }
+
+    FloatingPoint under_square_root = b * b - 4 * a * c;
+    if (under_square_root < 0) {
+      return false;
+    }
+    if (under_square_root <= 1e-6) {
+      t1 = -b / (2 * a);
+      // Just keep t2 at invalid default value.
+    } else {
+      // 2 ts.
+      t1 = (-b + std::sqrt(under_square_root)) / (2 * a);
+      t2 = (-b - std::sqrt(under_square_root)) / (2 * a);
+    }
+
+    // Great, now we got some ts, time to figure out whether we hit the cylinder
+    // or the endcaps.
+    FloatingPoint t = 0.0;
+
+    FloatingPoint z1 = vector_E.z() + t1 * vector_D.z();
+    FloatingPoint z2 = vector_E.z() + t2 * vector_D.z();
+    bool z1_valid = t1 >= 0.0 && z1 >= -height_ / 2.0 && z1 <= height_ / 2.0;
+    bool z2_valid = t2 >= 0.0 && z2 >= -height_ / 2.0 && z2 <= height_ / 2.0;
+    if (z1_valid && z2_valid) {
+      t = std::min(t1, t2);
+    } else if (z1_valid) {
+      t = t1;
+    } else if (z2_valid) {
+      t = t2;
+    } else {
+      // Check end-cap intersections now... :(
+      // Make sure we don't divide by 0.
+      if (std::abs(vector_D.z()) < 1e-6) {
+        return false;
+      }
+      FloatingPoint t3 = (-height_ / 2.0 - vector_E.z()) / vector_D.z();
+      FloatingPoint t4 = (height_ / 2.0 - vector_E.z()) / vector_D.z();
+
+      bool t3_valid = t3 >= 0.0;
+      bool t4_valid = t4 >= 0.0;
+      if (t3_valid && t4_valid) {
+        t = std::min(t3, t4);
+      } else if (t3_valid) {
+        t = t3;
+      } else if (t4_valid) {
+        t = t4;
+      } else {
+        return false;
+      }
+    }
+    // Intersection greater than max dist, so no intersection in the sensor
+    // range.
+    if (t > max_dist) {
+      return false;
+    }
+
+    // Back to normal coordinates now.
+    *intersect_point = ray_origin + t * ray_direction;
+    *intersect_dist = t;
+    return true;
+  }
+
+ protected:
+  FloatingPoint radius_;
+  FloatingPoint height_;
 };
 
 }  // namespace voxblox

--- a/voxblox/include/voxblox/simulation/objects.h
+++ b/voxblox/include/voxblox/simulation/objects.h
@@ -121,7 +121,7 @@ class Cube : public Object {
     FloatingPoint distance = distance_vector.norm();
 
     // Basically 0... Means it's inside!
-    if (distance < 1e-6) {
+    if (distance < kEpsilon) {
       distance_vector.x() = std::max(center_.x() - size_.x() / 2.0 - point.x(),
                                      point.x() - center_.x() - size_.x() / 2.0);
       distance_vector.y() = std::max(center_.y() - size_.y() / 2.0 - point.y(),
@@ -222,7 +222,7 @@ class Plane : public Object {
     // x = o + dl is the ray equation
     // n = normal, c = plane 'origin'
     FloatingPoint denominator = ray_direction.dot(normal_);
-    if (std::abs(denominator) < 1e-6) {
+    if (std::abs(denominator) < kEpsilon) {
       // Lines are parallel, no intersection.
       return false;
     }
@@ -306,7 +306,7 @@ class Cylinder : public Object {
     FloatingPoint t2 = -1.0;
 
     // Make sure we don't divide by 0.
-    if (std::abs(a) < 1e-6) {
+    if (std::abs(a) < kEpsilon) {
       return false;
     }
 
@@ -314,7 +314,7 @@ class Cylinder : public Object {
     if (under_square_root < 0) {
       return false;
     }
-    if (under_square_root <= 1e-6) {
+    if (under_square_root <= kEpsilon) {
       t1 = -b / (2 * a);
       // Just keep t2 at invalid default value.
     } else {
@@ -338,7 +338,7 @@ class Cylinder : public Object {
     bool t3_valid = false, t4_valid = false;
 
     // Make sure we don't divide by 0.
-    if (std::abs(vector_D.z()) > 1e-6) {
+    if (std::abs(vector_D.z()) > kEpsilon) {
       // t3 is the bottom end-cap, t4 is the top.
       t3 = (-height_ / 2.0 - vector_E.z()) / vector_D.z();
       t4 = (height_ / 2.0 - vector_E.z()) / vector_D.z();

--- a/voxblox/include/voxblox/utils/bucket_queue.h
+++ b/voxblox/include/voxblox/utils/bucket_queue.h
@@ -14,7 +14,10 @@ class BucketQueue {
  public:
   BucketQueue() : last_bucket_index_(0) {}
   explicit BucketQueue(int num_buckets, double max_val)
-      : num_buckets_(num_buckets), max_val_(max_val), last_bucket_index_(0) {
+      : num_buckets_(num_buckets),
+        max_val_(max_val),
+        last_bucket_index_(0),
+        num_elements_(0) {
     buckets_.resize(num_buckets_);
   }
 
@@ -69,6 +72,13 @@ class BucketQueue {
   }
 
   bool empty() { return num_elements_ == 0; }
+
+  void clear() {
+    buckets_.clear();
+    buckets_.resize(num_buckets_);
+    last_bucket_index_ = 0;
+    num_elements_ = 0;
+  }
 
  private:
   int num_buckets_;

--- a/voxblox/src/core/esdf_map.cc
+++ b/voxblox/src/core/esdf_map.cc
@@ -19,9 +19,18 @@ bool EsdfMap::getDistanceAndGradientAtPosition(
     Eigen::Vector3d* gradient) const {
   FloatingPoint distance_fp;
   Point gradient_fp = Point::Zero();
-
-  bool success = interpolator_.getAdaptiveDistanceAndGradient(
-      position.cast<FloatingPoint>(), &distance_fp, &gradient_fp);
+  bool interpolate = true;
+  bool use_adaptive = false;
+  bool success = false;
+  if (use_adaptive) {
+    success = interpolator_.getAdaptiveDistanceAndGradient(
+        position.cast<FloatingPoint>(), &distance_fp, &gradient_fp);
+  } else {
+    success = interpolator_.getDistance(position.cast<FloatingPoint>(),
+                                        &distance_fp, interpolate);
+    success &= interpolator_.getGradient(position.cast<FloatingPoint>(),
+                                         &gradient_fp, interpolate);
+  }
 
   *distance = static_cast<double>(distance_fp);
   *gradient = gradient_fp.cast<double>();

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -62,7 +62,6 @@ void EsdfIntegrator::addNewRobotPosition(const Point& position) {
 
     for (const VoxelIndex& voxel_index : kv.second) {
       if (!block_ptr->isValidVoxelIndex(voxel_index)) {
-        std::cout << "WTF!!!!\n";
         continue;
       }
       EsdfVoxel& esdf_voxel = block_ptr->getVoxelByVoxelIndex(voxel_index);

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -1,5 +1,7 @@
 #include "voxblox/integrator/esdf_integrator.h"
 
+#include <iostream>
+
 namespace voxblox {
 
 EsdfIntegrator::EsdfIntegrator(const Config& config,
@@ -59,6 +61,10 @@ void EsdfIntegrator::addNewRobotPosition(const Point& position) {
         esdf_layer_->allocateBlockPtrByIndex(kv.first);
 
     for (const VoxelIndex& voxel_index : kv.second) {
+      if (!block_ptr->isValidVoxelIndex(voxel_index)) {
+        std::cout << "WTF!!!!\n";
+        continue;
+      }
       EsdfVoxel& esdf_voxel = block_ptr->getVoxelByVoxelIndex(voxel_index);
       if (!esdf_voxel.observed) {
         esdf_voxel.distance = config_.default_distance_m;
@@ -127,7 +133,9 @@ void EsdfIntegrator::updateFromTsdfLayer(bool clear_updated_flag) {
 
   if (clear_updated_flag) {
     for (const BlockIndex& block_index : tsdf_blocks) {
-      tsdf_layer_->getBlockByIndex(block_index).updated() = false;
+      if (tsdf_layer_->hasBlock(block_index)) {
+        tsdf_layer_->getBlockByIndex(block_index).updated() = false;
+      }
     }
   }
 }
@@ -537,6 +545,9 @@ void EsdfIntegrator::processOpenSet() {
 
     Block<EsdfVoxel>::Ptr esdf_block =
         esdf_layer_->getBlockPtrByIndex(kv.first);
+    if (!esdf_block) {
+      continue;
+    }
     EsdfVoxel& esdf_voxel = esdf_block->getVoxelByVoxelIndex(kv.second);
 
     // Again, no point updating unobserved voxels.

--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -20,7 +20,7 @@ class EsdfServer : public TsdfServer {
   bool generateEsdfCallback(std_srvs::Empty::Request& request,      // NOLINT
                             std_srvs::Empty::Response& response);   // NOLINT
 
-  virtual void updateMeshEvent(const ros::TimerEvent& event);
+  virtual void updateMesh();
   virtual void newPoseCallback(const Transformation& T_G_C);
 
   void esdfMapCallback(const voxblox_msgs::Layer& layer_msg);

--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -17,8 +17,8 @@ class EsdfServer : public TsdfServer {
   void publishAllUpdatedEsdfVoxels();
   virtual void publishSlices();
 
-  bool generateEsdfCallback(std_srvs::Empty::Request& request,      // NOLINT
-                            std_srvs::Empty::Response& response);   // NOLINT
+  bool generateEsdfCallback(std_srvs::Empty::Request& request,     // NOLINT
+                            std_srvs::Empty::Response& response);  // NOLINT
 
   virtual void updateMesh();
   virtual void newPoseCallback(const Transformation& T_G_C);
@@ -26,6 +26,13 @@ class EsdfServer : public TsdfServer {
   void esdfMapCallback(const voxblox_msgs::Layer& layer_msg);
 
   std::shared_ptr<EsdfMap> getEsdfMapPtr() { return esdf_map_; }
+
+  bool getClearSphere() const { return clear_sphere_for_planning_; }
+  void setClearSphere(bool clear_sphere_for_planning) {
+    clear_sphere_for_planning_ = clear_sphere_for_planning;
+  }
+
+  virtual void clear();
 
  protected:
   // Publish markers for visualization.

--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -23,6 +23,10 @@ class EsdfServer : public TsdfServer {
   virtual void updateMesh();
   virtual void newPoseCallback(const Transformation& T_G_C);
 
+  // Call updateMesh if you want everything updated; call this specifically
+  // if you don't want the mesh or visualization.
+  void updateEsdf();
+
   void esdfMapCallback(const voxblox_msgs::Layer& layer_msg);
 
   std::shared_ptr<EsdfMap> getEsdfMapPtr() { return esdf_map_; }

--- a/voxblox_ros/include/voxblox_ros/mesh_vis.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_vis.h
@@ -123,10 +123,11 @@ inline void fillMarkerWithMesh(const MeshLayer::ConstPtr& mesh_layer,
       continue;
     }
     // Check that we can actually do the color stuff.
-    if (color_mode == kColor) {
+    if (color_mode == kColor || color_mode == kLambertColor) {
       CHECK(mesh->hasColors());
     }
-    if (color_mode == kNormals || color_mode == kLambert) {
+    if (color_mode == kNormals || color_mode == kLambert ||
+        color_mode == kLambertColor) {
       CHECK(mesh->hasNormals());
     }
 
@@ -178,10 +179,11 @@ inline void fillPointcloudWithMesh(
       continue;
     }
     // Check that we can actually do the color stuff.
-    if (color_mode == kColor) {
+    if (color_mode == kColor || color_mode == kLambertColor) {
       CHECK(mesh->hasColors());
     }
-    if (color_mode == kNormals || color_mode == kLambert) {
+    if (color_mode == kNormals || color_mode == kLambert ||
+        color_mode == kLambertColor) {
       CHECK(mesh->hasNormals());
     }
 

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -35,6 +35,9 @@ class TsdfServer {
 
   virtual void insertPointcloud(
       const sensor_msgs::PointCloud2::Ptr& pointcloud);
+
+  void integratePointcloud(const Transformation& T_G_C,
+                           const Pointcloud& ptcloud_C, const Colors& colors);
   virtual void newPoseCallback(const Transformation& new_pose) {}
 
   void publishAllUpdatedTsdfVoxels();
@@ -59,6 +62,9 @@ class TsdfServer {
   // Accessors for setting and getting parameters.
   double getSliceLevel() const { return slice_level_; }
   void setSliceLevel(double slice_level) { slice_level_ = slice_level; }
+
+  // CLEARS THE ENTIRE MAP!
+  virtual void clear();
 
  protected:
   ros::NodeHandle nh_;

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -40,7 +40,10 @@ class TsdfServer {
   void publishAllUpdatedTsdfVoxels();
   void publishTsdfSurfacePoints();
   void publishTsdfOccupiedNodes();
+
   virtual void publishSlices();
+  virtual void updateMesh();    // Incremental update.
+  virtual bool generateMesh();  // Batch update.
 
   bool saveMapCallback(voxblox_msgs::FilePath::Request& request,     // NOLINT
                        voxblox_msgs::FilePath::Response& response);  // NOLINT
@@ -49,7 +52,7 @@ class TsdfServer {
   bool generateMeshCallback(std_srvs::Empty::Request& request,       // NOLINT
                             std_srvs::Empty::Response& response);    // NOLINT
 
-  virtual void updateMeshEvent(const ros::TimerEvent& event);
+  void updateMeshEvent(const ros::TimerEvent& event);
 
   std::shared_ptr<TsdfMap> getTsdfMapPtr() { return tsdf_map_; }
 

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -112,6 +112,13 @@ void EsdfServer::updateMesh() {
   TsdfServer::updateMesh();
 }
 
+void EsdfServer::updateEsdf() {
+  if (tsdf_map_->getTsdfLayer().getNumberOfAllocatedBlocks() > 0) {
+    const bool clear_updated_flag_esdf = true;
+    esdf_integrator_->updateFromTsdfLayer(clear_updated_flag_esdf);
+  }
+}
+
 void EsdfServer::newPoseCallback(const Transformation& T_G_C) {
   if (clear_sphere_for_planning_) {
     esdf_integrator_->addNewRobotPosition(T_G_C.getPosition());
@@ -133,6 +140,7 @@ void EsdfServer::esdfMapCallback(const voxblox_msgs::Layer& layer_msg) {
 
 void EsdfServer::clear() {
   esdf_map_->getEsdfLayerPtr()->removeAllBlocks();
+  esdf_integrator_->clear();
 
   TsdfServer::clear();
 }

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -131,4 +131,10 @@ void EsdfServer::esdfMapCallback(const voxblox_msgs::Layer& layer_msg) {
   }
 }
 
+void EsdfServer::clear() {
+  esdf_map_->getEsdfLayerPtr()->removeAllBlocks();
+
+  TsdfServer::clear();
+}
+
 }  // namespace voxblox

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -92,7 +92,7 @@ bool EsdfServer::generateEsdfCallback(
   return true;
 }
 
-void EsdfServer::updateMeshEvent(const ros::TimerEvent& event) {
+void EsdfServer::updateMesh() {
   // Also update the ESDF now, if there's any blocks in the TSDF.
   if (tsdf_map_->getTsdfLayer().getNumberOfAllocatedBlocks() > 0) {
     const bool clear_updated_flag_esdf = false;
@@ -109,7 +109,7 @@ void EsdfServer::updateMeshEvent(const ros::TimerEvent& event) {
     esdf_map_pub_.publish(layer_msg);
   }
 
-  TsdfServer::updateMeshEvent(event);
+  TsdfServer::updateMesh();
 }
 
 void EsdfServer::newPoseCallback(const Transformation& T_G_C) {


### PR DESCRIPTION
In this PR:
 - Cylinders are my least favorite shape. 
 - Add ray casting and ground truth distance to cylinders in the object simulator.
 - Fix a bug with raycasting that sometimes caused infinite loops (most easy to see with synthetic data).
 - Fix a bug with getGridIndexFromPoint.
 - Slightly refactor ESDF and TSDF servers to just have an updateMesh function rather than timer callback, allowing more easily manually triggering this.