### PR TITLE
changed it so occupancy is always advertised

### DIFF
--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -29,7 +29,9 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
   tsdf_pointcloud_pub_ =
       nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI> >("tsdf_pointcloud",
                                                               1, true);
-
+  occupancy_marker_pub_ =
+      nh_private_.advertise<visualization_msgs::MarkerArray>("occupied_nodes",
+                                                              1, true);
   tsdf_slice_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI> >(
       "tsdf_slice", 1, true);
 

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -230,10 +230,10 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
         "esdf_slice", 1, true);
   }
 
-  if (generate_occupancy_) {
-    occupancy_marker_pub_ =
+  occupancy_marker_pub_ =
         nh_private_.advertise<visualization_msgs::MarkerArray>("occupied_nodes",
                                                                1, true);
+  if (generate_occupancy_) {
     occupancy_layer_pub_ =
         nh_private_.advertise<visualization_msgs::MarkerArray>(
             "occupancy_layer", 1, true);


### PR DESCRIPTION
occupancy_marker_pub_ is always published to (through a call to publishTsdfOccupiedNodes), but not always advertised, this can cause voxblox to crash with an error about "call to publish() on an invalid publisher".