### PR TITLE
Added interactive slider class.

### DIFF
--- a/voxblox_ros/CMakeLists.txt
+++ b/voxblox_ros/CMakeLists.txt
@@ -10,9 +10,10 @@ add_definitions(-std=c++11 -Wno-sign-compare -Wno-unused-value)
 # LIBRARIES #
 #############
 cs_add_library(${PROJECT_NAME}
+  src/esdf_server.cc
+  src/interactive_slider.cc
   src/transformer.cc
   src/tsdf_server.cc
-  src/esdf_server.cc
 )
 
 ############

--- a/voxblox_ros/include/voxblox_ros/interactive_slider.h
+++ b/voxblox_ros/include/voxblox_ros/interactive_slider.h
@@ -1,0 +1,36 @@
+#ifndef VOXBLOX_ROS_INTERACTIVE_SLIDER_H_
+#define VOXBLOX_ROS_INTERACTIVE_SLIDER_H_
+
+#include <functional>
+#include <string>
+
+#include <interactive_markers/interactive_marker_server.h>
+#include <visualization_msgs/InteractiveMarkerFeedback.h>
+#include <voxblox/core/common.h>
+
+namespace voxblox {
+
+// InteractiveSlider class which can be used for visualizing voxel map slices.
+class InteractiveSlider {
+ public:
+  InteractiveSlider(
+      const std::string& slider_name,
+      const std::function<void(const double& slice_level)>& slider_callback,
+      const Point& initial_position,
+      const unsigned int free_plane_index,
+      const float marker_scale_meters);
+  virtual ~InteractiveSlider() {}
+
+ private:
+  const unsigned int free_plane_index_;
+  interactive_markers::InteractiveMarkerServer interactive_marker_server_;
+
+  // Processes the feedback after moving the slider.
+  virtual void interactiveMarkerFeedback(
+      const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback,
+      const std::function<void(const double slice_level)>& slider_callback);
+};
+
+}  // namespace voxblox
+
+#endif  // VOXBLOX_ROS_INTERACTIVE_SLIDER_H_

--- a/voxblox_ros/package.xml
+++ b/voxblox_ros/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
 
   <depend>gflags_catkin</depend>
+  <depend>interactive_markers</depend>
   <depend>minkindr_conversions</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>

