### PR TITLE
Convert Tango SDF protobuf dumps; optional Python bindings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "voxblox/pybind11"]
+	path = voxblox/pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "voxblox/pybind11"]
 	path = voxblox/pybind11
 	url = https://github.com/pybind/pybind11.git
+[submodule "pybind11"]
+	path = pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "voxblox/pybind11"]
-	path = voxblox/pybind11
-	url = https://github.com/pybind/pybind11.git
 [submodule "pybind11"]
 	path = pybind11
 	url = https://github.com/pybind/pybind11.git

--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -7,6 +7,11 @@ catkin_simple()
 set(CMAKE_MACOSX_RPATH 0)
 add_definitions(-std=c++11 -Wno-sign-compare -Wno-unused-value)
 
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/pybind11/CMakeLists.txt")
+  set(HAVE_PYBIND11 TRUE)
+  message(STATUS "Found pybind11; generating Python bindings")
+endif()
+
 ############
 # PROTOBUF #
 ############
@@ -35,11 +40,11 @@ else()
   set(ADDITIONAL_LIBRARIES ${PROTOBUF_LIBRARY})
 endif()
 
+####################
+# SET SOURCE FILES #
+####################
 
-#############
-# LIBRARIES #
-#############
-cs_add_library(${PROJECT_NAME}
+set("${PROJECT_NAME}_SRCS"
   src/core/block.cc
   src/core/esdf_map.cc
   src/integrator/esdf_integrator.cc
@@ -50,9 +55,56 @@ cs_add_library(${PROJECT_NAME}
   src/simulation/simulation_world.cc
   src/utils/protobuf_utils.cc
   src/utils/timing.cc
+)
+
+#############
+# LIBRARIES #
+#############
+cs_add_library(${PROJECT_NAME}
+  ${${PROJECT_NAME}_SRCS}
   ${PROTO_SRCS}
 )
 target_link_libraries(${PROJECT_NAME} ${PROTOBUF_LIBRARIES})
+
+###################
+# PYTHON BINDINGS #
+###################
+if(HAVE_PYBIND11)
+  catkin_python_setup()
+
+  # TODO(mereweth@jpl.nasa.gov) - how to tell pybind11 about an existing library?
+  # or should we just use the pybind library for everything?
+  add_subdirectory(pybind11)
+  message("Building Python bindings for voxblox")
+  pybind11_add_module(voxbloxpy
+    ${${PROJECT_NAME}_SRCS}
+    ${PROTO_SRCS}
+    src/pybind11/esdf_map_bind.cc)
+  set_target_properties(voxbloxpy PROPERTIES LINKER_LANGUAGE CXX)
+  target_link_libraries(voxbloxpy PUBLIC ${PROTOBUF_LIBRARIES} ${catkin_LIBRARIES})
+
+  # TODO(mereweth@jpl.nasa.gov) - is there a better way to make this importable?
+  #cs_add_targets_to_package(voxbloxpy)
+
+  # TODO(mereweth@jpl.nasa.gov) - this is a bit hacky but it works
+  set_target_properties(voxbloxpy
+    PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+  ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/../)
+endif()
+
+############
+# BINARIES #
+############
+
+add_executable(tsdf_to_esdf
+  test/tsdf_to_esdf.cc
+)
+target_link_libraries(tsdf_to_esdf ${PROJECT_NAME} ${catkin_LIBRARIES})
+
+add_executable(test_load_esdf
+  test/test_load_esdf.cc
+)
+target_link_libraries(test_load_esdf ${PROJECT_NAME} ${catkin_LIBRARIES})
 
 #########
 # TESTS #

--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -7,7 +7,7 @@ catkin_simple()
 set(CMAKE_MACOSX_RPATH 0)
 add_definitions(-std=c++11 -Wno-sign-compare -Wno-unused-value)
 
-if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/pybind11/CMakeLists.txt")
+if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/../pybind11/CMakeLists.txt")
   set(HAVE_PYBIND11 TRUE)
   message(STATUS "Found pybind11; generating Python bindings")
 endif()
@@ -74,7 +74,7 @@ if(HAVE_PYBIND11)
 
   # TODO(mereweth@jpl.nasa.gov) - how to tell pybind11 about an existing library?
   # or should we just use the pybind library for everything?
-  add_subdirectory(pybind11)
+  add_subdirectory(../pybind11 pybind11)
   message("Building Python bindings for voxblox")
   pybind11_add_module(voxbloxpy
     ${${PROJECT_NAME}_SRCS}

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -157,6 +157,15 @@ class Block {
 
   size_t getMemorySize() const;
 
+protected:
+  std::unique_ptr<VoxelType[]> voxels_;
+
+  // Derived, cached parameters.
+  size_t num_voxels_;
+
+  // Is set to true if any one of the voxels in this block received an update.
+  bool has_data_;
+
  private:
   void deserializeProto(const BlockProto& proto);
   void serializeProto(BlockProto* proto) const;
@@ -167,17 +176,12 @@ class Block {
   const Point origin_;
 
   // Derived, cached parameters.
-  size_t num_voxels_;
   FloatingPoint voxel_size_inv_;
   FloatingPoint block_size_;
   FloatingPoint block_size_inv_;
 
-  // Is set to true if any one of the voxels in this block received an update.
-  bool has_data_;
   // Is set to true when data is updated.
   bool updated_;
-
-  std::unique_ptr<VoxelType[]> voxels_;
 };
 
 }  // namespace voxblox

--- a/voxblox/include/voxblox/core/esdf_map.h
+++ b/voxblox/include/voxblox/core/esdf_map.h
@@ -10,6 +10,8 @@
 #include "voxblox/core/voxel.h"
 #include "voxblox/interpolator/interpolator.h"
 
+#include "voxblox/io/layer_io.h"
+
 namespace voxblox {
 
 class EsdfMap {
@@ -26,6 +28,20 @@ class EsdfMap {
                                          config.esdf_voxels_per_side)),
         interpolator_(esdf_layer_.get()) {
     block_size_ = config.esdf_voxel_size * config.esdf_voxels_per_side;
+  }
+
+  EsdfMap(const std::string& file_path)
+      : esdf_layer_(io::LoadOrCreateLayerHeader<EsdfVoxel>(file_path,
+                                                           0.2,
+                                                           16u)),
+        interpolator_(esdf_layer_.get()) {
+    if (!io::LoadBlocksFromFile<EsdfVoxel>(file_path,
+                                           Layer<EsdfVoxel>::BlockMergingStrategy::kProhibit,
+                                           esdf_layer_.get())) {
+      // TODO(mereweth@jpl.nasa.gov) - throw std exception for Python to catch?
+      throw std::runtime_error(std::string("Invalid file path: ") + file_path);
+    }
+    block_size_ = esdf_layer_->block_size();
   }
 
   virtual ~EsdfMap() {}
@@ -49,6 +65,40 @@ class EsdfMap {
                                         Eigen::Vector3d* gradient) const;
 
   bool isObserved(const Eigen::Vector3d& position) const;
+
+  // Convenience functions for querying many points at once from Python
+
+  // TODO(mereweth@jpl.nasa.gov) - double check that position can not be mutated
+  // EigenDRef is fully dynamic stride type alias for Numpy array slices
+  // Use column-major matrices; column-by-column traversal is faster
+
+  // convenience alias borrowed from pybind11
+  using EigenDStride = Eigen::Stride<Eigen::Dynamic, Eigen::Dynamic>;
+  template <typename MatrixType> using EigenDRef = Eigen::Ref<MatrixType, 0, EigenDStride>;
+
+  void batchGetDistanceAtPosition(
+    EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+    Eigen::Ref<Eigen::VectorXd> distances,
+    Eigen::Ref<Eigen::VectorXi> observed) const;
+
+  void batchGetDistanceAndGradientAtPosition(
+    EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+    Eigen::Ref<Eigen::VectorXd> distances,
+    EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& gradients,
+    Eigen::Ref<Eigen::VectorXi> observed) const;
+
+  void batchIsObserved(
+    EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+    Eigen::Ref<Eigen::VectorXi> observed) const;
+
+  unsigned int coordPlaneSliceGetCount(unsigned int free_plane_index,
+                                       double free_plane_val) const;
+
+  unsigned int coordPlaneSliceGetDistance(
+    unsigned int free_plane_index,
+    double free_plane_val,
+    EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+    Eigen::Ref<Eigen::VectorXd> distances) const;
 
  protected:
   FloatingPoint block_size_;

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -209,9 +209,7 @@ class Layer {
 
   size_t getMemorySize() const;
 
- private:
-  std::string getType() const;
-
+protected:
   FloatingPoint voxel_size_;
   size_t voxels_per_side_;
   FloatingPoint block_size_;
@@ -219,6 +217,8 @@ class Layer {
   // Derived types.
   FloatingPoint block_size_inv_;
   FloatingPoint voxels_per_side_inv_;
+
+  std::string getType() const;
 
   BlockHashMap block_map_;
 };

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -209,7 +209,7 @@ class Layer {
 
   size_t getMemorySize() const;
 
-protected:
+ protected:
   FloatingPoint voxel_size_;
   size_t voxels_per_side_;
   FloatingPoint block_size_;

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -137,10 +137,15 @@ bool LoadBlocksFromFile(
   return true;
 }
 
-/*TODO(mereweth@jpl.nasa.gov) - best name for this function?
- * This function may be useful when debugging a malformed protobuf dump
- * Also prevents segfaulting Python using file_path EsdfMap constructor
+/*NOTE(mereweth@jpl.nasa.gov) - This function is for use with Python bindings
+ * for EsdfMap, so that trying to load a nonexistent file does not cause
+ * an assert in the C++ code.
+ *
+ * An upcoming PR will replace this function with a better-engineered overload
+ * for LoadLayer, specifically for Python bindings.
  */
+
+// If opening the file at file_path fails, create an empty layer
 template <typename VoxelType>
 typename Layer<VoxelType>::Ptr LoadOrCreateLayerHeader(
                                                 const std::string& file_path,

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -38,6 +38,7 @@
 
 namespace voxblox {
 
+template <typename VoxelType>
 class MeshIntegrator {
  public:
   struct Config {
@@ -46,7 +47,7 @@ class MeshIntegrator {
     float min_weight = 1e-4;
   };
 
-  MeshIntegrator(const Config& config, Layer<TsdfVoxel>* tsdf_layer,
+  MeshIntegrator(const Config& config, Layer<VoxelType>* tsdf_layer,
                  MeshLayer* mesh_layer)
       : config_(config),
         tsdf_layer_(CHECK_NOTNULL(tsdf_layer)),
@@ -83,7 +84,7 @@ class MeshIntegrator {
     tsdf_layer_->getAllAllocatedBlocks(&all_tsdf_blocks);
 
     for (const BlockIndex& block_index : all_tsdf_blocks) {
-      Block<TsdfVoxel>::Ptr block =
+      typename Block<VoxelType>::Ptr block =
           tsdf_layer_->getBlockPtrByIndex(block_index);
       if (block->updated()) {
         updateMeshForBlock(block_index);
@@ -94,7 +95,7 @@ class MeshIntegrator {
     }
   }
 
-  void extractBlockMesh(Block<TsdfVoxel>::ConstPtr block, Mesh::Ptr mesh) {
+  void extractBlockMesh(typename Block<VoxelType>::ConstPtr block, Mesh::Ptr mesh) {
     size_t vps = block->voxels_per_side();
     VertexIndex next_mesh_index = 0;
 
@@ -146,7 +147,7 @@ class MeshIntegrator {
     mesh->clear();
     // This block should already exist, otherwise it makes no sense to update
     // the mesh for it. ;)
-    Block<TsdfVoxel>::ConstPtr block =
+    typename Block<VoxelType>::ConstPtr block =
         tsdf_layer_->getBlockPtrByIndex(block_index);
 
     if (!block) {
@@ -167,7 +168,7 @@ class MeshIntegrator {
     }
   }
 
-  void extractMeshInsideBlock(const Block<TsdfVoxel>& block,
+  void extractMeshInsideBlock(const Block<VoxelType>& block,
                               const VoxelIndex& index, const Point& coords,
                               VertexIndex* next_mesh_index, Mesh* mesh) {
     DCHECK_NOTNULL(next_mesh_index);
@@ -180,7 +181,7 @@ class MeshIntegrator {
 
     for (unsigned int i = 0; i < 8; ++i) {
       VoxelIndex corner_index = index + cube_index_offsets_.col(i);
-      const TsdfVoxel& voxel = block.getVoxelByVoxelIndex(corner_index);
+      const VoxelType& voxel = block.getVoxelByVoxelIndex(corner_index);
 
       // Do not extract a mesh here if one of the corner is unobserved and
       // outside the truncation region.
@@ -200,7 +201,7 @@ class MeshIntegrator {
     }
   }
 
-  void extractMeshOnBorder(const Block<TsdfVoxel>& block,
+  void extractMeshOnBorder(const Block<VoxelType>& block,
                            const VoxelIndex& index, const Point& coords,
                            VertexIndex* next_mesh_index, Mesh* mesh) {
     DCHECK_NOTNULL(mesh);
@@ -216,7 +217,7 @@ class MeshIntegrator {
       VoxelIndex corner_index = index + cube_index_offsets_.col(i);
 
       if (block.isValidVoxelIndex(corner_index)) {
-        const TsdfVoxel& voxel = block.getVoxelByVoxelIndex(corner_index);
+        const VoxelType& voxel = block.getVoxelByVoxelIndex(corner_index);
 
         if (voxel.weight <= config_.min_weight) {
           all_neighbors_observed = false;
@@ -241,11 +242,11 @@ class MeshIntegrator {
         BlockIndex neighbor_index = block.block_index() + block_offset;
 
         if (tsdf_layer_->hasBlock(neighbor_index)) {
-          const Block<TsdfVoxel>& neighbor_block =
+          const Block<VoxelType>& neighbor_block =
               tsdf_layer_->getBlockByIndex(neighbor_index);
 
           CHECK(neighbor_block.isValidVoxelIndex(corner_index));
-          const TsdfVoxel& voxel =
+          const VoxelType& voxel =
               neighbor_block.getVoxelByVoxelIndex(corner_index);
 
           if (voxel.weight <= config_.min_weight) {
@@ -266,7 +267,7 @@ class MeshIntegrator {
     }
   }
 
-  void updateMeshColor(const Block<TsdfVoxel>& block, Mesh* mesh) {
+  void updateMeshColor(const Block<VoxelType>& block, Mesh* mesh) {
     CHECK_NOTNULL(mesh);
 
     mesh->colors.clear();
@@ -277,15 +278,15 @@ class MeshIntegrator {
       const Point& vertex = mesh->vertices[i];
       VoxelIndex voxel_index = block.computeVoxelIndexFromCoordinates(vertex);
       if (block.isValidVoxelIndex(voxel_index)) {
-        const TsdfVoxel& voxel = block.getVoxelByVoxelIndex(voxel_index);
+        const VoxelType& voxel = block.getVoxelByVoxelIndex(voxel_index);
 
         if (voxel.weight >= config_.min_weight) {
           mesh->colors[i] = voxel.color;
         }
       } else {
-        const Block<TsdfVoxel>::ConstPtr neighbor_block =
+        const Block<VoxelType>::ConstPtr neighbor_block =
             tsdf_layer_->getBlockPtrByCoordinates(vertex);
-        const TsdfVoxel& voxel = neighbor_block->getVoxelByCoordinates(vertex);
+        const VoxelType& voxel = neighbor_block->getVoxelByCoordinates(vertex);
         if (voxel.weight >= config_.min_weight) {
           mesh->colors[i] = voxel.color;
         }
@@ -293,11 +294,11 @@ class MeshIntegrator {
     }
   }
 
-  void computeMeshNormals(const Block<TsdfVoxel>& block, Mesh* mesh) {
+  void computeMeshNormals(const Block<VoxelType>& block, Mesh* mesh) {
     mesh->normals.clear();
     mesh->normals.resize(mesh->indices.size(), Point::Zero());
 
-    Interpolator<TsdfVoxel> interpolator(tsdf_layer_);
+    Interpolator<VoxelType> interpolator(tsdf_layer_);
 
     Point grad;
     for (size_t i = 0; i < mesh->vertices.size(); i++) {
@@ -314,7 +315,7 @@ class MeshIntegrator {
  protected:
   Config config_;
 
-  Layer<TsdfVoxel>* tsdf_layer_;
+  Layer<VoxelType>* tsdf_layer_;
   MeshLayer* mesh_layer_;
 
   // Cached map config.

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -284,7 +284,7 @@ class MeshIntegrator {
           mesh->colors[i] = voxel.color;
         }
       } else {
-        const Block<VoxelType>::ConstPtr neighbor_block =
+        const typename Block<VoxelType>::ConstPtr neighbor_block =
             tsdf_layer_->getBlockPtrByCoordinates(vertex);
         const VoxelType& voxel = neighbor_block->getVoxelByCoordinates(vertex);
         if (voxel.weight >= config_.min_weight) {

--- a/voxblox/python/voxblox/__init__.py
+++ b/voxblox/python/voxblox/__init__.py
@@ -1,0 +1,3 @@
+# TODO(mereweth@jpl.nasa.gov) - this is a bit convoluted but it works
+# we are importing all from the shared library that we built using pybind11
+from voxbloxpy import *

--- a/voxblox/setup.py
+++ b/voxblox/setup.py
@@ -1,0 +1,12 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['voxblox'],
+    package_dir={'': 'python'},
+)
+
+setup(**setup_args)

--- a/voxblox/src/core/esdf_map.cc
+++ b/voxblox/src/core/esdf_map.cc
@@ -50,4 +50,123 @@ bool EsdfMap::isObserved(const Eigen::Vector3d& position) const {
   return false;
 }
 
+void EsdfMap::batchGetDistanceAtPosition(
+          EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+          Eigen::Ref<Eigen::VectorXd> distances,
+          Eigen::Ref<Eigen::VectorXi> observed) const {
+  /* TODO(mereweth@jpl.nasa.gov) - this looks like it gets truncated on return
+   * to Python anyway. Throw std::runtime_error here if too small?
+   */
+  distances.resize(positions.cols());
+  observed.resize(positions.cols());
+  for (int i = 0; i < positions.cols(); i++) {
+    observed[i] = getDistanceAtPosition(positions.col(i), &distances[i]);
+  }
+}
+
+void EsdfMap::batchGetDistanceAndGradientAtPosition(
+          EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+          Eigen::Ref<Eigen::VectorXd> distances,
+          EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& gradients,
+          Eigen::Ref<Eigen::VectorXi> observed) const {
+  /* TODO(mereweth@jpl.nasa.gov) - this looks like it gets truncated on return
+   * to Python anyway. Throw std::runtime_error here if too small?
+   */
+  distances.resize(positions.cols());
+  gradients.resize(3, positions.cols());
+  observed.resize(positions.cols());
+  for (int i = 0; i < positions.cols(); i++) {
+    Eigen::Vector3d gradient;
+    observed[i] = getDistanceAndGradientAtPosition(positions.col(i),
+                                                   &distances[i],
+                                                   &gradient);
+
+    gradients.col(i) = gradient;
+  }
+}
+
+void EsdfMap::batchIsObserved(
+          EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+          Eigen::Ref<Eigen::VectorXi> observed) const {
+  /* TODO(mereweth@jpl.nasa.gov) - this looks like it gets truncated on return
+   * to Python anyway. Throw std::runtime_error here if too small?
+   */
+  observed.resize(positions.cols());
+  for (int i = 0; i < positions.cols(); i++) {
+    observed[i] = isObserved(positions.col(i));
+  }
+}
+
+unsigned int EsdfMap::coordPlaneSliceGetDistance(
+                unsigned int free_plane_index,
+                double free_plane_val,
+                EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+                Eigen::Ref<Eigen::VectorXd> distances) const {
+  BlockIndexList blocks;
+  esdf_layer_->getAllAllocatedBlocks(&blocks);
+
+  // Cache layer settings.
+  size_t vps = esdf_layer_->voxels_per_side();
+  size_t num_voxels_per_block = vps * vps * vps;
+
+  // Temp variables.
+  bool did_all_fit = true;
+  unsigned int count = 0;
+
+  // Iterate over all blocks.
+  for (const BlockIndex& index : blocks) {
+    // Iterate over all voxels in said blocks.
+    const Block<EsdfVoxel>& block = esdf_layer_->getBlockByIndex(index);
+
+    Point origin = block.origin();
+    if (std::abs(origin(free_plane_index) - free_plane_val)
+                                        > block.block_size()) {
+                                        //> block.block_size() / 2.0) {
+                                        //> esdf_layer_->block_size() / 2.0) {
+      continue;
+    }
+
+    for (size_t linear_index = 0; linear_index < num_voxels_per_block;
+         ++linear_index) {
+      Point coord = block.computeCoordinatesFromLinearIndex(linear_index);
+      const EsdfVoxel& voxel = block.getVoxelByLinearIndex(linear_index);
+      if (std::abs(coord(free_plane_index) - free_plane_val)
+                                          <= block.voxel_size()) {
+                                          //<= block.voxel_size() / 2.0) {
+                                          //<= esdf_layer_->voxel_size() / 2.0) {
+        double distance;
+        if (voxel.observed) {
+          distance = voxel.distance;
+        }
+        else {
+          continue;
+          // TODO(mereweth@jpl.nasa.gov) - how to indicate unobserved?
+          //distance = 0;
+        }
+
+        // TODO(mereweth@jpl.nasa.gov) - implement max points to return
+        if (count < positions.cols()) {
+          positions.col(count) = Eigen::Vector3d(coord.x(), coord.y(), coord.z());
+        }
+        else {
+          did_all_fit = false;
+        }
+        if (count < distances.size()) {
+          distances(count) = distance;
+        }
+        else {
+          did_all_fit = false;
+        }
+        count++;
+      }
+    }
+  }
+
+  if (!did_all_fit) {
+    throw std::runtime_error(std::string("Unable to store ") + std::to_string(count) + " values.");
+  }
+
+  return count;
+}
+
 }  // namespace voxblox

--- a/voxblox/src/core/esdf_map.cc
+++ b/voxblox/src/core/esdf_map.cc
@@ -51,9 +51,9 @@ bool EsdfMap::isObserved(const Eigen::Vector3d& position) const {
 }
 
 void EsdfMap::batchGetDistanceAtPosition(
-          EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
-          Eigen::Ref<Eigen::VectorXd> distances,
-          Eigen::Ref<Eigen::VectorXi> observed) const {
+    EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+    Eigen::Ref<Eigen::VectorXd> distances,
+    Eigen::Ref<Eigen::VectorXi> observed) const {
   /* TODO(mereweth@jpl.nasa.gov) - this looks like it gets truncated on return
    * to Python anyway. Throw std::runtime_error here if too small?
    */
@@ -65,10 +65,10 @@ void EsdfMap::batchGetDistanceAtPosition(
 }
 
 void EsdfMap::batchGetDistanceAndGradientAtPosition(
-          EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
-          Eigen::Ref<Eigen::VectorXd> distances,
-          EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& gradients,
-          Eigen::Ref<Eigen::VectorXi> observed) const {
+    EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+    Eigen::Ref<Eigen::VectorXd> distances,
+    EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& gradients,
+    Eigen::Ref<Eigen::VectorXi> observed) const {
   /* TODO(mereweth@jpl.nasa.gov) - this looks like it gets truncated on return
    * to Python anyway. Throw std::runtime_error here if too small?
    */
@@ -78,16 +78,15 @@ void EsdfMap::batchGetDistanceAndGradientAtPosition(
   for (int i = 0; i < positions.cols(); i++) {
     Eigen::Vector3d gradient;
     observed[i] = getDistanceAndGradientAtPosition(positions.col(i),
-                                                   &distances[i],
-                                                   &gradient);
+                                                   &distances[i], &gradient);
 
     gradients.col(i) = gradient;
   }
 }
 
 void EsdfMap::batchIsObserved(
-          EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
-          Eigen::Ref<Eigen::VectorXi> observed) const {
+    EigenDRef<const Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+    Eigen::Ref<Eigen::VectorXi> observed) const {
   /* TODO(mereweth@jpl.nasa.gov) - this looks like it gets truncated on return
    * to Python anyway. Throw std::runtime_error here if too small?
    */
@@ -97,15 +96,14 @@ void EsdfMap::batchIsObserved(
   }
 }
 
-/* NOTE(mereweth@jpl.nasa.gov) - this function is a convenience function for Python bindings.
- * std::exceptions are bound to Python exceptions by pybind11, allowing them to be handled
- * in Python code idiomatically.
+/* NOTE(mereweth@jpl.nasa.gov) - this function is a convenience function for
+ * Python bindings. std::exceptions are bound to Python exceptions by pybind11,
+ * allowing them to be handled in Python code idiomatically.
  */
 unsigned int EsdfMap::coordPlaneSliceGetDistance(
-                unsigned int free_plane_index,
-                double free_plane_val,
-                EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
-                Eigen::Ref<Eigen::VectorXd> distances) const {
+    unsigned int free_plane_index, double free_plane_val,
+    EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,
+    Eigen::Ref<Eigen::VectorXd> distances) const {
   BlockIndexList blocks;
   esdf_layer_->getAllAllocatedBlocks(&blocks);
 
@@ -123,8 +121,8 @@ unsigned int EsdfMap::coordPlaneSliceGetDistance(
     const Block<EsdfVoxel>& block = esdf_layer_->getBlockByIndex(index);
 
     Point origin = block.origin();
-    if (std::abs(origin(free_plane_index) - free_plane_val)
-                                        > block.block_size()) {
+    if (std::abs(origin(free_plane_index) - free_plane_val) >
+        block.block_size()) {
       continue;
     }
 
@@ -132,27 +130,25 @@ unsigned int EsdfMap::coordPlaneSliceGetDistance(
          ++linear_index) {
       Point coord = block.computeCoordinatesFromLinearIndex(linear_index);
       const EsdfVoxel& voxel = block.getVoxelByLinearIndex(linear_index);
-      if (std::abs(coord(free_plane_index) - free_plane_val)
-                                          <= block.voxel_size()) {
+      if (std::abs(coord(free_plane_index) - free_plane_val) <=
+          block.voxel_size()) {
         double distance;
         if (voxel.observed) {
           distance = voxel.distance;
-        }
-        else {
+        } else {
           continue;
         }
 
         // TODO(mereweth@jpl.nasa.gov) - implement max points to return
         if (count < positions.cols()) {
-          positions.col(count) = Eigen::Vector3d(coord.x(), coord.y(), coord.z());
-        }
-        else {
+          positions.col(count) =
+              Eigen::Vector3d(coord.x(), coord.y(), coord.z());
+        } else {
           did_all_fit = false;
         }
         if (count < distances.size()) {
           distances(count) = distance;
-        }
-        else {
+        } else {
           did_all_fit = false;
         }
         count++;
@@ -161,7 +157,8 @@ unsigned int EsdfMap::coordPlaneSliceGetDistance(
   }
 
   if (!did_all_fit) {
-    throw std::runtime_error(std::string("Unable to store ") + std::to_string(count) + " values.");
+    throw std::runtime_error(std::string("Unable to store ") +
+                             std::to_string(count) + " values.");
   }
 
   return count;

--- a/voxblox/src/core/esdf_map.cc
+++ b/voxblox/src/core/esdf_map.cc
@@ -97,6 +97,10 @@ void EsdfMap::batchIsObserved(
   }
 }
 
+/* NOTE(mereweth@jpl.nasa.gov) - this function is a convenience function for Python bindings.
+ * std::exceptions are bound to Python exceptions by pybind11, allowing them to be handled
+ * in Python code idiomatically.
+ */
 unsigned int EsdfMap::coordPlaneSliceGetDistance(
                 unsigned int free_plane_index,
                 double free_plane_val,
@@ -121,8 +125,6 @@ unsigned int EsdfMap::coordPlaneSliceGetDistance(
     Point origin = block.origin();
     if (std::abs(origin(free_plane_index) - free_plane_val)
                                         > block.block_size()) {
-                                        //> block.block_size() / 2.0) {
-                                        //> esdf_layer_->block_size() / 2.0) {
       continue;
     }
 
@@ -132,16 +134,12 @@ unsigned int EsdfMap::coordPlaneSliceGetDistance(
       const EsdfVoxel& voxel = block.getVoxelByLinearIndex(linear_index);
       if (std::abs(coord(free_plane_index) - free_plane_val)
                                           <= block.voxel_size()) {
-                                          //<= block.voxel_size() / 2.0) {
-                                          //<= esdf_layer_->voxel_size() / 2.0) {
         double distance;
         if (voxel.observed) {
           distance = voxel.distance;
         }
         else {
           continue;
-          // TODO(mereweth@jpl.nasa.gov) - how to indicate unobserved?
-          //distance = 0;
         }
 
         // TODO(mereweth@jpl.nasa.gov) - implement max points to return

--- a/voxblox/src/pybind11/esdf_map_bind.cc
+++ b/voxblox/src/pybind11/esdf_map_bind.cc
@@ -19,9 +19,7 @@ PYBIND11_MODULE(voxbloxpy, m) {
         .def("getDistanceAndGradientAtPosition", &voxblox::EsdfMap::batchGetDistanceAndGradientAtPosition)
         .def("isObserved", &voxblox::EsdfMap::batchIsObserved)
 
-        .def("coordPlaneSliceGetDistance", &voxblox::EsdfMap::coordPlaneSliceGetDistance)
-
-        ;
+        .def("coordPlaneSliceGetDistance", &voxblox::EsdfMap::coordPlaneSliceGetDistance);
 }
 
 #endif // VOXBLOX_PYBIND_ESDF_MAP_BIND_H_

--- a/voxblox/src/pybind11/esdf_map_bind.cc
+++ b/voxblox/src/pybind11/esdf_map_bind.cc
@@ -1,0 +1,27 @@
+#ifndef VOXBLOX_PYBIND_ESDF_MAP_BIND_H_
+#define VOXBLOX_PYBIND_ESDF_MAP_BIND_H_
+
+#include "voxblox/core/esdf_map.h"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+namespace py = pybind11;
+
+using voxblox::EsdfMap;
+
+PYBIND11_MODULE(voxbloxpy, m) {
+    py::class_<EsdfMap>(m, "EsdfMap")
+        .def(py::init<const std::string &>())
+        .def_property_readonly("block_size", &EsdfMap::block_size)
+        .def_property_readonly("voxel_size", &EsdfMap::voxel_size)
+
+        .def("getDistanceAtPosition", &voxblox::EsdfMap::batchGetDistanceAtPosition)
+        .def("getDistanceAndGradientAtPosition", &voxblox::EsdfMap::batchGetDistanceAndGradientAtPosition)
+        .def("isObserved", &voxblox::EsdfMap::batchIsObserved)
+
+        .def("coordPlaneSliceGetDistance", &voxblox::EsdfMap::coordPlaneSliceGetDistance)
+
+        ;
+}
+
+#endif // VOXBLOX_PYBIND_ESDF_MAP_BIND_H_

--- a/voxblox/src/pybind11/esdf_map_bind.cc
+++ b/voxblox/src/pybind11/esdf_map_bind.cc
@@ -1,25 +1,23 @@
-#ifndef VOXBLOX_PYBIND_ESDF_MAP_BIND_H_
-#define VOXBLOX_PYBIND_ESDF_MAP_BIND_H_
-
 #include "voxblox/core/esdf_map.h"
 
-#include <pybind11/pybind11.h>
 #include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
 namespace py = pybind11;
 
 using voxblox::EsdfMap;
 
 PYBIND11_MODULE(voxbloxpy, m) {
-    py::class_<EsdfMap>(m, "EsdfMap")
-        .def(py::init<const std::string &>())
-        .def_property_readonly("block_size", &EsdfMap::block_size)
-        .def_property_readonly("voxel_size", &EsdfMap::voxel_size)
+  py::class_<EsdfMap>(m, "EsdfMap")
+      .def(py::init<const std::string &>())
+      .def_property_readonly("block_size", &EsdfMap::block_size)
+      .def_property_readonly("voxel_size", &EsdfMap::voxel_size)
 
-        .def("getDistanceAtPosition", &voxblox::EsdfMap::batchGetDistanceAtPosition)
-        .def("getDistanceAndGradientAtPosition", &voxblox::EsdfMap::batchGetDistanceAndGradientAtPosition)
-        .def("isObserved", &voxblox::EsdfMap::batchIsObserved)
+      .def("getDistanceAtPosition",
+           &voxblox::EsdfMap::batchGetDistanceAtPosition)
+      .def("getDistanceAndGradientAtPosition",
+           &voxblox::EsdfMap::batchGetDistanceAndGradientAtPosition)
+      .def("isObserved", &voxblox::EsdfMap::batchIsObserved)
 
-        .def("coordPlaneSliceGetDistance", &voxblox::EsdfMap::coordPlaneSliceGetDistance);
+      .def("coordPlaneSliceGetDistance",
+           &voxblox::EsdfMap::coordPlaneSliceGetDistance);
 }
-
-#endif // VOXBLOX_PYBIND_ESDF_MAP_BIND_H_

--- a/voxblox/test/test_load_esdf.cc
+++ b/voxblox/test/test_load_esdf.cc
@@ -1,0 +1,31 @@
+#include <iostream>  // NOLINT
+
+#include "./Block.pb.h"
+#include "./Layer.pb.h"
+#include "voxblox/core/block.h"
+#include "voxblox/core/layer.h"
+#include "voxblox/core/voxel.h"
+#include "voxblox/io/layer_io.h"
+#include "voxblox/test/layer_test_utils.h"
+
+#include <voxblox/io/mesh_ply.h>
+#include <voxblox/mesh/mesh_integrator.h>
+
+using namespace voxblox;  // NOLINT
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+
+  if (argc != 2) {
+    throw std::runtime_error("Args: filename to load");
+  }
+
+  const std::string file = argv[1];
+
+  Layer<EsdfVoxel>::Ptr layer_from_file;
+  io::LoadLayer<EsdfVoxel>(file, &layer_from_file);
+
+  std::cout << "Layer memory size: " << layer_from_file->getMemorySize() << "\n";
+
+  return 0;
+}

--- a/voxblox/test/test_load_esdf.cc
+++ b/voxblox/test/test_load_esdf.cc
@@ -25,7 +25,8 @@ int main(int argc, char** argv) {
   Layer<EsdfVoxel>::Ptr layer_from_file;
   io::LoadLayer<EsdfVoxel>(file, &layer_from_file);
 
-  std::cout << "Layer memory size: " << layer_from_file->getMemorySize() << "\n";
+  std::cout << "Layer memory size: " << layer_from_file->getMemorySize()
+            << "\n";
 
   return 0;
 }

--- a/voxblox/test/test_voxbloxpy.py
+++ b/voxblox/test/test_voxbloxpy.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+import timeit
+
+import sys;
+sys.path.append('/Users/mereweth/snappy/tsdf_catkin_ws/devel/.private/voxblox/lib/')
+
+import voxblox
+dir(voxblox.EsdfMap)
+
+try:
+    map = voxblox.EsdfMap('THIS_DOES_NOT_EXIST')
+except RuntimeError as e:
+    print(e)
+
+map = voxblox.EsdfMap('/Users/mereweth/Desktop/cow_and_lady/cow_and_lady_esdf.proto')
+
+import numpy as np
+
+x_ = np.linspace(0.0, 0.2, 100)
+y_ = np.linspace(0.0, 0.2, 100)
+z_ = np.linspace(0.0, 0.2, 100)
+x, y, z = np.meshgrid(x_, y_, z_)
+query = np.matrix(np.c_[x.flatten(), y.flatten(), z.flatten()]).T
+
+#query = np.matrix([[0,0,0.1],
+#                   [0.1,0,0],
+#                   [0.1,0.1,0],
+#                   [0,0.1,0]], dtype='double').T
+
+grad = np.matrix(np.zeros(np.shape(query), dtype='double'))
+
+dist = np.matrix(np.zeros((np.shape(query)[1], 1), dtype='double'))
+
+obs = np.matrix(np.zeros((np.shape(query)[1], 1), dtype='int32'))
+
+map.isObserved(query, obs)
+map.getDistanceAtPosition(query, dist, obs)
+
+def interp_fun():
+    map.getDistanceAndGradientAtPosition(query, dist, grad, obs)
+interp_duration = timeit.timeit(interp_fun, number=10) / 10.0
+print(interp_duration)
+
+num_pts = 20480
+slice_pos = np.matrix(np.zeros((3, num_pts)))
+slice_dist = np.matrix(np.zeros((np.shape(slice_pos)[1], 1), dtype='double'))
+
+def no_interp_fun():
+    map.coordPlaneSliceGetDistance(2, # xy plane
+                                   0.5, # z
+                                   slice_pos,
+                                   slice_dist)
+no_interp_duration = timeit.timeit(no_interp_fun, number=10) / 10.0
+print(no_interp_duration)
+
+try:
+  import IPython; IPython.embed()
+
+except:
+  import code
+  code.interact(local=dict(globals(), **locals()))

--- a/voxblox/test/test_voxbloxpy.py
+++ b/voxblox/test/test_voxbloxpy.py
@@ -13,7 +13,7 @@ try:
 except RuntimeError as e:
     print(e)
 
-map = voxblox.EsdfMap('/Users/mereweth/Desktop/cow_and_lady/cow_and_lady_esdf.proto')
+map = voxblox.EsdfMap('/Users/mereweth/Desktop/cow_and_lady/cow_and_lady.esdf.proto')
 
 import numpy as np
 

--- a/voxblox/test/tsdf_to_esdf.cc
+++ b/voxblox/test/tsdf_to_esdf.cc
@@ -43,8 +43,6 @@ int main(int argc, char** argv) {
   EsdfIntegrator::Config esdf_integrator_config;
   // Make sure that this is the same as the truncation distance OR SMALLER!
   esdf_integrator_config.min_distance_m = esdf_config.esdf_voxel_size;
-  // esdf_integrator_config.min_distance_m =
-  //    tsdf_integrator_->getConfig().default_truncation_distance;
   esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
                                                  layer_from_file.get(),
                                                  esdf_map_->getEsdfLayerPtr()));

--- a/voxblox/test/tsdf_to_esdf.cc
+++ b/voxblox/test/tsdf_to_esdf.cc
@@ -1,0 +1,60 @@
+#include <iostream>  // NOLINT
+
+#include "./Block.pb.h"
+#include "./Layer.pb.h"
+#include "voxblox/core/block.h"
+#include "voxblox/core/layer.h"
+#include "voxblox/core/voxel.h"
+#include "voxblox/io/layer_io.h"
+#include "voxblox/test/layer_test_utils.h"
+
+#include <voxblox/io/mesh_ply.h>
+#include <voxblox/mesh/mesh_integrator.h>
+
+#include <voxblox/core/esdf_map.h>
+#include <voxblox/integrator/esdf_integrator.h>
+
+using namespace voxblox;  // NOLINT
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+
+  if (argc != 3) {
+    throw std::runtime_error("Args: filename to load, followed by filename to save to");
+  }
+
+  const std::string file = argv[1];
+
+  Layer<TsdfVoxel>::Ptr layer_from_file;
+  io::LoadLayer<TsdfVoxel>(file, &layer_from_file);
+
+  std::cout << "Layer memory size: " << layer_from_file->getMemorySize() << "\n";
+
+  // ESDF maps.
+  EsdfMap::Config esdf_config;
+  std::shared_ptr<EsdfMap> esdf_map_;
+  std::unique_ptr<EsdfIntegrator> esdf_integrator_;
+
+  // Same number of voxels per side for ESDF as with TSDF
+  esdf_config.esdf_voxels_per_side = layer_from_file->voxels_per_side();
+  // Same voxel size for ESDF as with TSDF
+  esdf_config.esdf_voxel_size = layer_from_file->voxel_size();
+  esdf_map_.reset(new EsdfMap(esdf_config));
+  EsdfIntegrator::Config esdf_integrator_config;
+  // Make sure that this is the same as the truncation distance OR SMALLER!
+  esdf_integrator_config.min_distance_m = esdf_config.esdf_voxel_size;
+  // esdf_integrator_config.min_distance_m =
+  //    tsdf_integrator_->getConfig().default_truncation_distance;
+  esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
+                                                 layer_from_file.get(),
+                                                 esdf_map_->getEsdfLayerPtr()));
+  esdf_integrator_->updateFromTsdfLayerBatch();
+
+  bool esdfSuccess = io::SaveLayer(esdf_map_->getEsdfLayer(), argv[2]);
+
+  if (esdfSuccess == false) {
+    throw std::runtime_error("Failed to save ESDF");
+  }
+
+  return 0;
+}

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -116,7 +116,7 @@ class TsdfServer {
 
   // Mesh accessories.
   std::shared_ptr<MeshLayer> mesh_layer_;
-  std::unique_ptr<MeshIntegrator> mesh_integrator_;
+  std::unique_ptr<MeshIntegrator<TsdfVoxel>> mesh_integrator_;
 
   // Transformer object to keep track of either TF transforms or messages from
   // a transform topic.

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="play_bag" default="true" />
-  <arg name="bag_file" default="/Users/helen/data/lady_cow_dataset/data.bag"/>
+  <arg name="bag_file" default="/Users/mereweth/snappy/tsdf_resources/cow_and_lady.bag"/>
   <arg name="voxel_size" default="0.10"/>
   <arg name="generate_esdf" default="false" />
 

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="play_bag" default="true" />
-  <arg name="bag_file" default="/Users/mereweth/snappy/tsdf_resources/cow_and_lady.bag"/>
+  <arg name="bag_file" default="/Users/helen/data/lady_cow_dataset/data.bag"/>
   <arg name="voxel_size" default="0.10"/>
   <arg name="generate_esdf" default="false" />
 

--- a/voxblox_ros/src/simulation_eval.cc
+++ b/voxblox_ros/src/simulation_eval.cc
@@ -472,9 +472,9 @@ void SimulationServer::visualize() {
 
   if (generate_mesh_) {
     // Generate TSDF GT mesh.
-    MeshIntegrator::Config mesh_config;
+    MeshIntegrator<TsdfVoxel>::Config mesh_config;
     MeshLayer::Ptr mesh(new MeshLayer(tsdf_gt_->block_size()));
-    MeshIntegrator mesh_integrator(mesh_config, tsdf_gt_.get(), mesh.get());
+    MeshIntegrator<TsdfVoxel> mesh_integrator(mesh_config, tsdf_gt_.get(), mesh.get());
     mesh_integrator.generateWholeMesh();
     visualization_msgs::MarkerArray marker_array;
     marker_array.markers.resize(1);
@@ -485,7 +485,7 @@ void SimulationServer::visualize() {
 
     // Also generate test mesh
     MeshLayer::Ptr mesh_test(new MeshLayer(tsdf_test_->block_size()));
-    MeshIntegrator mesh_integrator_test(mesh_config, tsdf_test_.get(),
+    MeshIntegrator<TsdfVoxel> mesh_integrator_test(mesh_config, tsdf_test_.get(),
                                         mesh_test.get());
     mesh_integrator_test.generateWholeMesh();
     marker_array.markers.clear();

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -114,13 +114,13 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
     color_mode_ = ColorMode::kGray;
   }
 
-  MeshIntegrator::Config mesh_config;
+  MeshIntegrator<TsdfVoxel>::Config mesh_config;
   nh_private_.param("mesh_min_weight", mesh_config.min_weight,
                     mesh_config.min_weight);
 
   mesh_layer_.reset(new MeshLayer(tsdf_map_->block_size()));
 
-  mesh_integrator_.reset(new MeshIntegrator(
+  mesh_integrator_.reset(new MeshIntegrator<TsdfVoxel>(
       mesh_config, tsdf_map_->getTsdfLayerPtr(), mesh_layer_.get()));
 
   // Advertise services.

--- a/voxblox_ros/src/voxblox_eval.cc
+++ b/voxblox_ros/src/voxblox_eval.cc
@@ -72,7 +72,7 @@ class VoxbloxEvaluator {
 
   // Mesh visualization.
   std::shared_ptr<MeshLayer> mesh_layer_;
-  std::shared_ptr<MeshIntegrator> mesh_integrator_;
+  std::shared_ptr<MeshIntegrator<TsdfVoxel>> mesh_integrator_;
 };
 
 VoxbloxEvaluator::VoxbloxEvaluator(const ros::NodeHandle& nh,
@@ -225,10 +225,10 @@ void VoxbloxEvaluator::evaluate() {
 
 void VoxbloxEvaluator::visualize() {
   // Generate the mesh.
-  MeshIntegrator::Config mesh_config;
+  MeshIntegrator<TsdfVoxel>::Config mesh_config;
   mesh_layer_.reset(new MeshLayer(tsdf_layer_->block_size()));
   mesh_integrator_.reset(
-      new MeshIntegrator(mesh_config, tsdf_layer_.get(), mesh_layer_.get()));
+      new MeshIntegrator<TsdfVoxel>(mesh_config, tsdf_layer_.get(), mesh_layer_.get()));
   mesh_integrator_->generateWholeMesh();
 
   // Publish mesh.

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -159,7 +159,7 @@ class VoxbloxNode {
   std::shared_ptr<OccupancyIntegrator> occupancy_integrator_;
   // Mesh accessories.
   std::shared_ptr<MeshLayer> mesh_layer_;
-  std::shared_ptr<MeshIntegrator> mesh_integrator_;
+  std::shared_ptr<MeshIntegrator<TsdfVoxel>> mesh_integrator_;
 
   // Transform queue, used only when use_tf_transforms is false.
   std::deque<geometry_msgs::TransformStamped> transform_queue_;
@@ -357,13 +357,13 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
     color_mode_ = ColorMode::kGray;
   }
 
-  MeshIntegrator::Config mesh_config;
+  MeshIntegrator<TsdfVoxel>::Config mesh_config;
   nh_private_.param("mesh_min_weight", mesh_config.min_weight,
                     mesh_config.min_weight);
 
   mesh_layer_.reset(new MeshLayer(tsdf_map_->block_size()));
 
-  mesh_integrator_.reset(new MeshIntegrator(
+  mesh_integrator_.reset(new MeshIntegrator<TsdfVoxel>(
       mesh_config, tsdf_map_->getTsdfLayerPtr(), mesh_layer_.get()));
 
   // Advertise services.

--- a/voxblox_tango_interface/CMakeLists.txt
+++ b/voxblox_tango_interface/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(voxblox_tango_interface)
+
+find_package(catkin_simple REQUIRED)
+catkin_simple()
+
+set(CMAKE_MACOSX_RPATH 0)
+add_definitions(-std=c++11 -Wno-sign-compare -Wno-unused-value)
+
+############
+# PROTOBUF #
+############
+# General idea: first check if we have protobuf catkin, then use that.
+# Otherwise use system protobuf.
+set(PROTO_DEFNS proto/tsdf2/MapHeader.proto
+                proto/tsdf2/Volume.proto)
+set(ADDITIONAL_LIBRARIES "")
+
+find_package(protobuf_catkin QUIET)
+if (protobuf_catkin_FOUND)
+    message(STATUS "Using protobuf_catkin")
+    list(APPEND catkin_INCLUDE_DIRS ${protobuf_catkin_INCLUDE_DIRS})
+    list(APPEND catkin_LIBRARIES ${protobuf_catkin_LIBRARIES})
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+    PROTOBUF_CATKIN_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${PROTO_DEFNS})
+    set(ADDITIONAL_LIBRARIES ${protobuf_catkin_LIBRARIES})
+else()
+  message(STATUS "Using system protobuf")
+  find_package(Protobuf REQUIRED)
+  include_directories(${PROTOBUF_INCLUDE_DIRS})
+  include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+  PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS ${PROTO_DEFNS})
+  set(ADDITIONAL_LIBRARIES ${PROTOBUF_LIBRARY})
+endif()
+
+####################
+# SET SOURCE FILES #
+####################
+
+set("${PROJECT_NAME}_SRCS"
+  src/core/tango_block_interface.cc
+)
+
+#############
+# LIBRARIES #
+#############
+cs_add_library(${PROJECT_NAME}
+  ${${PROJECT_NAME}_SRCS}
+  ${PROTO_SRCS}
+)
+target_link_libraries(${PROJECT_NAME} ${PROTOBUF_LIBRARIES})
+
+############
+# BINARIES #
+############
+
+add_executable(mesh_tango_tsdf
+  test/mesh_tango_tsdf.cc
+)
+target_link_libraries(mesh_tango_tsdf ${PROJECT_NAME} ${catkin_LIBRARIES})
+
+add_executable(tango_tsdf_to_esdf
+  test/tango_tsdf_to_esdf.cc
+)
+target_link_libraries(tango_tsdf_to_esdf ${PROJECT_NAME} ${catkin_LIBRARIES})
+
+##########
+# EXPORT #
+##########
+cs_install()
+cs_export(INCLUDE_DIRS include ${CMAKE_CURRENT_BINARY_DIR}
+          LIBRARIES ${ADDITIONAL_LIBRARIES})

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/ntsdf_voxel.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/ntsdf_voxel.h
@@ -1,0 +1,37 @@
+#ifndef VOXBLOX_TANGO_INTERFACE_CORE_VOXEL_H_
+#define VOXBLOX_TANGO_INTERFACE_CORE_VOXEL_H_
+
+#include <cstdint>
+
+#include "voxblox/core/common.h"
+#include "voxblox/core/color.h"
+#include "voxblox/core/voxel.h"
+
+namespace voxblox {
+
+/* NOTE(mereweth@jpl.nasa.gov) - This voxel type is not used for now.
+ * The only implemented functionality is to load the Tango serialized NTSDF into
+ * a Layer<TsdfVoxel>
+ */
+struct NtsdfVoxel {
+  uint32_t ntsdf = 0;
+  uint32_t color = 0;
+
+  /* TODO(mereweth@jpl.nasa.gov) - should we use 16-bit fields
+   * with attribute packed instead?
+   */
+};
+
+// Used for serialization only.
+namespace voxel_types {
+  const std::string kNtsdf = "ntsdf";
+}  // namespace voxel_types
+
+template <>
+inline std::string getVoxelType<NtsdfVoxel>() {
+  return voxel_types::kNtsdf;
+}
+
+}  // namespace voxblox
+
+#endif  // VOXBLOX_TANGO_INTERFACE_CORE_VOXEL_H_

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface.h
@@ -1,0 +1,37 @@
+#ifndef VOXBLOX_TANGO_INTERFACE_CORE_BLOCK_H_
+#define VOXBLOX_TANGO_INTERFACE_CORE_BLOCK_H_
+
+#include "voxblox/core/voxel.h"
+#include "voxblox/core/block.h"
+
+#include "./Volume.pb.h"
+
+namespace voxblox {
+
+class TangoBlockInterface : public Block<TsdfVoxel> {
+public:
+  TangoBlockInterface(size_t voxels_per_side, FloatingPoint voxel_size,
+                                          const Point& origin,
+                                          unsigned int max_ntsdf_voxel_weight,
+                                          FloatingPoint meters_to_ntsdf)
+      : Block<TsdfVoxel>(voxels_per_side, voxel_size, origin),
+        max_ntsdf_voxel_weight_(max_ntsdf_voxel_weight),
+        meters_to_ntsdf_(meters_to_ntsdf) {  }
+
+  TangoBlockInterface(const tsdf2:: VolumeProto& proto,
+                      unsigned int max_ntsdf_voxel_weight,
+                      FloatingPoint meters_to_ntsdf);
+
+private:
+  void deserializeProto(const tsdf2::VolumeProto& proto);
+  void deserializeFromIntegers(const std::vector<uint32_t>& data);
+
+  unsigned int max_ntsdf_voxel_weight_;
+  FloatingPoint meters_to_ntsdf_;
+};
+
+}  // namespace voxblox
+
+#include "voxblox_tango_interface/core/tango_block_interface_inl.h"
+
+#endif  // VOXBLOX_TANGO_INTERFACE_CORE_BLOCK_H_

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface_inl.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface_inl.h
@@ -1,0 +1,52 @@
+#ifndef VOXBLOX_TANGO_INTERFACE_CORE_BLOCK_INL_H_
+#define VOXBLOX_TANGO_INTERFACE_CORE_BLOCK_INL_H_
+
+#include "./Volume.pb.h"
+
+namespace voxblox {
+
+inline TangoBlockInterface::TangoBlockInterface(
+                                    const tsdf2::VolumeProto& proto,
+                                    unsigned int max_ntsdf_voxel_weight,
+                                    FloatingPoint meters_to_ntsdf)
+    : TangoBlockInterface(
+            proto.voxels_per_side(), proto.voxel_size(),
+            proto.has_origin() ?
+            Point(proto.origin().x(), proto.origin().y(), proto.origin().z()) :
+            /* NOTE(mereweth@jpl.nasa.gov) - origin field seems to be deprecated
+             * as of 2017/06/15
+             * Without it, loading of old TSDF2 dumps is broken, so we
+             * pass it if present in the protobuf dump
+             */
+            Point(proto.index().x() * proto.voxel_size() * proto.voxels_per_side(),
+                  proto.index().y() * proto.voxel_size() * proto.voxels_per_side(),
+                  proto.index().z() * proto.voxel_size() * proto.voxels_per_side()),
+            max_ntsdf_voxel_weight,
+            meters_to_ntsdf) {
+
+  has_data_ = proto.has_data();
+
+  // Convert the data into a vector of integers.
+  std::vector<uint32_t> data;
+  data.reserve(proto.ntsdf_voxels_size());
+
+  auto ntsdf_word = proto.ntsdf_voxels().begin();
+  auto color_word = proto.color_voxels().begin();
+  for(; ntsdf_word != proto.ntsdf_voxels().end() &&
+        color_word != proto.color_voxels().end();
+        ++ntsdf_word, ++color_word)
+  {
+    data.push_back(*ntsdf_word);
+    data.push_back(*color_word);
+  }
+  if (ntsdf_word != proto.ntsdf_voxels().end() ||
+      color_word != proto.color_voxels().end()) {
+    LOG(FATAL) << "Unequal number of tsdf and color voxels in Tango TSDF";
+  }
+
+  deserializeFromIntegers(data);
+}
+
+}  // namespace voxblox
+
+#endif  // VOXBLOX_TANGO_INTERFACE_CORE_BLOCK_INL_H_

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_layer_interface.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_layer_interface.h
@@ -1,0 +1,33 @@
+#ifndef VOXBLOX_TANGO_INTERFACE_CORE_LAYER_H_
+#define VOXBLOX_TANGO_INTERFACE_CORE_LAYER_H_
+
+#include "voxblox/core/layer.h"
+
+#include "./MapHeader.pb.h"
+#include "./Volume.pb.h"
+
+#include "voxblox_tango_interface/core/tango_block_interface.h"
+
+namespace voxblox {
+
+class TangoLayerInterface : public Layer<TsdfVoxel> {
+public:
+  // NOTE(mereweth@jpl.nasa.gov) - need this typedef
+  typedef std::shared_ptr<TangoLayerInterface> Ptr;
+
+  explicit TangoLayerInterface(const tsdf2::MapHeaderProto& proto);
+
+  bool isCompatible(const tsdf2::MapHeaderProto& layer_proto) const;
+  bool isCompatible(const tsdf2::VolumeProto& block_proto) const;
+  bool addBlockFromProto(const tsdf2::VolumeProto& block_proto,
+                         TangoLayerInterface::BlockMergingStrategy strategy);
+private:
+  unsigned int max_ntsdf_voxel_weight_;
+  FloatingPoint meters_to_ntsdf_;
+};
+
+}  // namespace voxblox
+
+#include "voxblox_tango_interface/core/tango_layer_interface_inl.h"
+
+#endif  // VOXBLOX_TANGO_INTERFACE_CORE_LAYER_H_

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_layer_interface_inl.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_layer_interface_inl.h
@@ -1,0 +1,93 @@
+#ifndef VOXBLOX_TANGO_INTERFACE_CORE_LAYER_INL_H_
+#define VOXBLOX_TANGO_INTERFACE_CORE_LAYER_INL_H_
+
+#include "./MapHeader.pb.h"
+#include "./Volume.pb.h"
+
+namespace voxblox {
+
+inline TangoLayerInterface::TangoLayerInterface(const tsdf2::MapHeaderProto& proto)
+    : Layer<TsdfVoxel>(proto.voxel_size(), proto.voxels_per_volume_side()),
+      max_ntsdf_voxel_weight_(proto.max_ntsdf_voxel_weight()),
+      meters_to_ntsdf_(proto.meters_to_ntsdf()) {
+  // Derived config parameter.
+  block_size_ = voxel_size_ * voxels_per_side_;
+  block_size_inv_ = 1.0 / block_size_;
+
+  LOG(INFO) << "Meters to NTSDF: " << meters_to_ntsdf_ << "\t"
+            << "Max NTSDF voxel weight: " << max_ntsdf_voxel_weight_ << "\n";
+
+  CHECK_GT(proto.voxel_size(), 0.0);
+  CHECK_GT(proto.voxels_per_volume_side(), 0u);
+}
+
+/* TODO (mereweth@jpl.nasa.gov) - is there a way to reuse some of
+ * Layer::addBlockFromProto easily?
+ */
+inline bool TangoLayerInterface ::
+    addBlockFromProto(const tsdf2::VolumeProto& block_proto,
+                      TangoLayerInterface::BlockMergingStrategy strategy) {
+  CHECK_EQ(getType().compare(voxel_types::kTsdf), 0)
+      << "The voxel type of this layer is not TsdfVoxel!";
+
+  if (isCompatible(block_proto)) {
+    TangoBlockInterface::Ptr block_ptr(new TangoBlockInterface(block_proto,
+                                                    max_ntsdf_voxel_weight_,
+                                                    meters_to_ntsdf_));
+
+    const BlockIndex block_index =
+        getGridIndexFromOriginPoint(block_ptr->origin(), block_size_inv_);
+    switch (strategy) {
+      case TangoLayerInterface::BlockMergingStrategy::kProhibit:
+        CHECK_EQ(block_map_.count(block_index), 0u)
+            << "Block collision at index: " << block_index;
+        block_map_[block_index] = block_ptr;
+      break;
+      case TangoLayerInterface::BlockMergingStrategy::kReplace:
+        block_map_[block_index] = block_ptr;
+        break;
+      case TangoLayerInterface::BlockMergingStrategy::kDiscard:
+        block_map_.insert(std::make_pair(block_index, block_ptr));
+        break;
+      case TangoLayerInterface::BlockMergingStrategy::kMerge: {
+        typename BlockHashMap::iterator it = block_map_.find(block_index);
+        if (it == block_map_.end()) {
+          block_map_[block_index] = block_ptr;
+        } else {
+          it->second->mergeBlock(*block_ptr);
+        }
+      } break;
+      default:
+        LOG(FATAL) << "Unknown BlockMergingStrategy: "
+                   << static_cast<int>(strategy);
+        return false;
+    }
+    // Mark that this block has been updated.
+    block_map_[block_index]->updated() = true;
+  } else {
+    LOG(ERROR)
+        << "The blocks from this protobuf are not compatible with this layer!";
+    return false;
+  }
+  return true;
+}
+
+inline bool TangoLayerInterface::isCompatible(
+                              const tsdf2::MapHeaderProto& layer_proto) const {
+  bool compatible = true;
+  compatible &= (layer_proto.voxel_size() == voxel_size_);
+  compatible &= (layer_proto.voxels_per_volume_side() == voxels_per_side_);
+  return compatible;
+}
+
+inline bool TangoLayerInterface::isCompatible(
+                                  const tsdf2::VolumeProto& block_proto) const {
+  bool compatible = true;
+  compatible &= (block_proto.voxel_size() == voxel_size_);
+  compatible &= (block_proto.voxels_per_side() == voxels_per_side_);
+  return compatible;
+}
+
+}  // namespace voxblox
+
+#endif  // VOXBLOX_TANGO_INTERFACE_CORE_LAYER_INL_H_

--- a/voxblox_tango_interface/package.xml
+++ b/voxblox_tango_interface/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>voxblox_tango_interface</name>
+  <version>0.0.0</version>
+  <description>Voxblox Tango interface</description>
+
+  <author email="genemerewether@gmail.com">Gene Merewether</author>
+
+  <maintainer email="genemerewether@gmail.com">Gene Merewether</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>catkin_simple</buildtool_depend>
+
+  <depend>gflags_catkin</depend>
+  <depend>voxblox</depend>
+</package>

--- a/voxblox_tango_interface/proto/tsdf2/MapHeader.proto
+++ b/voxblox_tango_interface/proto/tsdf2/MapHeader.proto
@@ -1,0 +1,10 @@
+package tsdf2;
+
+message MapHeaderProto {
+  optional double voxel_size = 1;
+  optional double voxels_per_volume_side = 2;
+  optional uint32 max_ntsdf_voxel_weight = 3;
+  optional bool use_color = 4;
+  optional double meters_to_ntsdf = 5;
+  optional uint32 num_volumes = 6;
+}

--- a/voxblox_tango_interface/proto/tsdf2/Volume.proto
+++ b/voxblox_tango_interface/proto/tsdf2/Volume.proto
@@ -1,0 +1,49 @@
+package tsdf2;
+
+// TODO(mereweth@jpl.nasa.gov) - include this or verify ok to omit
+//import "engine_data_proto/Vector3d.proto";
+
+message VolumeProto {
+  message GridIndex {
+    required int32 x = 1;
+    required int32 y = 2;
+    required int32 z = 3;
+  };
+
+  // TODO(mereweth@jpl.nasa.gov) - include this or verify ok to omit
+  message Vector3dProto {
+    required double x = 1;
+    required double y = 2;
+    required double z = 3;
+  }
+
+  // Number of voxels per each dimension.
+  optional int32 voxels_per_side = 1;
+
+  // Size of each voxel, in meters.
+  optional double voxel_size = 2;
+
+  // Maximum voxel weight
+  optional uint32 max_ntsdf_voxel_weight = 3;
+
+  // TODO(mereweth@jpl.nasa.gov) - include this or verify ok to omit
+  // DEPRECATED: The origin of the volume, in meters.
+  //optional engine_data_proto.Vector3dProto origin = 4 [deprecated=true];
+  optional Vector3dProto origin = 4 [deprecated=true];
+
+  // The grid index of the volume.
+  optional GridIndex index = 8;
+
+  // If the volume has received at least one update.
+  optional bool has_data = 5;
+
+  // Voxel data is in x -> y -> z major order.
+  // The first 16 bits of the voxel are its signed distance function, the
+  // second 16 bits are its weight.
+  repeated uint32 ntsdf_voxels = 6 [packed=true];
+
+  // Color data is in x -> y -> z major order.
+  // The first 24 bits are red, green and blue bytes. The last 8 bits are a
+  // weight.
+  repeated uint32 color_voxels = 7 [packed=true];
+}

--- a/voxblox_tango_interface/src/core/tango_block_interface.cc
+++ b/voxblox_tango_interface/src/core/tango_block_interface.cc
@@ -1,0 +1,37 @@
+#include "voxblox_tango_interface/core/tango_block_interface.h"
+
+#include <cstdint>
+
+namespace voxblox {
+
+void TangoBlockInterface::deserializeFromIntegers(
+    const std::vector<uint32_t>& data) {
+  constexpr size_t kNumDataPacketsPerVoxel = 2u;
+  const size_t num_data_packets = data.size();
+
+  CHECK_EQ(num_voxels_ * kNumDataPacketsPerVoxel, num_data_packets);
+  for (size_t voxel_idx = 0u, data_idx = 0u;
+       voxel_idx < num_voxels_ && data_idx < num_data_packets;
+       ++voxel_idx, data_idx += kNumDataPacketsPerVoxel) {
+    const uint32_t bytes_1 = data[data_idx];
+    const uint32_t bytes_2 = data[data_idx + 1u];
+
+    TsdfVoxel& voxel = voxels_[voxel_idx];
+
+    // TODO(mereweth@jpl.nasa.gov) - is this the best way to unpack NTSDF?
+
+    voxel.distance = static_cast<int16_t>(bytes_1 >> 16)
+                     * meters_to_ntsdf_;
+
+    voxel.weight = static_cast<float>(max_ntsdf_voxel_weight_)
+                   / static_cast<float>(UINT16_MAX)
+                   * static_cast<uint16_t>(bytes_1 & 0x0000FFFF);
+
+    voxel.color.r = static_cast<uint8_t>(bytes_2 >> 24);
+    voxel.color.g = static_cast<uint8_t>((bytes_2 & 0x00FF0000) >> 16);
+    voxel.color.b = static_cast<uint8_t>((bytes_2 & 0x0000FF00) >> 8);
+    voxel.color.a = static_cast<uint8_t>(bytes_2 & 0x000000FF);
+  }
+}
+
+}

--- a/voxblox_tango_interface/test/mesh_tango_tsdf.cc
+++ b/voxblox_tango_interface/test/mesh_tango_tsdf.cc
@@ -1,0 +1,43 @@
+#include <iostream>  // NOLINT
+
+#include <voxblox/io/mesh_ply.h>
+#include <voxblox/mesh/mesh_integrator.h>
+
+#include "voxblox_tango_interface/io/tango_layer_io.h"
+#include "voxblox_tango_interface/core/tango_layer_interface.h"
+
+using namespace voxblox;  // NOLINT
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+
+  if (argc != 3) {
+    throw std::runtime_error("Args: filename to load, followed by filename to save to");
+  }
+
+  const std::string file = argv[1];
+
+  TangoLayerInterface::Ptr layer_from_file;
+  io::TangoLoadLayer(file, &layer_from_file);
+
+  std::cout << "Layer memory size: " << layer_from_file->getMemorySize() << "\n";
+
+  // Mesh accessories.
+  MeshIntegrator<TsdfVoxel>::Config mesh_config;
+  std::shared_ptr<MeshLayer> mesh_layer_;
+  std::unique_ptr<MeshIntegrator<TsdfVoxel> > mesh_integrator_;
+
+  mesh_layer_.reset(new MeshLayer(layer_from_file->block_size()));
+  mesh_integrator_.reset(new MeshIntegrator<TsdfVoxel>(
+      mesh_config, layer_from_file.get(), mesh_layer_.get()));
+
+  mesh_integrator_->generateWholeMesh();
+  std::cout << "Number of meshes: " << mesh_layer_->getNumberOfAllocatedMeshes() << "\n";
+  bool meshSuccess = outputMeshLayerAsPly(argv[2], *mesh_layer_);
+
+  if (meshSuccess == false) {
+    throw std::runtime_error("Failed to save mesh");
+  }
+
+  return 0;
+}

--- a/voxblox_tango_interface/test/tango_tsdf_to_esdf.cc
+++ b/voxblox_tango_interface/test/tango_tsdf_to_esdf.cc
@@ -35,8 +35,6 @@ int main(int argc, char** argv) {
   EsdfIntegrator::Config esdf_integrator_config;
   // Make sure that this is the same as the truncation distance OR SMALLER!
   esdf_integrator_config.min_distance_m = esdf_config.esdf_voxel_size;
-  // esdf_integrator_config.min_distance_m =
-  //    tsdf_integrator_->getConfig().default_truncation_distance;
   esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
                                                  layer_from_file.get(),
                                                  esdf_map_->getEsdfLayerPtr()));

--- a/voxblox_tango_interface/test/tango_tsdf_to_esdf.cc
+++ b/voxblox_tango_interface/test/tango_tsdf_to_esdf.cc
@@ -1,0 +1,52 @@
+#include <iostream>  // NOLINT
+
+#include <voxblox/core/esdf_map.h>
+#include <voxblox/integrator/esdf_integrator.h>
+
+#include "voxblox_tango_interface/io/tango_layer_io.h"
+#include "voxblox_tango_interface/core/tango_layer_interface.h"
+
+using namespace voxblox;  // NOLINT
+
+int main(int argc, char** argv) {
+  google::InitGoogleLogging(argv[0]);
+
+  if (argc != 3) {
+    throw std::runtime_error("Args: filename to load, followed by filename to save to");
+  }
+
+  const std::string file = argv[1];
+
+  TangoLayerInterface::Ptr layer_from_file;
+  io::TangoLoadLayer(file, &layer_from_file);
+
+  std::cout << "Layer memory size: " << layer_from_file->getMemorySize() << "\n";
+
+  // ESDF maps.
+  EsdfMap::Config esdf_config;
+  std::shared_ptr<EsdfMap> esdf_map_;
+  std::unique_ptr<EsdfIntegrator> esdf_integrator_;
+
+  // Same number of voxels per side for ESDF as with TSDF
+  esdf_config.esdf_voxels_per_side = layer_from_file->voxels_per_side();
+  // Same voxel size for ESDF as with TSDF
+  esdf_config.esdf_voxel_size = layer_from_file->voxel_size();
+  esdf_map_.reset(new EsdfMap(esdf_config));
+  EsdfIntegrator::Config esdf_integrator_config;
+  // Make sure that this is the same as the truncation distance OR SMALLER!
+  esdf_integrator_config.min_distance_m = esdf_config.esdf_voxel_size;
+  // esdf_integrator_config.min_distance_m =
+  //    tsdf_integrator_->getConfig().default_truncation_distance;
+  esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
+                                                 layer_from_file.get(),
+                                                 esdf_map_->getEsdfLayerPtr()));
+  esdf_integrator_->updateFromTsdfLayerBatch();
+
+  bool esdfSuccess = io::SaveLayer(esdf_map_->getEsdfLayer(), argv[2]);
+
+  if (esdfSuccess == false) {
+    throw std::runtime_error("Failed to save ESDF");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Hi Helen and Marius - I restructured the Tango interface code to live in a separate ROS package, like we discussed. I'll hopefully have another PR (or add to this one - your choice) in another week or so for functionality involving known occupied or free space, and some more Python bindings.

- I changed some of the Layer and Block class members to `protected` so that I could access them in the derived Tango Interface classes.
- I added batch query functions to EsdfMap to reduce overhead of calling from Python
- Added some simple binaries for offline processing of TSDFs and ESDFs