### PR TITLE
Feature/clearing pointcloud

### DIFF
--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -9,8 +9,8 @@
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <std_srvs/Empty.h>
-#include <string>
 #include <visualization_msgs/MarkerArray.h>
+#include <string>
 
 #include <voxblox/core/tsdf_map.h>
 #include <voxblox/integrator/tsdf_integrator.h>
@@ -34,7 +34,8 @@ class TsdfServer {
   virtual ~TsdfServer() {}
 
   virtual void insertPointcloud(
-      const sensor_msgs::PointCloud2::ConstPtr& pointcloud, const bool freespace);
+      const sensor_msgs::PointCloud2::ConstPtr& pointcloud,
+      const bool freespace);
   virtual void newPoseCallback(const Transformation& new_pose) {}
 
   void publishAllUpdatedTsdfVoxels();
@@ -72,6 +73,9 @@ class TsdfServer {
 
   // Pointcloud visualization settings.
   double slice_level_;
+
+  // If the system should subscribe to a pointcloud giving points in freespace
+  bool use_freespace_pointcloud_;
 
   // Mesh output settings. Mesh is only written to file if mesh_filename_ is
   // not empty.

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -34,7 +34,7 @@ class TsdfServer {
   virtual ~TsdfServer() {}
 
   virtual void insertPointcloud(
-      const sensor_msgs::PointCloud2::Ptr& pointcloud);
+      const sensor_msgs::PointCloud2::ConstPtr& pointcloud, const bool freespace);
   virtual void newPoseCallback(const Transformation& new_pose) {}
 
   void publishAllUpdatedTsdfVoxels();
@@ -81,10 +81,12 @@ class TsdfServer {
 
   // Keep track of these for throttling.
   ros::Duration min_time_between_msgs_;
-  ros::Time last_msg_time_;
+  ros::Time last_msg_time_points_;
+  ros::Time last_msg_time_freespace_;
 
   // Data subscribers.
   ros::Subscriber pointcloud_sub_;
+  ros::Subscriber freespace_pointcloud_sub_;
 
   // Publish markers for visualization.
   ros::Publisher mesh_pub_;

--- a/voxblox_ros/src/simulation_eval.cc
+++ b/voxblox_ros/src/simulation_eval.cc
@@ -314,7 +314,7 @@ void SimulationServer::generateSDF() {
     // Put into the real map.
     bool discard = false;
     tsdf_integrator_->integratePointCloudMerged(T_G_C, ptcloud_C, colors,
-                                                discard);
+                                                discard, false);
 
     if (generate_occupancy_) {
       occ_integrator_->integratePointCloud(T_G_C, ptcloud_C);


### PR DESCRIPTION
Allows for voxblox to subscribe to points that are not inside an object, but that are also not guaranteed to be on a surface (i.e. they are floating in freespace) . These points will only be used beyond the truncation distance. Not needed for most applications (thus off by default) but could be useful to plan from stereo in a low texture environment. 

Tested on the KITTI dataset with the new version of image_undistort https://github.com/ethz-asl/image_undistort/pull/18

![screenshot from 2017-06-26 16-09-10](https://user-images.githubusercontent.com/730680/27543558-cd064a0a-5a8a-11e7-90bf-73060fb00bb3.png)

Left is without freespace points, right is with. Slightly more complete freespace into