--- a/voxblox_ros/src/interactive_slider.cc
+++ b/voxblox_ros/src/interactive_slider.cc
@@ -47,7 +47,7 @@ InteractiveSlider::InteractiveSlider(
   control.orientation.x = 0.0;
   control.orientation.y = 0.0;
   control.orientation.z = 0.0;
-  switch (free_plane_index) {
+  switch (free_plane_index_) {
     case 0u:
       marker.scale.x *= 0.1f;
       control.orientation.x = 1.0;
@@ -77,7 +77,16 @@ InteractiveSlider::InteractiveSlider(
   interactive_marker_server_.applyChanges();
 
   // Initial callback.
-  slider_callback(interactive_marker.pose.position.z);
+  switch (free_plane_index_) {
+    case 0u:
+      slider_callback(interactive_marker.pose.position.x);
+      break;
+    case 1u:
+      slider_callback(interactive_marker.pose.position.y);
+      break;
+    case 2u:
+      slider_callback(interactive_marker.pose.position.z);
+  }
 }
 
 void InteractiveSlider::interactiveMarkerFeedback(

--- a/voxblox_ros/src/interactive_slider.cc
+++ b/voxblox_ros/src/interactive_slider.cc
@@ -1,0 +1,101 @@
+#include "voxblox_ros/interactive_slider.h"
+
+#include <visualization_msgs/InteractiveMarker.h>
+#include <visualization_msgs/Marker.h>
+
+namespace voxblox {
+
+InteractiveSlider::InteractiveSlider(
+    const std::string& slider_name,
+    const std::function<void(const double& slice_level)>& slider_callback,
+    const Point& initial_position,
+    const unsigned int free_plane_index,
+    const float marker_scale_meters)
+    : free_plane_index_(free_plane_index),
+      interactive_marker_server_(slider_name) {
+  CHECK(!slider_name.empty());
+  CHECK_LT(free_plane_index, 3u);
+
+  // Create an interactive marker.
+  visualization_msgs::InteractiveMarker interactive_marker;
+  interactive_marker.header.frame_id = "map";
+  interactive_marker.header.stamp = ros::Time::now();
+  interactive_marker.pose.position.x =
+      static_cast<double>(initial_position.x());
+  interactive_marker.pose.position.y =
+      static_cast<double>(initial_position.y());
+  interactive_marker.pose.position.z =
+      static_cast<double>(initial_position.z());
+
+  // Create a marker.
+  visualization_msgs::Marker marker;
+  marker.type = visualization_msgs::Marker::CUBE;
+  marker.scale.x = marker_scale_meters;
+  marker.scale.y = marker_scale_meters;
+  marker.scale.z = marker_scale_meters;
+  constexpr float kGreyValue = 0.1f;
+  marker.color.r = kGreyValue;
+  marker.color.g = kGreyValue;
+  marker.color.b = kGreyValue;
+  marker.color.a = 1.0f;
+
+  // Control for moving the marker in the direction of the free plane index.
+  visualization_msgs::InteractiveMarkerControl control;
+  control.interaction_mode =
+      visualization_msgs::InteractiveMarkerControl::MOVE_AXIS;
+  control.orientation.w = 1.0;
+  control.orientation.x = 0.0;
+  control.orientation.y = 0.0;
+  control.orientation.z = 0.0;
+  switch (free_plane_index) {
+    case 0u:
+      marker.scale.x *= 0.1f;
+      control.orientation.x = 1.0;
+      break;
+    case 1u:
+      marker.scale.y *= 0.1f;
+      control.orientation.z = 1.0;
+      break;
+    case 2u:
+      marker.scale.z *= 0.1f;
+      control.orientation.y = 1.0;
+  }
+  interactive_marker.controls.push_back(control);
+
+  // Control for moving the marker in the plane which is orthogonal to the free
+  // plane index direction.
+  control.interaction_mode =
+      visualization_msgs::InteractiveMarkerControl::MOVE_PLANE;
+  control.markers.push_back(marker);
+  interactive_marker.controls.push_back(control);
+
+  // Add interactive marker to server.
+  interactive_marker_server_.insert(
+      interactive_marker,
+      std::bind(&InteractiveSlider::interactiveMarkerFeedback, this,
+                std::placeholders::_1, slider_callback));
+  interactive_marker_server_.applyChanges();
+
+  // Initial callback.
+  slider_callback(interactive_marker.pose.position.z);
+}
+
+void InteractiveSlider::interactiveMarkerFeedback(
+    const visualization_msgs::InteractiveMarkerFeedbackConstPtr& feedback,
+    const std::function<void(const double slice_level)>& slider_callback) {
+  if (feedback->event_type ==
+      visualization_msgs::InteractiveMarkerFeedback::POSE_UPDATE) {
+    switch (free_plane_index_) {
+      case 0u:
+        slider_callback(feedback->pose.position.x);
+        break;
+      case 1u:
+        slider_callback(feedback->pose.position.y);
+        break;
+      case 2u:
+        slider_callback(feedback->pose.position.z);
+    }
+  }
+}
+
+}  // namespace voxblox


### PR DESCRIPTION
![interactive_marker](https://user-images.githubusercontent.com/14781925/28959277-0b1f3c60-78fa-11e7-81f9-504f87079331.gif)

Example usage to visualize a `voxblox::TsdfMap tsdf_map` slice:

```c++
  constexpr unsigned int kFreePlaneIndex = 2u;
  constexpr float kMarkerScaleMeters = 2.f;
  std::function<void(const double)> slider_callback =
      [&tsdf_map](const double slice_level) {
        pcl::PointCloud<pcl::PointXYZI> pointcloud_tsdf;
        voxblox::createDistancePointcloudFromTsdfLayerSlice(
            tsdf_map.getTsdfLayer(), kFreePlaneIndex, slice_level,
            &pointcloud_tsdf);
        pointcloud_tsdf.header.frame_id = "map";
        tsdf_pointcloud_pub_.publish(pointcloud_tsdf);
      };
  topo_map::InteractiveSlider interactive_slider(
      "tsdf_slice_slider", std::bind(slider_callback, std::placeholders::_1),
      voxblox::Point(0.0, 0.0, 0.0), kFreePlaneIndex, kMarkerScaleMeters);
  ros::spin();
```
