### PR TITLE
Feature/merged verts

### DIFF
--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -26,15 +26,15 @@
 #include <algorithm>
 #include <vector>
 
-#include <Eigen/Core>
 #include <glog/logging.h>
+#include <Eigen/Core>
 
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"
+#include "voxblox/interpolator/interpolator.h"
 #include "voxblox/mesh/marching_cubes.h"
 #include "voxblox/mesh/mesh_layer.h"
 #include "voxblox/utils/timing.h"
-#include "voxblox/interpolator/interpolator.h"
 
 namespace voxblox {
 

--- a/voxblox/include/voxblox/mesh/mesh_layer.h
+++ b/voxblox/include/voxblox/mesh/mesh_layer.h
@@ -98,8 +98,8 @@ class MeshLayer {
     auto insert_status = mesh_map_.insert(std::make_pair(
         index, std::shared_ptr<Mesh>(new Mesh(
                    block_size_, index.cast<FloatingPoint>() * block_size_))));
-    DCHECK(insert_status.second) << "Mesh already exists when allocating at "
-                                 << index.transpose();
+    DCHECK(insert_status.second)
+        << "Mesh already exists when allocating at " << index.transpose();
     DCHECK(insert_status.first->second);
     DCHECK_EQ(insert_status.first->first, index);
     return insert_status.first->second;
@@ -121,6 +121,46 @@ class MeshLayer {
     for (const std::pair<const BlockIndex, typename Mesh::Ptr>& kv :
          mesh_map_) {
       meshes->emplace_back(kv.first);
+    }
+  }
+
+  void combineMesh(Mesh::Ptr combined_mesh) const {
+    combined_mesh = Mesh::Ptr(new Mesh(block_size(), Point::Zero()));
+
+    // Used to prevent double ups in vertices
+    BlockHashMapType<IndexElement>::type uniques;
+
+    // If two vertices closer than (voxel_size / key_multiplication_factor) then
+    // the second vertice will be discarded and the first one used in its place
+    constexpr FloatingPoint key_multiplication_factor = 100;
+
+    // Combine everything in the layer into one giant combined mesh.
+    size_t v = 0;
+    BlockIndexList mesh_indices;
+    getAllAllocatedMeshes(&mesh_indices);
+    for (const BlockIndex& block_index : mesh_indices) {
+      Mesh::ConstPtr mesh = getMeshPtrByIndex(block_index);
+      for (const Point& vert : mesh->vertices) {
+        // convert from 3D point to key
+        //BlockIndex vert_key = (key_multiplication_factor * vert / block_size())
+        //                          .cast<IndexElement>();
+        //if (uniques.find(vert_key) == uniques.end()) {
+        //  uniques[vert_key] = v;
+          combined_mesh->vertices.push_back(vert);
+          combined_mesh->indices.push_back(v);
+          v++;
+        //} else {
+        //  combined_mesh->indices.push_back(uniques[vert_key]);
+        //}
+      }
+
+      for (const Color& color : mesh->colors) {
+        combined_mesh->colors.push_back(color);
+      }
+
+      for (const Point& normal : mesh->normals) {
+        combined_mesh->normals.push_back(normal);
+      }
     }
   }
 

--- a/voxblox/src/io/mesh_ply.cc
+++ b/voxblox/src/io/mesh_ply.cc
@@ -26,8 +26,8 @@ namespace voxblox {
 
 bool outputMeshLayerAsPly(const std::string& filename,
                           const MeshLayer& mesh_layer) {
-  
-  Mesh::Ptr combined_mesh;
+  Mesh::Ptr combined_mesh =
+      std::make_shared<Mesh>(mesh_layer.block_size(), Point::Zero());
   mesh_layer.combineMesh(combined_mesh);
 
   bool success = outputMeshAsPly(filename, *combined_mesh);
@@ -59,7 +59,6 @@ bool outputMeshAsPly(const std::string& filename, const Mesh& mesh) {
   stream << "element face " << mesh.indices.size() / 3 << std::endl;
   stream << "property list uchar int vertex_index" << std::endl;
   stream << "end_header" << std::endl;
-
   size_t vert_idx = 0;
   for (const Point& vert : mesh.vertices) {
     stream << vert(0) << " " << vert(1) << " " << vert(2);
@@ -76,8 +75,7 @@ bool outputMeshAsPly(const std::string& filename, const Mesh& mesh) {
     stream << std::endl;
     vert_idx++;
   }
-
-  /*for (size_t i = 0; i < mesh.indices.size(); i += 3) {
+  for (size_t i = 0; i < mesh.indices.size(); i += 3) {
     stream << "3 ";
 
     for (int j = 0; j < 3; j++) {
@@ -85,8 +83,7 @@ bool outputMeshAsPly(const std::string& filename, const Mesh& mesh) {
     }
 
     stream << std::endl;
-  }*/
-
+  }
   return true;
 }
 

--- a/voxblox/src/io/mesh_ply.cc
+++ b/voxblox/src/io/mesh_ply.cc
@@ -26,31 +26,11 @@ namespace voxblox {
 
 bool outputMeshLayerAsPly(const std::string& filename,
                           const MeshLayer& mesh_layer) {
-  Mesh::Ptr combined_mesh(new Mesh(mesh_layer.block_size(), Point::Zero()));
-  // Combine everything in the layer into one giant combined mesh.
-  size_t v = 0;
-  BlockIndexList mesh_indices;
-  mesh_layer.getAllAllocatedMeshes(&mesh_indices);
-  for (const BlockIndex& block_index : mesh_indices) {
-    Mesh::ConstPtr mesh = mesh_layer.getMeshPtrByIndex(block_index);
-    for (const Point& vert : mesh->vertices) {
-      combined_mesh->vertices.push_back(vert);
-      combined_mesh->indices.push_back(v);
-      v++;
-    }
+  
+  Mesh::Ptr combined_mesh;
+  mesh_layer.combineMesh(combined_mesh);
 
-    for (const Color& color : mesh->colors) {
-      combined_mesh->colors.push_back(color);
-    }
-
-    for (const Point& normal : mesh->normals) {
-      combined_mesh->normals.push_back(normal);
-    }
-  }
-
-  LOG(INFO) << "Full mesh has " << v << " verts";
   bool success = outputMeshAsPly(filename, *combined_mesh);
-
   if (!success) {
     LOG(WARNING) << "Saving to PLY failed!";
   }
@@ -76,7 +56,7 @@ bool outputMeshAsPly(const std::string& filename, const Mesh& mesh) {
     stream << "property uchar green" << std::endl;
     stream << "property uchar blue" << std::endl;
   }
-  stream << "element face " << num_points / 3 << std::endl;
+  stream << "element face " << mesh.indices.size() / 3 << std::endl;
   stream << "property list uchar int vertex_index" << std::endl;
   stream << "end_header" << std::endl;
 
@@ -97,7 +77,7 @@ bool outputMeshAsPly(const std::string& filename, const Mesh& mesh) {
     vert_idx++;
   }
 
-  for (size_t i = 0; i < mesh.indices.size(); i += 3) {
+  /*for (size_t i = 0; i < mesh.indices.size(); i += 3) {
     stream << "3 ";
 
     for (int j = 0; j < 3; j++) {
@@ -105,7 +85,7 @@ bool outputMeshAsPly(const std::string& filename, const Mesh& mesh) {
     }
 
     stream << std::endl;
-  }
+  }*/
 
   return true;
 }

--- a/voxblox_ros/include/voxblox_ros/mesh_pcl.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_pcl.h
@@ -45,6 +45,7 @@ inline void toPCLPolygonMesh(const MeshLayer& mesh_layer,
   mesh_layer.combineMesh(mesh);
 
   // add points
+  pointcloud.reserve(mesh->vertices.size());
   for (const Point& point : mesh->vertices) {
     pointcloud.push_back(pcl::PointXYZ(static_cast<float>(point[0]),
                                        static_cast<float>(point[1]),
@@ -52,6 +53,7 @@ inline void toPCLPolygonMesh(const MeshLayer& mesh_layer,
   }
   // add triangles
   pcl::Vertices vertices_idx;
+  polygons.reserve(mesh->indices.size()/3);
   for (const VertexIndex& idx : mesh->indices) {
     vertices_idx.vertices.push_back(idx);
 

--- a/voxblox_ros/include/voxblox_ros/mesh_pcl.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_pcl.h
@@ -40,7 +40,8 @@ inline void toPCLPolygonMesh(const MeshLayer& mesh_layer,
   pcl::PointCloud<pcl::PointXYZ> pointcloud;
   std::vector<pcl::Vertices> polygons;
 
-  Mesh::Ptr mesh;
+  Mesh::Ptr mesh =
+      std::make_shared<Mesh>(mesh_layer.block_size(), Point::Zero());
   mesh_layer.combineMesh(mesh);
 
   // add points

--- a/voxblox_ros/include/voxblox_ros/mesh_pcl.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_pcl.h
@@ -39,35 +39,27 @@ inline void toPCLPolygonMesh(const MeshLayer& mesh_layer,
   // Constructing the vertices pointcloud
   pcl::PointCloud<pcl::PointXYZ> pointcloud;
   std::vector<pcl::Vertices> polygons;
-  BlockIndexList mesh_indices;
-  mesh_layer.getAllAllocatedMeshes(&mesh_indices);
-  // Looping over the block indices and adding the pointcloud
-  for (const BlockIndex& block_index : mesh_indices) {
-    // Getting the mesh triangles in this block
-    const Mesh& mesh = mesh_layer.getMeshByIndex(block_index);
-    // Looping over vertices in this mesh
-    for (const Point& point : mesh.vertices) {
-      pointcloud.push_back(pcl::PointXYZ(static_cast<float>(point[0]),
-                                         static_cast<float>(point[1]),
-                                         static_cast<float>(point[2])));
-    }
-    // Adding the triangles
-    VertexIndex last_biggest_index;
-    if (!polygons.empty()) {
-      last_biggest_index = polygons.back().vertices.back();
-    } else {
-      last_biggest_index = -1;
-    }
-    for (size_t start_idx = 0; start_idx < mesh.indices.size();
-         start_idx += 3) {
-      pcl::Vertices vertices;
-      for (int vertex_idx = 0; vertex_idx < 3; vertex_idx++) {
-        vertices.vertices.push_back(
-            last_biggest_index + mesh.indices.at(start_idx + vertex_idx) + 1);
-      }
-      polygons.push_back(vertices);
+
+  Mesh::Ptr mesh;
+  mesh_layer.combineMesh(mesh);
+
+  // add points
+  for (const Point& point : mesh->vertices) {
+    pointcloud.push_back(pcl::PointXYZ(static_cast<float>(point[0]),
+                                       static_cast<float>(point[1]),
+                                       static_cast<float>(point[2])));
+  }
+  // add triangles
+  pcl::Vertices vertices_idx;
+  for (const VertexIndex& idx : mesh->indices) {
+    vertices_idx.vertices.push_back(idx);
+
+    if (vertices_idx.vertices.size() == 3) {
+      polygons.push_back(vertices_idx);
+      vertices_idx.vertices.clear();
     }
   }
+
   // Converting to the pointcloud binary
   pcl::PCLPointCloud2 pointcloud2;
   pcl::toPCLPointCloud2(pointcloud, pointcloud2);


### PR DESCRIPTION
By default voxblox duplicates vertices for triangles with shared edges. This removes connectivity information which can be useful for some applications.

The approach taken here will merge all close mesh verticies and discard very small triangles