### PR TITLE
A faster prettier voxblox

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Voxblox is a volumetric mapping library based mainly on Truncated Signed Distanc
 # Table of Contents
 * [Paper and Video](README.md#paper-and-video)
 * [Credits](README.md#credits)
+* [Performance](README.md#performance)
 * [Installation](README.md#installation)
 * [Running Voxblox](README.md#running-voxblox)
 * [Voxblox Node](README.md#voxblox-node)
@@ -42,6 +43,26 @@ Helen Oleynikova, Zachary Taylor, Marius Fehr, Juan Nieto, and Roland Siegwart, 
 
 # Credits
 This library was written primarily by Helen Oleynikova and Marius Fehr, with significant contributions from Zachary Taylor, Alexander Millane, and others. The marching cubes meshing and ROS mesh generation were taken or heavily derived from [open_chisel](https://github.com/personalrobotics/OpenChisel). We've retained the copyright headers for the relevant files.
+
+# Performance
+The Voxblox code has prioritized readability and easy extension over performance. It was also designed to operate on systems that lack a GPU. One of the main drives to create Voxblox was to create a volumetric mapping library that fit the needs of planning for robots, because of this, and unlike many TSDF libraries all possible freespace is mapped in addition to areas close to surfaces. These design decisions limit performance, however high quality real-time mapping of large enviroments is still easily acheivable. 
+
+An example of the system integrating a TSDF, generating a mesh and publishing the result to RViz in real time is shown below. A table of the performance on the cow and lady dataset on a i7-4810MQ 2.80GHz CPU is also shown.
+
+![example_gif](http://i.imgur.com/2wLztFm.gif)
+
+<center>
+
+Rendered Mesh | Setup
+--- | --- 
+<img src="http://i.imgur.com/NYykPND.jpg" width="500"> | <table><tr><td>Integrator:</td><td>Merged</td></tr><tr><td>Voxel:</td><td>20 cm</td></tr><tr><td>TSDF:</td><td>56 ms / scan</td></tr><tr><td>Meshing:</td><td>2 ms / scan</td></tr><tr><td>Total RAM:</td><td>49 MB</td></tr></table>
+<img src="http://i.imgur.com/tHmGk8h.jpg" width="500"> | <table><tr><td>Integrator:</td><td>Fast</td></tr><tr><td>Voxel:</td><td>20 cm</td></tr><tr><td>TSDF:</td><td>20 ms / scan</td></tr><tr><td>Meshing:</td><td>2 ms / scan</td></tr><tr><td>Total RAM:</td><td>62 MB</td></tr></table>
+<img src="http://i.imgur.com/9KNmnum.jpg" width="500"> | <table><tr><td>Integrator:</td><td>Merged</td></tr><tr><td>Voxel:</td><td>5 cm</td></tr><tr><td>TSDF:</td><td>112 ms / scan</td></tr><tr><td>Meshing:</td><td>10 ms / scan</td></tr><tr><td>Total RAM:</td><td>144.2 MB</td></tr></table>
+<img src="http://i.imgur.com/3zolhrB.jpg" width="500"> | <table><tr><td>Integrator:</td><td>Fast</td></tr><tr><td>Voxel:</td><td>5 cm</td></tr><tr><td>TSDF:</td><td>23 ms / scan</td></tr><tr><td>Meshing:</td><td>12 ms / scan</td></tr><tr><td>Total RAM:</td><td>153.9 MB</td></tr></table>
+<img src="http://i.imgur.com/9WvpFIt.jpg" width="500"> | <table><tr><td>Integrator:</td><td>Merged</td></tr><tr><td>Voxel:</td><td>2 cm</td></tr><tr><td>TSDF:</td><td>527 ms / scan</td></tr><tr><td>Meshing:</td><td>66 ms / scan</td></tr><tr><td>Total RAM:</td><td>609.2 MB</td></tr></table>
+<img src="http://i.imgur.com/GcYiHZ1.jpg" width="500"> | <table><tr><td>Integrator:</td><td>Fast</td></tr><tr><td>Voxel:</td><td>2 cm</td></tr><tr><td>TSDF:</td><td>63 ms / scan</td></tr><tr><td>Meshing:</td><td>110 ms / scan</td></tr><tr><td>Total RAM:</td><td>673.1 MB</td></tr></table>
+
+</center>
 
 # Installation
 To install voxblox, please install [ROS Indigo](http://wiki.ros.org/indigo/Installation/Ubuntu) or [ROS Kinetic](http://wiki.ros.org/kinetic/Installation/Ubuntu).

--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -49,6 +49,7 @@ set("${PROJECT_NAME}_SRCS"
   src/core/esdf_map.cc
   src/integrator/esdf_integrator.cc
   src/integrator/esdf_occ_integrator.cc
+  src/integrator/tsdf_integrator.cc
   src/io/mesh_ply.cc
   src/mesh/marching_cubes.cc
   src/simulation/objects.cc

--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -124,7 +124,7 @@ add_custom_command(TARGET test_data
 catkin_add_gtest(test_approx_hash_array
   test/test_approx_hash_array.cc
 )
-target_link_libraries(test_approx_hash_array ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(test_approx_hash_array ${PROJECT_NAME})
 
 catkin_add_gtest(test_tsdf_map
   test/test_tsdf_map.cc

--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -121,6 +121,11 @@ add_custom_command(TARGET test_data
 
 #add_definitions(-DVISUALIZE_UNIT_TEST_RESULTS)
 
+catkin_add_gtest(test_approx_hash_array
+  test/test_approx_hash_array.cc
+)
+target_link_libraries(test_approx_hash_array ${PROJECT_NAME} ${catkin_LIBRARIES})
+
 catkin_add_gtest(test_tsdf_map
   test/test_tsdf_map.cc
 )

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -134,7 +134,7 @@ class Block {
   inline VoxelWithFlag<VoxelType> getVoxelAndFlagByVoxelIndex(
       const VoxelIndex& index) {
     const size_t linear_index = computeLinearIndexFromVoxelIndex(index);
-    return VoxelWithFlag<VoxelType>(voxels_[&linear_index],
+    return VoxelWithFlag<VoxelType>(&voxels_[linear_index],
                                     &lock_flags_[linear_index]);
   }
 

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -1,5 +1,5 @@
-#ifndef CORE_BLOCK_H_
-#define CORE_BLOCK_H_
+#ifndef VOXBLOX_CORE_BLOCK_H_
+#define VOXBLOX_CORE_BLOCK_H_
 
 #include <atomic>
 #include <memory>
@@ -195,4 +195,4 @@ class Block {
 
 #include "voxblox/core/block_inl.h"
 
-#endif  // CORE_BLOCK_H_
+#endif  // VOXBLOX_CORE_BLOCK_H_

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -11,15 +11,6 @@
 namespace voxblox {
 
 template <typename VoxelType>
-struct VoxelWithFlag {
-  VoxelWithFlag(VoxelType* voxel, std::atomic_flag* flag)
-      : voxel_(*voxel), flag_(*flag) {}
-
-  VoxelType& voxel_;
-  std::atomic_flag& flag_;
-};
-
-template <typename VoxelType>
 class Block {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -124,24 +115,6 @@ class Block {
 
   inline VoxelType& getVoxelByCoordinates(const Point& coords) {
     return voxels_[computeLinearIndexFromCoordinates(coords)];
-  }
-
-  inline VoxelWithFlag<VoxelType> getVoxelAndFlagByLinearIndex(size_t index) {
-    DCHECK_LT(index, num_voxels_);
-    return VoxelWithFlag<VoxelType>(&voxels_[index], &lock_flags_[index]);
-  }
-
-  inline VoxelWithFlag<VoxelType> getVoxelAndFlagByVoxelIndex(
-      const VoxelIndex& index) {
-    const size_t linear_index = computeLinearIndexFromVoxelIndex(index);
-    return VoxelWithFlag<VoxelType>(&voxels_[linear_index],
-                                    &lock_flags_[linear_index]);
-  }
-
-  inline VoxelWithFlag<VoxelType> getVoxelAndFlagByCoordinates(
-      const Point& coords) {
-    const size_t index = computeLinearIndexFromCoordinates(index);
-    return VoxelWithFlag<VoxelType>(&voxels_[index], &lock_flags_[index]);
   }
 
   inline bool isValidVoxelIndex(const VoxelIndex& index) const {

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -29,11 +29,6 @@ class Block {
     block_size_ = voxels_per_side_ * voxel_size_;
     block_size_inv_ = 1.0 / block_size_;
     voxels_.reset(new VoxelType[num_voxels_]);
-    lock_flags_.reset(new std::atomic_flag[num_voxels_]);
-
-    for (size_t i = 0; i < num_voxels_; ++i) {
-      lock_flags_[i].clear();
-    }
   }
 
   explicit Block(const BlockProto& proto);
@@ -165,7 +160,6 @@ class Block {
 
  protected:
   std::unique_ptr<VoxelType[]> voxels_;
-  std::unique_ptr<std::atomic_flag[]> lock_flags_;
 
   // Derived, cached parameters.
   size_t num_voxels_;

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -149,9 +149,9 @@ class Block {
   FloatingPoint block_size() const { return block_size_; }
 
   bool has_data() const { return has_data_; }
-  bool updated() const { return updated_; }
+  const bool updated() const { return updated_; }
 
-  bool& updated() { return updated_; }
+  std::atomic<bool>& updated() { return updated_; }
   bool& has_data() { return has_data_; }
 
   // Serialization.
@@ -188,7 +188,7 @@ class Block {
   FloatingPoint block_size_inv_;
 
   // Is set to true when data is updated.
-  bool updated_;
+  std::atomic<bool> updated_;
 };
 
 }  // namespace voxblox

--- a/voxblox/include/voxblox/core/block_hash.h
+++ b/voxblox/include/voxblox/core/block_hash.h
@@ -23,7 +23,7 @@ struct AnyIndexHash {
 };
 
 template <typename ValueType>
-struct BlockHashMapType {
+struct AnyIndexHashMapType {
   typedef std::unordered_map<
       BlockIndex, ValueType, AnyIndexHash, std::equal_to<BlockIndex>,
       Eigen::aligned_allocator<std::pair<const BlockIndex, ValueType> > >
@@ -34,7 +34,7 @@ typedef std::unordered_set<AnyIndex, AnyIndexHash, std::equal_to<AnyIndex>,
                            Eigen::aligned_allocator<AnyIndex> >
     IndexSet;
 
-typedef typename BlockHashMapType<IndexVector>::type HierarchicalIndexMap;
+typedef typename AnyIndexHashMapType<IndexVector>::type HierarchicalIndexMap;
 
 typedef typename HierarchicalIndexMap::value_type HierarchicalIndex;
 

--- a/voxblox/include/voxblox/core/block_hash.h
+++ b/voxblox/include/voxblox/core/block_hash.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <unordered_map>
+#include <utility>
 
 #include <Eigen/Core>
 
@@ -10,12 +11,12 @@
 
 namespace voxblox {
 
-struct BlockIndexHash {
+struct AnyIndexHash {
   static constexpr size_t prime1 = 73856093;
   static constexpr size_t prime2 = 19349663;
   static constexpr size_t prime3 = 83492791;
 
-  std::size_t operator()(const BlockIndex& index) const {
+  std::size_t operator()(const AnyIndex& index) const {
     return (static_cast<unsigned int>(index.x()) * prime1 ^ index.y() * prime2 ^
             index.z() * prime3);
   }
@@ -24,12 +25,12 @@ struct BlockIndexHash {
 template <typename ValueType>
 struct BlockHashMapType {
   typedef std::unordered_map<
-      BlockIndex, ValueType, BlockIndexHash, std::equal_to<BlockIndex>,
+      BlockIndex, ValueType, AnyIndexHash, std::equal_to<BlockIndex>,
       Eigen::aligned_allocator<std::pair<const BlockIndex, ValueType> > >
       type;
 };
 
-typedef std::unordered_set<AnyIndex, BlockIndexHash, std::equal_to<AnyIndex>,
+typedef std::unordered_set<AnyIndex, AnyIndexHash, std::equal_to<AnyIndex>,
                            Eigen::aligned_allocator<AnyIndex> >
     IndexSet;
 

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -1,5 +1,5 @@
-#ifndef CORE_LAYER_H_
-#define CORE_LAYER_H_
+#ifndef VOXBLOX_CORE_LAYER_H_
+#define VOXBLOX_CORE_LAYER_H_
 
 #include <glog/logging.h>
 #include <string>
@@ -231,4 +231,4 @@ class Layer {
 
 #include "voxblox/core/layer_inl.h"
 
-#endif  // CORE_LAYER_H_
+#endif  // VOXBLOX_CORE_LAYER_H_

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -19,7 +19,8 @@ class Layer {
  public:
   typedef std::shared_ptr<Layer> Ptr;
   typedef Block<VoxelType> BlockType;
-  typedef typename BlockHashMapType<typename BlockType::Ptr>::type BlockHashMap;
+  typedef
+      typename AnyIndexHashMapType<typename BlockType::Ptr>::type BlockHashMap;
   typedef typename std::pair<BlockIndex, typename BlockType::Ptr> BlockMapPair;
 
   explicit Layer(FloatingPoint voxel_size, size_t voxels_per_side)

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -1,5 +1,5 @@
-#ifndef VOXBLOX_CORE_LAYER_H_
-#define VOXBLOX_CORE_LAYER_H_
+#ifndef CORE_LAYER_H_
+#define CORE_LAYER_H_
 
 #include <glog/logging.h>
 #include <string>
@@ -196,6 +196,7 @@ class Layer {
   }
 
   FloatingPoint block_size() const { return block_size_; }
+  FloatingPoint block_size_inv() const { return block_size_inv_; }
   FloatingPoint voxel_size() const { return voxel_size_; }
   size_t voxels_per_side() const { return voxels_per_side_; }
 
@@ -230,4 +231,4 @@ class Layer {
 
 #include "voxblox/core/layer_inl.h"
 
-#endif  // VOXBLOX_CORE_LAYER_H_
+#endif  // CORE_LAYER_H_

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -125,7 +125,7 @@ class EsdfIntegrator {
 
  protected:
   // Convenience functions for planning.
-  typedef BlockHashMapType<VoxelIndexList>::type BlockVoxelListMap;
+  typedef AnyIndexHashMapType<VoxelIndexList>::type BlockVoxelListMap;
   void getSphereAroundPoint(const Point& center, FloatingPoint radius,
                             BlockVoxelListMap* block_voxel_list) const;
 

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -44,6 +44,10 @@ class ThreadSafeIndex {
     const size_t number_of_groups = number_of_threads_;
     const size_t points_per_group = number_of_points_ / number_of_groups;
 
+    if (number_of_groups * points_per_group <= base_idx) {
+      return base_idx;
+    }
+
     const size_t group_num = base_idx % number_of_groups;
     const size_t position_in_group = base_idx / number_of_groups;
 

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -46,17 +46,21 @@ class RayCaster {
     setupRayCaster(start_scaled, end_scaled);
   }
 
+  // returns false if ray terminates at ray_index, true otherwise
   bool nextRayIndex(AnyIndex* ray_index) {
+    if (at_end_) {
+      return false;
+    }
     DCHECK_NOTNULL(ray_index);
     *ray_index = curr_index_;
-    bool not_at_end = curr_index_ != end_index_;
+    at_end_ = curr_index_ == end_index_;
 
     int t_min_idx;
     t_to_next_boundary_.minCoeff(&t_min_idx);
     curr_index_[t_min_idx] += ray_step_signs_[t_min_idx];
     t_to_next_boundary_[t_min_idx] += t_step_size_[t_min_idx];
 
-    return not_at_end;
+    return true;
   }
 
  private:
@@ -65,6 +69,8 @@ class RayCaster {
 
     curr_index_ = getGridIndexFromPoint(start_scaled);
     end_index_ = getGridIndexFromPoint(end_scaled);
+
+    at_end_ = false;
 
     const Ray ray_scaled = end_scaled - start_scaled;
 
@@ -108,6 +114,7 @@ class RayCaster {
   AnyIndex end_index_;
   AnyIndex ray_step_signs_;
   Ray t_step_size_;
+  bool at_end_;
 };
 
 // This function assumes PRE-SCALED coordinates, where one unit = one voxel

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -1,5 +1,5 @@
-#ifndef VOXBLOX_INTEGRATOR_INTEGRATOR_UTILS_H_
-#define VOXBLOX_INTEGRATOR_INTEGRATOR_UTILS_H_
+#ifndef INTEGRATOR_INTEGRATOR_UTILS_H_
+#define INTEGRATOR_INTEGRATOR_UTILS_H_
 
 #include <algorithm>
 #include <vector>
@@ -94,7 +94,7 @@ inline void castRay(
   RayCaster ray_caster(start_scaled, end_scaled);
 
   AnyIndex ray_index;
-  while(ray_caster.nextRayIndex(&ray_index)){
+  while (ray_caster.nextRayIndex(&ray_index)) {
     indices->push_back(ray_index);
   }
 }
@@ -148,4 +148,4 @@ inline void getHierarchicalIndexAlongRay(
 
 }  // namespace voxblox
 
-#endif  // VOXBLOX_INTEGRATOR_INTEGRATOR_UTILS_H_
+#endif  // INTEGRATOR_INTEGRATOR_UTILS_H_

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -51,7 +51,7 @@ class RayCaster {
     if (at_end_) {
       return false;
     }
-    DCHECK_NOTNULL(ray_index);
+    DCHECK(ray_index != nullptr);
     *ray_index = curr_index_;
     at_end_ = curr_index_ == end_index_;
 

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -1,5 +1,5 @@
-#ifndef INTEGRATOR_INTEGRATOR_UTILS_H_
-#define INTEGRATOR_INTEGRATOR_UTILS_H_
+#ifndef VOXBLOX_INTEGRATOR_INTEGRATOR_UTILS_H_
+#define VOXBLOX_INTEGRATOR_INTEGRATOR_UTILS_H_
 
 #include <algorithm>
 #include <vector>
@@ -175,4 +175,4 @@ inline void getHierarchicalIndexAlongRay(
 
 }  // namespace voxblox
 
-#endif  // INTEGRATOR_INTEGRATOR_UTILS_H_
+#endif  // VOXBLOX_INTEGRATOR_INTEGRATOR_UTILS_H_

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -152,7 +152,6 @@ class RayCaster {
                                                             ray_scaled.z());
   }
 
- private:
   Ray t_to_next_boundary_;
   AnyIndex curr_index_;
   AnyIndex end_index_;

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -49,23 +49,7 @@ class TsdfIntegratorBase {
     bool enable_anti_grazing = false;
   };
 
-  TsdfIntegratorBase(const Config& config, Layer<TsdfVoxel>* layer)
-      : config_(config), layer_(layer) {
-    DCHECK(layer_);
-
-    voxel_size_ = layer_->voxel_size();
-    block_size_ = layer_->block_size();
-    voxels_per_side_ = layer_->voxels_per_side();
-
-    voxel_size_inv_ = 1.0 / voxel_size_;
-    block_size_inv_ = 1.0 / block_size_;
-    voxels_per_side_inv_ = 1.0 / voxels_per_side_;
-
-    if (config_.integrator_threads == 0) {
-      LOG(WARNING) << "Automatic core count failed, defaulting to 1 threads";
-      config_.integrator_threads = 1;
-    }
-  }
+  TsdfIntegratorBase(const Config& config, Layer<TsdfVoxel>* layer);
 
   // NOT thread safe.
   virtual void integratePointCloud(const Transformation& T_G_C,
@@ -77,22 +61,7 @@ class TsdfIntegratorBase {
 
  protected:
   // Thread safe.
-  bool isPointValid(const Point& point_C, bool* is_clearing) {
-    const FloatingPoint ray_distance = point_C.norm();
-    if (ray_distance < config_.min_ray_length_m) {
-      return false;
-    } else if (ray_distance > config_.max_ray_length_m) {
-      if (config_.allow_clear) {
-        *is_clearing = true;
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      *is_clearing = false;
-      return true;
-    }
-  }
+  inline bool isPointValid(const Point& point_C, bool* is_clearing) const;
 
   // Will return a pointer to a voxel located at global_voxel_idx in the tsdf
   // layer. Thread safe
@@ -101,161 +70,22 @@ class TsdfIntegratorBase {
   // This can be merged into the layer later by calling
   // updateLayerWithStoredVoxels(temp_voxel_storage)
   inline TsdfVoxel* findOrTempAllocateVoxelPtr(
-      const VoxelIndex& global_voxel_idx, VoxelMap* temp_voxel_storage) {
-    static thread_local Block<TsdfVoxel>::Ptr block = nullptr;
-    static thread_local BlockIndex last_block_idx;
-
-    BlockIndex block_idx = getBlockIndexFromGlobalVoxelIndex(
-        global_voxel_idx, voxels_per_side_inv_);
-    VoxelIndex local_voxel_idx =
-        getLocalFromGlobalVoxelIndex(global_voxel_idx, voxels_per_side_);
-
-    if (block_idx != last_block_idx) {
-      block = layer_->getBlockPtrByIndex(block_idx);
-      last_block_idx = block_idx;
-      if (block != nullptr) {
-        block->updated() = true;
-      }
-    }
-
-    // If no block at this location currently exists, we allocate a temporary
-    // voxel that will be merged into the map later
-    if (block == nullptr) {
-      return &((*temp_voxel_storage)[global_voxel_idx]);
-    } else {
-      return &(block->getVoxelByVoxelIndex(local_voxel_idx));
-    }
-  }
+      const VoxelIndex& global_voxel_idx, VoxelMap* temp_voxel_storage) const;
 
   // NOT thread safe
-  void updateLayerWithStoredVoxels(const VoxelMap& temp_voxel_storage) {
-    BlockIndex last_block_idx;
-    Block<TsdfVoxel>::Ptr block = nullptr;
-    for (const std::pair<const VoxelIndex, TsdfVoxel>& temp_voxel :
-         temp_voxel_storage) {
-      BlockIndex block_idx = getBlockIndexFromGlobalVoxelIndex(
-          temp_voxel.first, voxels_per_side_inv_);
-      VoxelIndex local_voxel_idx =
-          getLocalFromGlobalVoxelIndex(temp_voxel.first, voxels_per_side_);
-
-      if ((block_idx != last_block_idx) || (block == nullptr)) {
-        block = layer_->allocateBlockPtrByIndex(block_idx);
-        block->updated() = true;
-      }
-
-      TsdfVoxel& base_voxel = block->getVoxelByVoxelIndex(local_voxel_idx);
-
-      const float new_weight = base_voxel.weight + temp_voxel.second.weight;
-
-      // it is possible that both voxels have weights very close to zero
-      if (new_weight < kFloatEpsilon) {
-        continue;
-      }
-
-      // color blending is expensive only do it close to the surface
-      if (std::abs(temp_voxel.second.distance) <
-          config_.default_truncation_distance) {
-        base_voxel.color = Color::blendTwoColors(
-            base_voxel.color, base_voxel.weight, temp_voxel.second.color,
-            temp_voxel.second.weight);
-      }
-
-      base_voxel.distance =
-          (base_voxel.distance * base_voxel.weight +
-           temp_voxel.second.distance * temp_voxel.second.weight) /
-          new_weight;
-
-      base_voxel.weight = std::min(config_.max_weight, new_weight);
-    }
-  }
+  inline void updateLayerWithStoredVoxels(const VoxelMap& temp_voxel_storage);
 
   // Updates tsdf_voxel. Thread safe.
   inline void updateTsdfVoxel(const Point& origin, const Point& point_G,
                               const Point& voxel_center, const Color& color,
-                              const float weight, TsdfVoxel* tsdf_voxel) {
-    // Figure out whether the voxel is behind or in front of the surface.
-    // To do this, project the voxel_center onto the ray from origin to point G.
-    // Then check if the the magnitude of the vector is smaller or greater than
-    // the original distance...
-    Point v_voxel_origin = voxel_center - origin;
-    Point v_point_origin = point_G - origin;
-
-    FloatingPoint dist_G = v_point_origin.norm();
-    // projection of a (v_voxel_origin) onto b (v_point_origin)
-    FloatingPoint dist_G_V = v_voxel_origin.dot(v_point_origin) / dist_G;
-
-    float sdf = static_cast<float>(dist_G - dist_G_V);
-
-    float updated_weight = weight;
-    // Compute updated weight in case we use weight dropoff. It's easier here
-    // that in getVoxelWeight as here we have the actual SDF for the voxel
-    // already computed.
-    const FloatingPoint dropoff_epsilon = voxel_size_;
-    if (config_.use_weight_dropoff && sdf < -dropoff_epsilon) {
-      updated_weight = weight * (config_.default_truncation_distance + sdf) /
-                       (config_.default_truncation_distance - dropoff_epsilon);
-      updated_weight = std::max(updated_weight, 0.0f);
-    }
-
-    // Compute the updated weight in case we compensate for sparsity. By
-    // multiplicating the weight of occupied areas (|sdf| < truncation distance)
-    // by a factor, we prevent to easily fade out these areas with the free
-    // space parts of other rays which pass through the corresponding voxels.
-    // This can be useful for creating a TSDF map from sparse sensor data (e.g.
-    // visual features from a SLAM system). By default, this option is disabled.
-    if (config_.use_sparsity_compensation_factor) {
-      if (std::abs(sdf) < config_.default_truncation_distance) {
-        updated_weight *= config_.sparsity_compensation_factor;
-      }
-    }
-
-    // Grab and lock the mutex responsible for this voxel
-    std::lock_guard<std::mutex> lock(
-        mutexes_.get(getGridIndexFromPoint(point_G, voxel_size_inv_)));
-
-    const float new_weight = tsdf_voxel->weight + updated_weight;
-    const float new_sdf =
-        (sdf * updated_weight + tsdf_voxel->distance * tsdf_voxel->weight) /
-        new_weight;
-
-    // color blending is expensive only do it close to the surface
-    if (std::abs(sdf) < config_.default_truncation_distance) {
-      tsdf_voxel->color = Color::blendTwoColors(
-          tsdf_voxel->color, tsdf_voxel->weight, color, updated_weight);
-    }
-
-    tsdf_voxel->distance =
-        (new_sdf > 0.0)
-            ? std::min(config_.default_truncation_distance, new_sdf)
-            : std::max(-config_.default_truncation_distance, new_sdf);
-    tsdf_voxel->weight = std::min(config_.max_weight, new_weight);
-  }
+                              const float weight, TsdfVoxel* tsdf_voxel);
 
   // Thread safe.
   inline float computeDistance(const Point& origin, const Point& point_G,
-                               const Point& voxel_center) {
-    Point v_voxel_origin = voxel_center - origin;
-    Point v_point_origin = point_G - origin;
-
-    FloatingPoint dist_G = v_point_origin.norm();
-    // projection of a (v_voxel_origin) onto b (v_point_origin)
-    FloatingPoint dist_G_V = v_voxel_origin.dot(v_point_origin) / dist_G;
-
-    float sdf = static_cast<float>(dist_G - dist_G_V);
-    return sdf;
-  }
+                               const Point& voxel_center) const;
 
   // Thread safe.
-  inline float getVoxelWeight(const Point& point_C) const {
-    if (config_.use_const_weight) {
-      return 1.0f;
-    }
-    FloatingPoint dist_z = std::abs(point_C.z());
-    if (dist_z > kEpsilon) {
-      return 1.0f / (dist_z * dist_z);
-    }
-    return 0.0f;
-  }
+  inline float getVoxelWeight(const Point& point_C) const;
 
   Config config_;
 
@@ -280,66 +110,12 @@ class SimpleTsdfIntegrator : public TsdfIntegratorBase {
       : TsdfIntegratorBase(config, layer) {}
 
   void integratePointCloud(const Transformation& T_G_C,
-                           const Pointcloud& points_C, const Colors& colors) {
-    std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
-
-    timing::Timer integrate_timer("integrate");
-
-    ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
-
-    std::vector<std::thread> integration_threads;
-    for (size_t i = 0; i < config_.integrator_threads; ++i) {
-      integration_threads.emplace_back(&SimpleTsdfIntegrator::integrateFunction,
-                                       this, T_G_C, points_C, colors,
-                                       &index_getter, &(temp_voxel_storage[i]));
-    }
-
-    for (std::thread& thread : integration_threads) {
-      thread.join();
-    }
-    integrate_timer.Stop();
-
-    timing::Timer insertion_timer("inserting_missed_voxels");
-    for (const VoxelMap& temp_voxels : temp_voxel_storage) {
-      updateLayerWithStoredVoxels(temp_voxels);
-    }
-    insertion_timer.Stop();
-  }
+                           const Pointcloud& points_C, const Colors& colors);
 
   void integrateFunction(const Transformation& T_G_C,
                          const Pointcloud& points_C, const Colors& colors,
                          ThreadSafeIndex* index_getter,
-                         VoxelMap* temp_voxel_storage) {
-    size_t point_idx;
-    while (index_getter->getNextIndex(&point_idx)) {
-      const Point& point_C = points_C[point_idx];
-      const Color& color = colors[point_idx];
-      bool is_clearing;
-      if (!isPointValid(point_C, &is_clearing)) {
-        continue;
-      }
-
-      const Point origin = T_G_C.getPosition();
-      const Point point_G = T_G_C * point_C;
-
-      RayCaster ray_caster(origin, point_G, is_clearing,
-                           config_.voxel_carving_enabled,
-                           config_.max_ray_length_m, voxel_size_inv_,
-                           config_.default_truncation_distance);
-
-      VoxelIndex global_voxel_idx;
-      while (ray_caster.nextRayIndex(&global_voxel_idx)) {
-        TsdfVoxel* voxel =
-            findOrTempAllocateVoxelPtr(global_voxel_idx, temp_voxel_storage);
-
-        const float weight = getVoxelWeight(point_C);
-        const Point voxel_center_G =
-            getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
-
-        updateTsdfVoxel(origin, point_G, voxel_center_G, color, weight, voxel);
-      }
-    }
-  }
+                         VoxelMap* temp_voxel_storage);
 };
 
 class MergedTsdfIntegrator : public TsdfIntegratorBase {
@@ -348,186 +124,34 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
       : TsdfIntegratorBase(config, layer) {}
 
   void integratePointCloud(const Transformation& T_G_C,
-                           const Pointcloud& points_C, const Colors& colors) {
-    timing::Timer integrate_timer("integrate");
-
-    // Pre-compute a list of unique voxels to end on.
-    // Create a hashmap: VOXEL INDEX -> index in original cloud.
-    BlockHashMapType<std::vector<size_t>>::type voxel_map;
-    // This is a hash map (same as above) to all the indices that need to be
-    // cleared.
-    BlockHashMapType<std::vector<size_t>>::type clear_map;
-
-    ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
-
-    bundleRays(T_G_C, points_C, colors, &index_getter, &voxel_map, &clear_map);
-
-    integrateRays(T_G_C, points_C, colors, config_.enable_anti_grazing, false,
-                  voxel_map, clear_map);
-
-    timing::Timer clear_timer("integrate/clear");
-
-    integrateRays(T_G_C, points_C, colors, config_.enable_anti_grazing, true,
-                  voxel_map, clear_map);
-
-    clear_timer.Stop();
-
-    integrate_timer.Stop();
-  }
+                           const Pointcloud& points_C, const Colors& colors);
 
  private:
   inline void bundleRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, ThreadSafeIndex* index_getter,
       BlockHashMapType<std::vector<size_t>>::type* voxel_map,
-      BlockHashMapType<std::vector<size_t>>::type* clear_map) {
-    size_t point_idx;
-    while (index_getter->getNextIndex(&point_idx)) {
-      const Point& point_C = points_C[point_idx];
-      bool is_clearing;
-      if (!isPointValid(point_C, &is_clearing)) {
-        continue;
-      }
-
-      const Point point_G = T_G_C * point_C;
-
-      VoxelIndex voxel_index = getGridIndexFromPoint(point_G, voxel_size_inv_);
-
-      if (is_clearing) {
-        (*clear_map)[voxel_index].push_back(point_idx);
-      } else {
-        (*voxel_map)[voxel_index].push_back(point_idx);
-      }
-    }
-
-    LOG(INFO) << "Went from " << points_C.size() << " points to "
-              << voxel_map->size() << " raycasts  and " << clear_map->size()
-              << " clear rays.";
-  }
+      BlockHashMapType<std::vector<size_t>>::type* clear_map);
 
   void integrateVoxel(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
       const std::pair<AnyIndex, std::vector<size_t>>& kv,
       const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
-      VoxelMap* temp_voxel_storage) {
-    if (kv.second.empty()) {
-      return;
-    }
-
-    const Point& origin = T_G_C.getPosition();
-    Color merged_color;
-    Point merged_point_C = Point::Zero();
-    FloatingPoint merged_weight = 0.0;
-
-    for (const size_t pt_idx : kv.second) {
-      const Point& point_C = points_C[pt_idx];
-      const Color& color = colors[pt_idx];
-
-      float point_weight = getVoxelWeight(point_C);
-      merged_point_C =
-          (merged_point_C * merged_weight + point_C * point_weight) /
-          (merged_weight + point_weight);
-      merged_color = Color::blendTwoColors(merged_color, merged_weight, color,
-                                           point_weight);
-      merged_weight += point_weight;
-
-      // only take first point when clearing
-      if (clearing_ray) {
-        break;
-      }
-    }
-
-    const Point merged_point_G = T_G_C * merged_point_C;
-
-    RayCaster ray_caster(origin, merged_point_G, clearing_ray,
-                         config_.voxel_carving_enabled,
-                         config_.max_ray_length_m, voxel_size_inv_,
-                         config_.default_truncation_distance, false);
-
-    BlockIndex last_block_idx = BlockIndex::Zero();
-    Block<TsdfVoxel>::Ptr block;
-
-    VoxelIndex global_voxel_idx;
-    while (ray_caster.nextRayIndex(&global_voxel_idx)) {
-      if (enable_anti_grazing) {
-        // Check if this one is already the the block hash map for this
-        // insertion. Skip this to avoid grazing.
-        if ((clearing_ray || global_voxel_idx != kv.first) &&
-            voxel_map.find(global_voxel_idx) != voxel_map.end()) {
-          continue;
-        }
-      }
-
-      TsdfVoxel* voxel =
-          findOrTempAllocateVoxelPtr(global_voxel_idx, temp_voxel_storage);
-      const Point voxel_center_G =
-          getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
-
-      updateTsdfVoxel(origin, merged_point_G, voxel_center_G, merged_color,
-                      merged_weight, voxel);
-    }
-  }
+      VoxelMap* temp_voxel_storage);
 
   void integrateVoxels(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
       const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
       const BlockHashMapType<std::vector<size_t>>::type& clear_map, size_t tid,
-      VoxelMap* temp_voxel_storage) {
-    BlockHashMapType<std::vector<size_t>>::type::const_iterator it;
-    size_t map_size;
-    if (clearing_ray) {
-      it = clear_map.begin();
-      map_size = clear_map.size();
-    } else {
-      it = voxel_map.begin();
-      map_size = voxel_map.size();
-    }
-
-    for (size_t i = 0; i < map_size; ++i) {
-      if (((i + tid + 1) % config_.integrator_threads) == 0) {
-        integrateVoxel(T_G_C, points_C, colors, enable_anti_grazing,
-                       clearing_ray, *it, voxel_map, temp_voxel_storage);
-      }
-      ++it;
-    }
-  }
+      VoxelMap* temp_voxel_storage);
 
   void integrateRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
       const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
-      const BlockHashMapType<std::vector<size_t>>::type& clear_map) {
-    const Point& origin = T_G_C.getPosition();
-
-    std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
-
-    // if only 1 thread just do function call, otherwise spawn threads
-    if (config_.integrator_threads == 1) {
-      integrateVoxels(T_G_C, points_C, colors, enable_anti_grazing,
-                      clearing_ray, voxel_map, clear_map, 0,
-                      &(temp_voxel_storage[0]));
-    } else {
-      std::vector<std::thread> integration_threads;
-      for (size_t i = 0; i < config_.integrator_threads; ++i) {
-        integration_threads.emplace_back(
-            &MergedTsdfIntegrator::integrateVoxels, this, T_G_C, points_C,
-            colors, enable_anti_grazing, clearing_ray, voxel_map, clear_map, i,
-            &(temp_voxel_storage[i]));
-      }
-
-      for (std::thread& thread : integration_threads) {
-        thread.join();
-      }
-    }
-
-    timing::Timer insertion_timer("inserting_missed_voxels");
-    for (const VoxelMap& temp_voxels : temp_voxel_storage) {
-      updateLayerWithStoredVoxels(temp_voxels);
-    }
-    insertion_timer.Stop();
-  }
+      const BlockHashMapType<std::vector<size_t>>::type& clear_map);
 };
 
 class FastTsdfIntegrator : public TsdfIntegratorBase {
@@ -538,93 +162,14 @@ class FastTsdfIntegrator : public TsdfIntegratorBase {
   void integrateFunction(const Transformation& T_G_C,
                          const Pointcloud& points_C, const Colors& colors,
                          ThreadSafeIndex* index_getter,
-                         VoxelMap* temp_voxel_storage) {
-    size_t point_idx;
-    while (index_getter->getNextIndex(&point_idx)) {
-      const Point& point_C = points_C[point_idx];
-      const Color& color = colors[point_idx];
-      bool is_clearing;
-      if (!isPointValid(point_C, &is_clearing)) {
-        continue;
-      }
-
-      const Point origin = T_G_C.getPosition();
-      const Point point_G = T_G_C * point_C;
-      // immediately check if the voxel the point is in has already been ray
-      // traced (saves time setting up ray tracer for already used points)
-      AnyIndex global_voxel_idx =
-          getGridIndexFromPoint(point_G, voxel_sub_sample_ * voxel_size_inv_);
-      if (!approx_start_tester_.replaceHash(global_voxel_idx)) {
-        continue;
-      }
-
-      RayCaster ray_caster(origin, point_G, is_clearing,
-                           config_.voxel_carving_enabled,
-                           config_.max_ray_length_m, voxel_size_inv_,
-                           config_.default_truncation_distance, false);
-
-      BlockIndex last_block_idx = BlockIndex::Zero();
-      Block<TsdfVoxel>::Ptr block;
-
-      size_t consecutive_ray_collisions = 0;
-
-      while (ray_caster.nextRayIndex(&global_voxel_idx)) {
-        // if all a ray is doing is follow in the path of another, stop casting
-        if (!approx_ray_tester_.replaceHash(global_voxel_idx)) {
-          ++consecutive_ray_collisions;
-        } else {
-          consecutive_ray_collisions = 0;
-        }
-        if (consecutive_ray_collisions > max_consecutive_ray_collisions_) {
-          break;
-        }
-
-        TsdfVoxel* voxel =
-            findOrTempAllocateVoxelPtr(global_voxel_idx, temp_voxel_storage);
-
-        const float weight = getVoxelWeight(point_C);
-        const Point voxel_center_G =
-            getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
-
-        updateTsdfVoxel(origin, point_G, voxel_center_G, color, weight, voxel);
-      }
-    }
-  }
+                         VoxelMap* temp_voxel_storage);
 
   void integratePointCloud(const Transformation& T_G_C,
-                           const Pointcloud& points_C, const Colors& colors) {
-    std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
-
-    timing::Timer integrate_timer("integrate");
-
-    approx_ray_tester_.resetApproxSet();
-    approx_start_tester_.resetApproxSet();
-
-    ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
-
-    std::vector<std::thread> integration_threads;
-    for (size_t i = 0; i < config_.integrator_threads; ++i) {
-      integration_threads.emplace_back(&FastTsdfIntegrator::integrateFunction,
-                                       this, T_G_C, points_C, colors,
-                                       &index_getter, &(temp_voxel_storage[i]));
-    }
-
-    for (std::thread& thread : integration_threads) {
-      thread.join();
-    }
-
-    integrate_timer.Stop();
-
-    timing::Timer insertion_timer("inserting_missed_voxels");
-    for (const VoxelMap& temp_voxels : temp_voxel_storage) {
-      updateLayerWithStoredVoxels(temp_voxels);
-    }
-    insertion_timer.Stop();
-  }
+                           const Pointcloud& points_C, const Colors& colors);
 
  private:
   static constexpr FloatingPoint voxel_sub_sample_ = 2.0f;
-  static constexpr size_t max_consecutive_ray_collisions_ = 8;
+  static constexpr size_t max_consecutive_ray_collisions_ = 2;
   static constexpr size_t masked_bits_ = 20;  // 8 mb of ram per tester
   static constexpr size_t full_reset_threshold = 10000;
   ApproxHashSet<masked_bits_, full_reset_threshold> approx_start_tester_;

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -226,6 +226,10 @@ class TsdfIntegratorBase {
       }
     }
 
+    // Grab and lock the mutex responsible for this voxel
+    std::lock_guard<std::mutex> lock(
+        mutexes_.get(getGridIndexFromPoint(point_G, voxel_size_inv_)));
+
     const float new_weight = tsdf_voxel->weight + updated_weight;
     tsdf_voxel->color = Color::blendTwoColors(
         tsdf_voxel->color, tsdf_voxel->weight, color, updated_weight);
@@ -365,7 +369,6 @@ class SimpleTsdfIntegrator : public TsdfIntegratorBase {
 
         const float weight = getVoxelWeight(point_C);
 
-        std::lock_guard<std::mutex> lock(mutexes_.get(global_voxel_idx));
         updateTsdfVoxel(origin, point_G, voxel_center_G, color,
                         truncation_distance, weight, &tsdf_voxel);
       }
@@ -691,7 +694,6 @@ class FastTsdfIntegrator : public TsdfIntegratorBase {
 
         const float weight = getVoxelWeight(point_C);
 
-        std::lock_guard<std::mutex> lock(mutexes_.get(global_voxel_idx));
         updateTsdfVoxel(origin, point_G, voxel_center_G, color,
                         truncation_distance, weight, &tsdf_voxel);
       }

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -158,8 +158,8 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
       const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
-      const BlockHashMapType<std::vector<size_t>>::type& clear_map, size_t tid,
-      VoxelMap* temp_voxel_storage);
+      const BlockHashMapType<std::vector<size_t>>::type& clear_map,
+      size_t thread_idx, VoxelMap* temp_voxel_storage);
 
   void integrateRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
@@ -198,12 +198,12 @@ class FastTsdfIntegrator : public TsdfIntegratorBase {
   // Voxel start locations are added to this set before ray casting. The ray
   // casting only occurs if no ray has been cast from this location for this
   // scan.
-  ApproxHashSet<masked_bits_, full_reset_threshold> approx_start_tester_;
+  ApproxHashSet<masked_bits_, full_reset_threshold> start_voxel_approx_set_;
   // This set records which voxels a scans rays have passed through. If a ray
   // moves through max_consecutive_ray_collisions voxels in a row that have
   // already been seen this scan, it is deemed to be adding no new information
   // and the casting stops.
-  ApproxHashSet<masked_bits_, full_reset_threshold> approx_ray_tester_;
+  ApproxHashSet<masked_bits_, full_reset_threshold> voxel_observed_approx_set_;
 };
 
 }  // namespace voxblox

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -91,7 +91,7 @@ class TsdfIntegratorBase {
         const Point& point_C = points_C_[*point_idx];
         *point_G = T_G_C_ * point_C;
 
-        FloatingPoint ray_distance = (*point_G - origin_).norm();
+        const FloatingPoint ray_distance = (*point_G - origin_).norm();
         if (ray_distance < config_.min_ray_length_m) {
           continue;
         } else if (ray_distance > config_.max_ray_length_m) {
@@ -127,15 +127,14 @@ class TsdfIntegratorBase {
 
    private:
     // Mixes up the order rays are given in so that each thread is working with
-    // a
-    // point that is far away from the other threads current points.
+    // a point that is far away from the other threads current points.
     size_t getMixedIdx(size_t base_idx) {
       const size_t number_of_points = points_C_.size();
       const size_t number_of_groups = config_.integrator_threads;
       const size_t points_per_group = number_of_points / number_of_groups;
 
-      size_t group_num = base_idx % number_of_groups;
-      size_t position_in_group = base_idx / number_of_groups;
+      const size_t group_num = base_idx % number_of_groups;
+      const size_t position_in_group = base_idx / number_of_groups;
 
       return group_num * points_per_group + position_in_group;
     }

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -69,13 +69,15 @@ class TsdfIntegratorBase {
   inline bool isPointValid(const Point& point_C, bool* is_clearing) const;
 
   // Will return a pointer to a voxel located at global_voxel_idx in the tsdf
-  // layer. Thread safe
+  // layer. Thread safe.
+  // Takes in the last_block_idx and last_block to prevent unneeded map lookups.
   // If the block this voxel would be in has not been allocated, a voxel in
   // temp_voxel_storage is allocated and returned instead.
   // This can be merged into the layer later by calling
   // updateLayerWithStoredVoxels(temp_voxel_storage)
   inline TsdfVoxel* findOrTempAllocateVoxelPtr(
-      const VoxelIndex& global_voxel_idx, VoxelMap* temp_voxel_storage) const;
+      const VoxelIndex& global_voxel_idx, Block<TsdfVoxel>::Ptr* last_block,
+      BlockIndex* last_block_idx, VoxelMap* temp_voxel_storage) const;
 
   // NOT thread safe
   inline void updateLayerWithStoredVoxels(const VoxelMap& temp_voxel_storage);

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -146,28 +146,28 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
   inline void bundleRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, ThreadSafeIndex* index_getter,
-      BlockHashMapType<std::vector<size_t>>::type* voxel_map,
-      BlockHashMapType<std::vector<size_t>>::type* clear_map);
+      AnyIndexHashMapType<std::vector<size_t>>::type* voxel_map,
+      AnyIndexHashMapType<std::vector<size_t>>::type* clear_map);
 
   void integrateVoxel(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
       const std::pair<AnyIndex, std::vector<size_t>>& kv,
-      const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
+      const AnyIndexHashMapType<std::vector<size_t>>::type& voxel_map,
       VoxelMap* temp_voxel_storage);
 
   void integrateVoxels(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
-      const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
-      const BlockHashMapType<std::vector<size_t>>::type& clear_map,
+      const AnyIndexHashMapType<std::vector<size_t>>::type& voxel_map,
+      const AnyIndexHashMapType<std::vector<size_t>>::type& clear_map,
       size_t thread_idx, VoxelMap* temp_voxel_storage);
 
   void integrateRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
-      const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
-      const BlockHashMapType<std::vector<size_t>>::type& clear_map);
+      const AnyIndexHashMapType<std::vector<size_t>>::type& voxel_map,
+      const AnyIndexHashMapType<std::vector<size_t>>::type& clear_map);
 };
 
 class FastTsdfIntegrator : public TsdfIntegratorBase {

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -1,5 +1,5 @@
-#ifndef INTEGRATOR_TSDF_INTEGRATOR_H_
-#define INTEGRATOR_TSDF_INTEGRATOR_H_
+#ifndef VOXBLOX_INTEGRATOR_TSDF_INTEGRATOR_H_
+#define VOXBLOX_INTEGRATOR_TSDF_INTEGRATOR_H_
 
 #include <algorithm>
 #include <atomic>
@@ -645,4 +645,4 @@ class FastTsdfIntegrator : public TsdfIntegratorBase {
 
 }  // namespace voxblox
 
-#endif  // INTEGRATOR_TSDF_INTEGRATOR_H_
+#endif  // VOXBLOX_INTEGRATOR_TSDF_INTEGRATOR_H_

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -26,12 +26,12 @@
 namespace voxblox {
 
 // Note most functions state if they are thread safe. Unless explicitly stated
-// otherwise, this thread saftey is based on the assumption that any pointers
+// otherwise, this thread safety is based on the assumption that any pointers
 // passed to the functions point to objects that are guaranteed to not be
 // accessed by other threads.
 class TsdfIntegratorBase {
  public:
-  typedef BlockHashMapType<TsdfVoxel>::type VoxelMap;
+  typedef AnyIndexHashMapType<TsdfVoxel>::type VoxelMap;
 
   struct Config {
     float default_truncation_distance = 0.1;

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -217,8 +217,8 @@ class MeshIntegrator {
   void extractMeshInsideBlock(const Block<VoxelType>& block,
                               const VoxelIndex& index, const Point& coords,
                               VertexIndex* next_mesh_index, Mesh* mesh) {
-    DCHECK_NOTNULL(next_mesh_index);
-    DCHECK_NOTNULL(mesh);
+    DCHECK(next_mesh_index != nullptr);
+    DCHECK(mesh != nullptr);
 
     // If the distance to the surface is greater than the length of two voxels,
     // the mesh will be empty.
@@ -254,7 +254,7 @@ class MeshIntegrator {
   void extractMeshOnBorder(const Block<VoxelType>& block,
                            const VoxelIndex& index, const Point& coords,
                            VertexIndex* next_mesh_index, Mesh* mesh) {
-    DCHECK_NOTNULL(mesh);
+    DCHECK(mesh != nullptr);
 
     // If the distance to the surface is greater than the length of two voxels,
     // the mesh will be empty.
@@ -326,7 +326,7 @@ class MeshIntegrator {
   }
 
   void updateMeshColor(const Block<VoxelType>& block, Mesh* mesh) {
-    CHECK_NOTNULL(mesh);
+    DCHECK(mesh != nullptr);
 
     mesh->colors.clear();
     mesh->colors.resize(mesh->indices.size());

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -170,7 +170,7 @@ class MeshIntegrator {
 
     // If the distance to the surface is greater than the length of two voxels,
     // the mesh will be empty.
-    if ((2 * block.voxel_size()) <=
+    if ((2.0 * block.voxel_size()) <=
         std::abs(block.getVoxelByVoxelIndex(index).distance)) {
       return;
     }
@@ -206,7 +206,7 @@ class MeshIntegrator {
 
     // If the distance to the surface is greater than the length of two voxels,
     // the mesh will be empty.
-    if ((2 * block.voxel_size()) <=
+    if ((2.0 * block.voxel_size()) <=
         std::abs(block.getVoxelByVoxelIndex(index).distance)) {
       return;
     }
@@ -286,7 +286,7 @@ class MeshIntegrator {
       if (block.isValidVoxelIndex(voxel_index)) {
         const VoxelType& voxel = block.getVoxelByVoxelIndex(voxel_index);
 
-        if (((2 * block.voxel_size()) > std::abs(voxel.distance)) &&
+        if (((2.0 * block.voxel_size()) > std::abs(voxel.distance)) &&
             (voxel.weight >= config_.min_weight)) {
           mesh->colors[i] = voxel.color;
         }

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -24,6 +24,7 @@
 #define VOXBLOX_MESH_MESH_INTEGRATOR_H_
 
 #include <algorithm>
+#include <thread>
 #include <vector>
 
 #include <glog/logging.h>
@@ -31,6 +32,7 @@
 
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"
+#include "voxblox/integrator/integrator_utils.h"
 #include "voxblox/interpolator/interpolator.h"
 #include "voxblox/mesh/marching_cubes.h"
 #include "voxblox/mesh/mesh_layer.h"

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#ifndef MESH_MESH_INTEGRATOR_H_
-#define MESH_MESH_INTEGRATOR_H_
+#ifndef VOXBLOX_MESH_MESH_INTEGRATOR_H_
+#define VOXBLOX_MESH_MESH_INTEGRATOR_H_
 
 #include <algorithm>
 #include <vector>
@@ -323,4 +323,4 @@ class MeshIntegrator {
 
 }  // namespace voxblox
 
-#endif  // MESH_MESH_INTEGRATOR_H_
+#endif  // VOXBLOX_MESH_MESH_INTEGRATOR_H_

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -88,9 +88,10 @@ class MeshIntegrator {
 
     std::vector<std::thread> integration_threads;
     for (size_t i = 0; i < config_.integrator_threads; ++i) {
+      constexpr bool clear_updated_flag = true;
       integration_threads.emplace_back(
           &MeshIntegrator::generateMeshBlocksFunction, this, all_tsdf_blocks,
-          true, &index_getter);
+          clear_updated_flag, &index_getter);
     }
 
     for (std::thread& thread : integration_threads) {

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -170,7 +170,7 @@ class MeshIntegrator {
 
     // If the distance to the surface is greater than the length of two voxels,
     // the mesh will be empty.
-    if ((2 * block.voxel_size()) <
+    if ((2 * block.voxel_size()) <=
         std::abs(block.getVoxelByVoxelIndex(index).distance)) {
       return;
     }
@@ -206,7 +206,7 @@ class MeshIntegrator {
 
     // If the distance to the surface is greater than the length of two voxels,
     // the mesh will be empty.
-    if ((2 * block.voxel_size()) <
+    if ((2 * block.voxel_size()) <=
         std::abs(block.getVoxelByVoxelIndex(index).distance)) {
       return;
     }
@@ -286,7 +286,7 @@ class MeshIntegrator {
       if (block.isValidVoxelIndex(voxel_index)) {
         const VoxelType& voxel = block.getVoxelByVoxelIndex(voxel_index);
 
-        if (((2 * block.voxel_size()) >= std::abs(voxel.distance)) &&
+        if (((2 * block.voxel_size()) > std::abs(voxel.distance)) &&
             (voxel.weight >= config_.min_weight)) {
           mesh->colors[i] = voxel.color;
         }

--- a/voxblox/include/voxblox/mesh/mesh_layer.h
+++ b/voxblox/include/voxblox/mesh/mesh_layer.h
@@ -132,8 +132,9 @@ class MeshLayer {
     // them
     VertexIndexList temp_indices;
 
-    // If two vertices closer than (voxel_size / key_multiplication_factor) then
-    // the second vertice will be discarded and the first one used in its place
+    // If two vertexes are closer together than (voxel_size /
+    // key_multiplication_factor), then the second vertex will be discarded and
+    // the first one used in its place
     constexpr FloatingPoint key_multiplication_factor = 10;
 
     // Combine everything in the layer into one giant combined mesh.

--- a/voxblox/include/voxblox/mesh/mesh_layer.h
+++ b/voxblox/include/voxblox/mesh/mesh_layer.h
@@ -16,7 +16,7 @@ class MeshLayer {
  public:
   typedef std::shared_ptr<MeshLayer> Ptr;
   typedef std::shared_ptr<const MeshLayer> ConstPtr;
-  typedef typename BlockHashMapType<Mesh::Ptr>::type MeshMap;
+  typedef typename AnyIndexHashMapType<Mesh::Ptr>::type MeshMap;
 
   explicit MeshLayer(FloatingPoint block_size) : block_size_(block_size) {}
   virtual ~MeshLayer() {}
@@ -126,7 +126,7 @@ class MeshLayer {
 
   void combineMesh(Mesh::Ptr combined_mesh) const {
     // Used to prevent double ups in vertices
-    BlockHashMapType<IndexElement>::type uniques;
+    AnyIndexHashMapType<IndexElement>::type uniques;
 
     // Some triangles will have zero area we store them here first then filter
     // them

--- a/voxblox/include/voxblox/mesh/mesh_layer.h
+++ b/voxblox/include/voxblox/mesh/mesh_layer.h
@@ -134,7 +134,7 @@ class MeshLayer {
 
     // If two vertices closer than (voxel_size / key_multiplication_factor) then
     // the second vertice will be discarded and the first one used in its place
-    constexpr FloatingPoint key_multiplication_factor = 100;
+    constexpr FloatingPoint key_multiplication_factor = 10;
 
     // Combine everything in the layer into one giant combined mesh.
     size_t v = 0;

--- a/voxblox/include/voxblox/simulation/objects.h
+++ b/voxblox/include/voxblox/simulation/objects.h
@@ -268,14 +268,14 @@ class Cylinder : public Object {
       distance = std::sqrt(
           std::max((point.head<2>() - center_.head<2>()).squaredNorm() -
                        radius_ * radius_,
-                   0.0) +
+                   static_cast<FloatingPoint>(0.0)) +
           (point.z() - max_z_limit) * (point.z() - max_z_limit));
     } else {
       // Case 3: below cylinder.
       distance = std::sqrt(
           std::max((point.head<2>() - center_.head<2>()).squaredNorm() -
                        radius_ * radius_,
-                   0.0) +
+                   static_cast<FloatingPoint>(0.0)) +
           (point.z() - min_z_limit) * (point.z() - min_z_limit));
     }
     return distance;

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -1,6 +1,7 @@
 #ifndef VOXBLOX_UTILS_APPROX_HASH_ARRAY_H_
 #define VOXBLOX_UTILS_APPROX_HASH_ARRAY_H_
 
+#include <array>
 #include <atomic>
 #include <limits>
 #include "voxblox/core/common.h"

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -1,5 +1,5 @@
-#ifndef UTILS_APPROX_HASH_ARRAY_H_
-#define UTILS_APPROX_HASH_ARRAY_H_
+#ifndef VOXBLOX_UTILS_APPROX_HASH_ARRAY_H_
+#define VOXBLOX_UTILS_APPROX_HASH_ARRAY_H_
 
 #include <atomic>
 #include <limits>
@@ -150,4 +150,4 @@ class ApproxHashSet {
 };
 }  // namespace voxblox
 
-#endif  // UTILS_APPROX_HASH_ARRAY_H_
+#endif  // VOXBLOX_UTILS_APPROX_HASH_ARRAY_H_

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -48,7 +48,7 @@ class ApproxHashArray {
   static constexpr size_t bit_mask_ = (1 << unmasked_bits_) - 1;
 
   std::array<StoredElement, pseudo_map_size_> pseudo_map_;
-  BlockIndexHash hasher_;
+  AnyIndexHash hasher_;
 };
 
 // Acts as a fast and thread safe set, with the serious limitation of both
@@ -146,7 +146,7 @@ class ApproxHashSet {
   size_t reset_counter_;
   std::array<std::atomic<size_t>, pseudo_set_size_> pseudo_set_;
   std::atomic<size_t>* pseudo_set_ptr_;
-  BlockIndexHash hasher_;
+  AnyIndexHash hasher_;
 };
 }  // namespace voxblox
 

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -15,16 +15,16 @@
 // simply locking the entire layer
 // Disadvantages-
 // - Highly inefficient use of memory (allocates 2^N elements)
-// - Cannot disern between two different elements with the same hash
+// - Cannot discern between two different elements with the same hash
 // - If the hash of two elements have the same first N elements of their hash,
 // only one can be store.
 
-// Basic container, given in an index and get the element that was stored there.
+namespace voxblox {
+
+// Basic container, give in an index and get the element that was stored there.
 // There are 2^unmasked_bits_ elements in the container, which element is
 // returned depends on your hashing function.
 // Uses at least 2^unmaksed_bits * sizeof(StoreElement) bytes of ram
-
-namespace voxblox {
 template <size_t unmasked_bits_, typename StoredElement>
 class ApproxHashArray {
  public:
@@ -53,6 +53,11 @@ class ApproxHashArray {
 
 // Acts as a fast and thread safe set, with the serious limitation of both
 // false-negatives and false positives being possible.
+// A false positive occurs if two different elements have the same hash, and the
+// other element was already added to the set.
+// A false negative occurs if an element was removed to add another element with
+// the same masked hash. The chance of this happening is inversely proportional
+// to 2^unmasked_bits_.
 // Uses at least (2^unmaksed_bits + full_reset_threshold) * sizeof(StoreElement)
 // bytes of ram.
 // Note that the reset function is not thread safe.
@@ -68,7 +73,7 @@ class ApproxHashSet {
   }
 
   // Returns true if an element with the same hash is currently in the set,
-  // false otherwise
+  // false otherwise.
   // Note due to the masking of bits, many elements that were previously
   // inserted into the ApproxHashSet have been overwritten by other values.
   bool isHashCurrentlyPresent(const size_t& hash) {
@@ -92,8 +97,8 @@ class ApproxHashSet {
   }
 
   // Returns true if it replaced the element in the masked_hash's with the hash
-  // of the given element
-  // Returns false if this hash was already there and no replacement was needed
+  // of the given element.
+  // Returns false if this hash was already there and no replacement was needed.
   bool replaceHash(const size_t& hash) {
     const size_t masked_hash = hash & bit_mask_;
     if (pseudo_set_ptr_[masked_hash].load(std::memory_order_relaxed) == hash) {

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -17,14 +17,14 @@
 // - Highly inefficient use of memory (allocates 2^N elements)
 // - Cannot discern between two different elements with the same hash
 // - If the hash of two elements have the same first N elements of their hash,
-// only one can be store.
+// only one can be stored.
 
 namespace voxblox {
 
 // Basic container, give in an index and get the element that was stored there.
 // There are 2^unmasked_bits_ elements in the container, which element is
 // returned depends on your hashing function.
-// Uses at least 2^unmaksed_bits * sizeof(StoreElement) bytes of ram
+// Uses at least 2^unmasked_bits * sizeof(StoreElement) bytes of ram
 template <size_t unmasked_bits_, typename StoredElement>
 class ApproxHashArray {
  public:
@@ -58,7 +58,7 @@ class ApproxHashArray {
 // A false negative occurs if an element was removed to add another element with
 // the same masked hash. The chance of this happening is inversely proportional
 // to 2^unmasked_bits_.
-// Uses at least (2^unmaksed_bits + full_reset_threshold) * sizeof(StoreElement)
+// Uses at least (2^unmasked_bits + full_reset_threshold) * sizeof(StoreElement)
 // bytes of ram.
 // Note that the reset function is not thread safe.
 template <size_t unmasked_bits_, size_t full_reset_threshold_>

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -1,0 +1,153 @@
+#ifndef UTILS_APPROX_HASH_ARRAY_H_
+#define UTILS_APPROX_HASH_ARRAY_H_
+
+#include <atomic>
+#include <limits>
+#include "voxblox/core/common.h"
+
+// These classes allocate a fixed size array and index it with a hash that is
+// masked so that only its first N bits are non zero. This can be
+// thought of as a fast rough approximation of a hash table.
+// There are several advantages and some very significant disadvantages
+// Advantages-
+// - Simple and blazing fast lockless thread-safe approximate sets
+// - Can be used to provide more fine grain locking of blocks for threading then
+// simply locking the entire layer
+// Disadvantages-
+// - Highly inefficient use of memory (allocates 2^N elements)
+// - Cannot disern between two different elements with the same hash
+// - If the hash of two elements have the same first N elements of their hash,
+// only one can be store.
+
+// Basic container, given in an index and get the element that was stored there.
+// There are 2^unmasked_bits_ elements in the container, which element is
+// returned depends on your hashing function.
+// Uses at least 2^unmaksed_bits * sizeof(StoreElement) bytes of ram
+
+namespace voxblox {
+template <size_t unmasked_bits_, typename StoredElement>
+class ApproxHashArray {
+ public:
+  StoredElement& get(const size_t& hash) {
+    return pseudo_map_[hash & bit_mask_];
+  }
+
+  StoredElement& get(const AnyIndex& index, size_t* hash) {
+    DCHECK(hash);
+    *hash = hasher_(index);
+    return get(hash);
+  }
+
+  StoredElement& get(const AnyIndex& index) {
+    size_t hash = hasher_(index);
+    return get(hash);
+  }
+
+ private:
+  static constexpr size_t pseudo_map_size_ = (1 << unmasked_bits_);
+  static constexpr size_t bit_mask_ = (1 << unmasked_bits_) - 1;
+
+  std::array<StoredElement, pseudo_map_size_> pseudo_map_;
+  BlockIndexHash hasher_;
+};
+
+// Acts as a fast and thread safe set, with the serious limitation of both
+// false-negatives and false positives being possible.
+// Uses at least (2^unmaksed_bits + full_reset_threshold) * sizeof(StoreElement)
+// bytes of ram.
+// Note that the reset function is not thread safe.
+template <size_t unmasked_bits_, size_t full_reset_threshold_>
+class ApproxHashSet {
+ public:
+  ApproxHashSet() {
+    pseudo_set_ptr_ = &pseudo_set_[reset_counter_++];
+
+    // we init our set with zeros, except for the 0 bin which needs a different
+    // number
+    pseudo_set_ptr_[0].store(std::numeric_limits<size_t>::max());
+  }
+
+  // Returns true if an element with the same hash is currently in the set,
+  // false otherwise
+  // Note due to the masking of bits, many elements that were previously
+  // inserted into the ApproxHashSet have been overwritten by other values.
+  bool isHashCurrentlyPresent(const size_t& hash) {
+    if (pseudo_set_ptr_[hash & bit_mask_].load(std::memory_order_relaxed) ==
+        hash) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  bool isHashCurrentlyPresent(const AnyIndex& index, size_t* hash) {
+    DCHECK(hash);
+    *hash = hasher_(index);
+    return isHashCurrentlyPresent(hash);
+  }
+
+  bool isHashCurrentlyPresent(const AnyIndex& index) {
+    size_t hash = hasher_(index);
+    return isHashCurrentlyPresent(hash);
+  }
+
+  // Returns true if it replaced the element in the masked_hash's with the hash
+  // of the given element
+  // Returns false if this hash was already there and no replacement was needed
+  bool replaceHash(const size_t& hash) {
+    const size_t masked_hash = hash & bit_mask_;
+    if (pseudo_set_ptr_[masked_hash].load(std::memory_order_relaxed) == hash) {
+      return false;
+    } else {
+      pseudo_set_ptr_[masked_hash].store(hash, std::memory_order_relaxed);
+      return true;
+    }
+  }
+
+  bool replaceHash(const AnyIndex& index, size_t* hash) {
+    DCHECK(hash);
+    *hash = hasher_(index);
+    return replaceHash(hash);
+  }
+
+  bool replaceHash(const AnyIndex& index) {
+    size_t hash = hasher_(index);
+    return replaceHash(hash);
+  }
+
+  // If unmasked_bits_ is large, the array takes a lot of memory, this makes
+  // clearing it slow.
+  // However offsetting which bin hashes are placed into have the same effect.
+  // Once we run out of room to offset by (determined by full_reset_threshold we
+  // clear the memory).
+  // This function is not thread safe.
+  void resetApproxSet() {
+    if (reset_counter_ > full_reset_threshold_) {
+      for (std::atomic<size_t>& value : pseudo_set_) {
+        value.store(0, std::memory_order_relaxed);
+      }
+      reset_counter_ = 0;
+      pseudo_set_ptr_ = &pseudo_set_[reset_counter_++];
+
+      // we init our set with zeros, except for the 0 bin which needs a
+      // different number
+      pseudo_set_ptr_[0].store(std::numeric_limits<size_t>::max());
+
+    } else {
+      pseudo_set_ptr_ = &pseudo_set_[reset_counter_++];
+    }
+  }
+
+ private:
+  static constexpr size_t pseudo_set_size_ =
+      (1 << unmasked_bits_) + full_reset_threshold_;
+  static constexpr size_t bit_mask_ = (1 << unmasked_bits_) - 1;
+
+  size_t reset_counter_;
+  std::array<std::atomic<size_t>, pseudo_set_size_> pseudo_set_;
+  std::atomic<size_t>* pseudo_set_ptr_;
+  BlockIndexHash hasher_;
+};
+}  // namespace voxblox
+
+#endif  // UTILS_APPROX_HASH_ARRAY_H_

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -65,8 +65,12 @@ class ApproxHashArray {
 template <size_t unmasked_bits_, size_t full_reset_threshold_>
 class ApproxHashSet {
  public:
-  ApproxHashSet() {
+  ApproxHashSet() : reset_counter_(0) {
     pseudo_set_ptr_ = &pseudo_set_[reset_counter_++];
+
+    for (std::atomic<size_t>& value : pseudo_set_) {
+      value.store(0, std::memory_order_relaxed);
+    }
 
     // we init our set with zeros, except for the 0 bin which needs a different
     // number
@@ -128,7 +132,7 @@ class ApproxHashSet {
   // clear the memory).
   // This function is not thread safe.
   void resetApproxSet() {
-    if (reset_counter_ > full_reset_threshold_) {
+    if (reset_counter_ >= full_reset_threshold_) {
       for (std::atomic<size_t>& value : pseudo_set_) {
         value.store(0, std::memory_order_relaxed);
       }

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -1,0 +1,540 @@
+#include "voxblox/integrator/tsdf_integrator.h"
+
+namespace voxblox {
+
+TsdfIntegratorBase::TsdfIntegratorBase(const Config& config,
+                                       Layer<TsdfVoxel>* layer)
+    : config_(config), layer_(layer) {
+  DCHECK(layer_);
+
+  voxel_size_ = layer_->voxel_size();
+  block_size_ = layer_->block_size();
+  voxels_per_side_ = layer_->voxels_per_side();
+
+  voxel_size_inv_ = 1.0 / voxel_size_;
+  block_size_inv_ = 1.0 / block_size_;
+  voxels_per_side_inv_ = 1.0 / voxels_per_side_;
+
+  if (config_.integrator_threads == 0) {
+    LOG(WARNING) << "Automatic core count failed, defaulting to 1 threads";
+    config_.integrator_threads = 1;
+  }
+}
+
+// Thread safe.
+inline bool TsdfIntegratorBase::isPointValid(const Point& point_C,
+                                             bool* is_clearing) const {
+  const FloatingPoint ray_distance = point_C.norm();
+  if (ray_distance < config_.min_ray_length_m) {
+    return false;
+  } else if (ray_distance > config_.max_ray_length_m) {
+    if (config_.allow_clear) {
+      *is_clearing = true;
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    *is_clearing = false;
+    return true;
+  }
+}
+
+// Will return a pointer to a voxel located at global_voxel_idx in the tsdf
+// layer. Thread safe
+// If the block this voxel would be in has not been allocated, a voxel in
+// temp_voxel_storage is allocated and returned instead.
+// This can be merged into the layer later by calling
+// updateLayerWithStoredVoxels(temp_voxel_storage)
+inline TsdfVoxel* TsdfIntegratorBase::findOrTempAllocateVoxelPtr(
+    const VoxelIndex& global_voxel_idx, VoxelMap* temp_voxel_storage) const {
+  static thread_local Block<TsdfVoxel>::Ptr block = nullptr;
+  static thread_local BlockIndex last_block_idx;
+
+  BlockIndex block_idx =
+      getBlockIndexFromGlobalVoxelIndex(global_voxel_idx, voxels_per_side_inv_);
+  VoxelIndex local_voxel_idx =
+      getLocalFromGlobalVoxelIndex(global_voxel_idx, voxels_per_side_);
+
+  if (block_idx != last_block_idx) {
+    block = layer_->getBlockPtrByIndex(block_idx);
+    last_block_idx = block_idx;
+    if (block != nullptr) {
+      block->updated() = true;
+    }
+  }
+
+  // If no block at this location currently exists, we allocate a temporary
+  // voxel that will be merged into the map later
+  if (block == nullptr) {
+    return &((*temp_voxel_storage)[global_voxel_idx]);
+  } else {
+    return &(block->getVoxelByVoxelIndex(local_voxel_idx));
+  }
+}
+
+// NOT thread safe
+inline void TsdfIntegratorBase::updateLayerWithStoredVoxels(
+    const VoxelMap& temp_voxel_storage) {
+  BlockIndex last_block_idx;
+  Block<TsdfVoxel>::Ptr block = nullptr;
+  for (const std::pair<const VoxelIndex, TsdfVoxel>& temp_voxel :
+       temp_voxel_storage) {
+    BlockIndex block_idx = getBlockIndexFromGlobalVoxelIndex(
+        temp_voxel.first, voxels_per_side_inv_);
+    VoxelIndex local_voxel_idx =
+        getLocalFromGlobalVoxelIndex(temp_voxel.first, voxels_per_side_);
+
+    if ((block_idx != last_block_idx) || (block == nullptr)) {
+      block = layer_->allocateBlockPtrByIndex(block_idx);
+      block->updated() = true;
+    }
+
+    TsdfVoxel& base_voxel = block->getVoxelByVoxelIndex(local_voxel_idx);
+
+    const float new_weight = base_voxel.weight + temp_voxel.second.weight;
+
+    // it is possible that both voxels have weights very close to zero
+    if (new_weight < kFloatEpsilon) {
+      continue;
+    }
+
+    // color blending is expensive only do it close to the surface
+    if (std::abs(temp_voxel.second.distance) <
+        config_.default_truncation_distance) {
+      base_voxel.color = Color::blendTwoColors(
+          base_voxel.color, base_voxel.weight, temp_voxel.second.color,
+          temp_voxel.second.weight);
+    }
+
+    base_voxel.distance =
+        (base_voxel.distance * base_voxel.weight +
+         temp_voxel.second.distance * temp_voxel.second.weight) /
+        new_weight;
+
+    base_voxel.weight = std::min(config_.max_weight, new_weight);
+  }
+}
+
+// Updates tsdf_voxel. Thread safe.
+inline void TsdfIntegratorBase::updateTsdfVoxel(
+    const Point& origin, const Point& point_G, const Point& voxel_center,
+    const Color& color, const float weight, TsdfVoxel* tsdf_voxel) {
+  // Figure out whether the voxel is behind or in front of the surface.
+  // To do this, project the voxel_center onto the ray from origin to point G.
+  // Then check if the the magnitude of the vector is smaller or greater than
+  // the original distance...
+  Point v_voxel_origin = voxel_center - origin;
+  Point v_point_origin = point_G - origin;
+
+  FloatingPoint dist_G = v_point_origin.norm();
+  // projection of a (v_voxel_origin) onto b (v_point_origin)
+  FloatingPoint dist_G_V = v_voxel_origin.dot(v_point_origin) / dist_G;
+
+  float sdf = static_cast<float>(dist_G - dist_G_V);
+
+  float updated_weight = weight;
+  // Compute updated weight in case we use weight dropoff. It's easier here
+  // that in getVoxelWeight as here we have the actual SDF for the voxel
+  // already computed.
+  const FloatingPoint dropoff_epsilon = voxel_size_;
+  if (config_.use_weight_dropoff && sdf < -dropoff_epsilon) {
+    updated_weight = weight * (config_.default_truncation_distance + sdf) /
+                     (config_.default_truncation_distance - dropoff_epsilon);
+    updated_weight = std::max(updated_weight, 0.0f);
+  }
+
+  // Compute the updated weight in case we compensate for sparsity. By
+  // multiplicating the weight of occupied areas (|sdf| < truncation distance)
+  // by a factor, we prevent to easily fade out these areas with the free
+  // space parts of other rays which pass through the corresponding voxels.
+  // This can be useful for creating a TSDF map from sparse sensor data (e.g.
+  // visual features from a SLAM system). By default, this option is disabled.
+  if (config_.use_sparsity_compensation_factor) {
+    if (std::abs(sdf) < config_.default_truncation_distance) {
+      updated_weight *= config_.sparsity_compensation_factor;
+    }
+  }
+
+  // Grab and lock the mutex responsible for this voxel
+  std::lock_guard<std::mutex> lock(
+      mutexes_.get(getGridIndexFromPoint(point_G, voxel_size_inv_)));
+
+  const float new_weight = tsdf_voxel->weight + updated_weight;
+  const float new_sdf =
+      (sdf * updated_weight + tsdf_voxel->distance * tsdf_voxel->weight) /
+      new_weight;
+
+  // color blending is expensive only do it close to the surface
+  if (std::abs(sdf) < config_.default_truncation_distance) {
+    tsdf_voxel->color = Color::blendTwoColors(
+        tsdf_voxel->color, tsdf_voxel->weight, color, updated_weight);
+  }
+
+  tsdf_voxel->distance =
+      (new_sdf > 0.0) ? std::min(config_.default_truncation_distance, new_sdf)
+                      : std::max(-config_.default_truncation_distance, new_sdf);
+  tsdf_voxel->weight = std::min(config_.max_weight, new_weight);
+}
+
+// Thread safe.
+inline float TsdfIntegratorBase::computeDistance(
+    const Point& origin, const Point& point_G,
+    const Point& voxel_center) const {
+  Point v_voxel_origin = voxel_center - origin;
+  Point v_point_origin = point_G - origin;
+
+  FloatingPoint dist_G = v_point_origin.norm();
+  // projection of a (v_voxel_origin) onto b (v_point_origin)
+  FloatingPoint dist_G_V = v_voxel_origin.dot(v_point_origin) / dist_G;
+
+  float sdf = static_cast<float>(dist_G - dist_G_V);
+  return sdf;
+}
+
+// Thread safe.
+inline float TsdfIntegratorBase::getVoxelWeight(const Point& point_C) const {
+  if (config_.use_const_weight) {
+    return 1.0f;
+  }
+  FloatingPoint dist_z = std::abs(point_C.z());
+  if (dist_z > kEpsilon) {
+    return 1.0f / (dist_z * dist_z);
+  }
+  return 0.0f;
+}
+
+void SimpleTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
+                                               const Pointcloud& points_C,
+                                               const Colors& colors) {
+  std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
+
+  timing::Timer integrate_timer("integrate");
+
+  ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
+
+  std::vector<std::thread> integration_threads;
+  for (size_t i = 0; i < config_.integrator_threads; ++i) {
+    integration_threads.emplace_back(&SimpleTsdfIntegrator::integrateFunction,
+                                     this, T_G_C, points_C, colors,
+                                     &index_getter, &(temp_voxel_storage[i]));
+  }
+
+  for (std::thread& thread : integration_threads) {
+    thread.join();
+  }
+  integrate_timer.Stop();
+
+  timing::Timer insertion_timer("inserting_missed_voxels");
+  for (const VoxelMap& temp_voxels : temp_voxel_storage) {
+    updateLayerWithStoredVoxels(temp_voxels);
+  }
+  insertion_timer.Stop();
+}
+
+void SimpleTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
+                                             const Pointcloud& points_C,
+                                             const Colors& colors,
+                                             ThreadSafeIndex* index_getter,
+                                             VoxelMap* temp_voxel_storage) {
+  size_t point_idx;
+  while (index_getter->getNextIndex(&point_idx)) {
+    const Point& point_C = points_C[point_idx];
+    const Color& color = colors[point_idx];
+    bool is_clearing;
+    if (!isPointValid(point_C, &is_clearing)) {
+      continue;
+    }
+
+    const Point origin = T_G_C.getPosition();
+    const Point point_G = T_G_C * point_C;
+
+    RayCaster ray_caster(origin, point_G, is_clearing,
+                         config_.voxel_carving_enabled,
+                         config_.max_ray_length_m, voxel_size_inv_,
+                         config_.default_truncation_distance);
+
+    VoxelIndex global_voxel_idx;
+    while (ray_caster.nextRayIndex(&global_voxel_idx)) {
+      TsdfVoxel* voxel =
+          findOrTempAllocateVoxelPtr(global_voxel_idx, temp_voxel_storage);
+
+      const float weight = getVoxelWeight(point_C);
+      const Point voxel_center_G =
+          getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
+
+      updateTsdfVoxel(origin, point_G, voxel_center_G, color, weight, voxel);
+    }
+  }
+}
+
+void MergedTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
+                                               const Pointcloud& points_C,
+                                               const Colors& colors) {
+  timing::Timer integrate_timer("integrate");
+
+  // Pre-compute a list of unique voxels to end on.
+  // Create a hashmap: VOXEL INDEX -> index in original cloud.
+  BlockHashMapType<std::vector<size_t>>::type voxel_map;
+  // This is a hash map (same as above) to all the indices that need to be
+  // cleared.
+  BlockHashMapType<std::vector<size_t>>::type clear_map;
+
+  ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
+
+  bundleRays(T_G_C, points_C, colors, &index_getter, &voxel_map, &clear_map);
+
+  integrateRays(T_G_C, points_C, colors, config_.enable_anti_grazing, false,
+                voxel_map, clear_map);
+
+  timing::Timer clear_timer("integrate/clear");
+
+  integrateRays(T_G_C, points_C, colors, config_.enable_anti_grazing, true,
+                voxel_map, clear_map);
+
+  clear_timer.Stop();
+
+  integrate_timer.Stop();
+}
+
+inline void MergedTsdfIntegrator::bundleRays(
+    const Transformation& T_G_C, const Pointcloud& points_C,
+    const Colors& colors, ThreadSafeIndex* index_getter,
+    BlockHashMapType<std::vector<size_t>>::type* voxel_map,
+    BlockHashMapType<std::vector<size_t>>::type* clear_map) {
+  size_t point_idx;
+  while (index_getter->getNextIndex(&point_idx)) {
+    const Point& point_C = points_C[point_idx];
+    bool is_clearing;
+    if (!isPointValid(point_C, &is_clearing)) {
+      continue;
+    }
+
+    const Point point_G = T_G_C * point_C;
+
+    VoxelIndex voxel_index = getGridIndexFromPoint(point_G, voxel_size_inv_);
+
+    if (is_clearing) {
+      (*clear_map)[voxel_index].push_back(point_idx);
+    } else {
+      (*voxel_map)[voxel_index].push_back(point_idx);
+    }
+  }
+
+  LOG(INFO) << "Went from " << points_C.size() << " points to "
+            << voxel_map->size() << " raycasts  and " << clear_map->size()
+            << " clear rays.";
+}
+
+void MergedTsdfIntegrator::integrateVoxel(
+    const Transformation& T_G_C, const Pointcloud& points_C,
+    const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
+    const std::pair<AnyIndex, std::vector<size_t>>& kv,
+    const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
+    VoxelMap* temp_voxel_storage) {
+  if (kv.second.empty()) {
+    return;
+  }
+
+  const Point& origin = T_G_C.getPosition();
+  Color merged_color;
+  Point merged_point_C = Point::Zero();
+  FloatingPoint merged_weight = 0.0;
+
+  for (const size_t pt_idx : kv.second) {
+    const Point& point_C = points_C[pt_idx];
+    const Color& color = colors[pt_idx];
+
+    float point_weight = getVoxelWeight(point_C);
+    merged_point_C = (merged_point_C * merged_weight + point_C * point_weight) /
+                     (merged_weight + point_weight);
+    merged_color =
+        Color::blendTwoColors(merged_color, merged_weight, color, point_weight);
+    merged_weight += point_weight;
+
+    // only take first point when clearing
+    if (clearing_ray) {
+      break;
+    }
+  }
+
+  const Point merged_point_G = T_G_C * merged_point_C;
+
+  RayCaster ray_caster(origin, merged_point_G, clearing_ray,
+                       config_.voxel_carving_enabled, config_.max_ray_length_m,
+                       voxel_size_inv_, config_.default_truncation_distance,
+                       false);
+
+  BlockIndex last_block_idx = BlockIndex::Zero();
+  Block<TsdfVoxel>::Ptr block;
+
+  VoxelIndex global_voxel_idx;
+  while (ray_caster.nextRayIndex(&global_voxel_idx)) {
+    if (enable_anti_grazing) {
+      // Check if this one is already the the block hash map for this
+      // insertion. Skip this to avoid grazing.
+      if ((clearing_ray || global_voxel_idx != kv.first) &&
+          voxel_map.find(global_voxel_idx) != voxel_map.end()) {
+        continue;
+      }
+    }
+
+    TsdfVoxel* voxel =
+        findOrTempAllocateVoxelPtr(global_voxel_idx, temp_voxel_storage);
+    const Point voxel_center_G =
+        getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
+
+    updateTsdfVoxel(origin, merged_point_G, voxel_center_G, merged_color,
+                    merged_weight, voxel);
+  }
+}
+
+void MergedTsdfIntegrator::integrateVoxels(
+    const Transformation& T_G_C, const Pointcloud& points_C,
+    const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
+    const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
+    const BlockHashMapType<std::vector<size_t>>::type& clear_map, size_t tid,
+    VoxelMap* temp_voxel_storage) {
+  BlockHashMapType<std::vector<size_t>>::type::const_iterator it;
+  size_t map_size;
+  if (clearing_ray) {
+    it = clear_map.begin();
+    map_size = clear_map.size();
+  } else {
+    it = voxel_map.begin();
+    map_size = voxel_map.size();
+  }
+
+  for (size_t i = 0; i < map_size; ++i) {
+    if (((i + tid + 1) % config_.integrator_threads) == 0) {
+      integrateVoxel(T_G_C, points_C, colors, enable_anti_grazing, clearing_ray,
+                     *it, voxel_map, temp_voxel_storage);
+    }
+    ++it;
+  }
+}
+
+void MergedTsdfIntegrator::integrateRays(
+    const Transformation& T_G_C, const Pointcloud& points_C,
+    const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
+    const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
+    const BlockHashMapType<std::vector<size_t>>::type& clear_map) {
+  const Point& origin = T_G_C.getPosition();
+
+  std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
+
+  // if only 1 thread just do function call, otherwise spawn threads
+  if (config_.integrator_threads == 1) {
+    integrateVoxels(T_G_C, points_C, colors, enable_anti_grazing, clearing_ray,
+                    voxel_map, clear_map, 0, &(temp_voxel_storage[0]));
+  } else {
+    std::vector<std::thread> integration_threads;
+    for (size_t i = 0; i < config_.integrator_threads; ++i) {
+      integration_threads.emplace_back(
+          &MergedTsdfIntegrator::integrateVoxels, this, T_G_C, points_C, colors,
+          enable_anti_grazing, clearing_ray, voxel_map, clear_map, i,
+          &(temp_voxel_storage[i]));
+    }
+
+    for (std::thread& thread : integration_threads) {
+      thread.join();
+    }
+  }
+
+  timing::Timer insertion_timer("inserting_missed_voxels");
+  for (const VoxelMap& temp_voxels : temp_voxel_storage) {
+    updateLayerWithStoredVoxels(temp_voxels);
+  }
+  insertion_timer.Stop();
+}
+
+void FastTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
+                                           const Pointcloud& points_C,
+                                           const Colors& colors,
+                                           ThreadSafeIndex* index_getter,
+                                           VoxelMap* temp_voxel_storage) {
+  size_t point_idx;
+  while (index_getter->getNextIndex(&point_idx)) {
+    const Point& point_C = points_C[point_idx];
+    const Color& color = colors[point_idx];
+    bool is_clearing;
+    if (!isPointValid(point_C, &is_clearing)) {
+      continue;
+    }
+
+    const Point origin = T_G_C.getPosition();
+    const Point point_G = T_G_C * point_C;
+    // immediately check if the voxel the point is in has already been ray
+    // traced (saves time setting up ray tracer for already used points)
+    AnyIndex global_voxel_idx =
+        getGridIndexFromPoint(point_G, voxel_sub_sample_ * voxel_size_inv_);
+    if (!approx_start_tester_.replaceHash(global_voxel_idx)) {
+      continue;
+    }
+
+    RayCaster ray_caster(origin, point_G, is_clearing,
+                         config_.voxel_carving_enabled,
+                         config_.max_ray_length_m, voxel_size_inv_,
+                         config_.default_truncation_distance, false);
+
+    BlockIndex last_block_idx = BlockIndex::Zero();
+    Block<TsdfVoxel>::Ptr block;
+
+    size_t consecutive_ray_collisions = 0;
+
+    while (ray_caster.nextRayIndex(&global_voxel_idx)) {
+      // if all a ray is doing is follow in the path of another, stop casting
+      if (!approx_ray_tester_.replaceHash(global_voxel_idx)) {
+        ++consecutive_ray_collisions;
+      } else {
+        consecutive_ray_collisions = 0;
+      }
+      if (consecutive_ray_collisions > max_consecutive_ray_collisions_) {
+        break;
+      }
+
+      TsdfVoxel* voxel =
+          findOrTempAllocateVoxelPtr(global_voxel_idx, temp_voxel_storage);
+
+      const float weight = getVoxelWeight(point_C);
+      const Point voxel_center_G =
+          getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
+
+      updateTsdfVoxel(origin, point_G, voxel_center_G, color, weight, voxel);
+    }
+  }
+}
+
+void FastTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
+                                             const Pointcloud& points_C,
+                                             const Colors& colors) {
+  std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
+
+  timing::Timer integrate_timer("integrate");
+
+  approx_ray_tester_.resetApproxSet();
+  approx_start_tester_.resetApproxSet();
+
+  ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
+
+  std::vector<std::thread> integration_threads;
+  for (size_t i = 0; i < config_.integrator_threads; ++i) {
+    integration_threads.emplace_back(&FastTsdfIntegrator::integrateFunction,
+                                     this, T_G_C, points_C, colors,
+                                     &index_getter, &(temp_voxel_storage[i]));
+  }
+
+  for (std::thread& thread : integration_threads) {
+    thread.join();
+  }
+
+  integrate_timer.Stop();
+
+  timing::Timer insertion_timer("inserting_missed_voxels");
+  for (const VoxelMap& temp_voxels : temp_voxel_storage) {
+    updateLayerWithStoredVoxels(temp_voxels);
+  }
+  insertion_timer.Stop();
+}
+
+}  // namespace voxblox

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -162,7 +162,7 @@ inline void TsdfIntegratorBase::updateTsdfVoxel(
   // it is possible to have weights very close to zero, due to the limited
   // precision of floating points dividing by this small value can cause nans
   if (new_weight < kFloatEpsilon) {
-    continue;
+    return;
   }
 
   const float new_sdf =

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -98,7 +98,9 @@ inline void TsdfIntegratorBase::updateLayerWithStoredVoxels(
 
     const float new_weight = base_voxel.weight + temp_voxel.second.weight;
 
-    // it is possible that both voxels have weights very close to zero
+    // it is possible that both voxels have weights very close to zero, due to
+    // the limited precision of floating points dividing by this small value can
+    // cause nans
     if (new_weight < kFloatEpsilon) {
       continue;
     }
@@ -156,6 +158,13 @@ inline void TsdfIntegratorBase::updateTsdfVoxel(
       mutexes_.get(getGridIndexFromPoint(point_G, voxel_size_inv_)));
 
   const float new_weight = tsdf_voxel->weight + updated_weight;
+
+  // it is possible to have weights very close to zero, due to the limited
+  // precision of floating points dividing by this small value can cause nans
+  if (new_weight < kFloatEpsilon) {
+    continue;
+  }
+
   const float new_sdf =
       (sdf * updated_weight + tsdf_voxel->distance * tsdf_voxel->weight) /
       new_weight;

--- a/voxblox/src/simulation/simulation_world.cc
+++ b/voxblox/src/simulation/simulation_world.cc
@@ -56,9 +56,9 @@ void SimulationWorld::getPointcloudFromViewpoint(
   // Calculate transformation between nominal camera view direction and our
   // view direction. Nominal view is positive x direction.
   Point nominal_view_direction(1.0, 0.0, 0.0);
-  // TODO(helenol): fix type for floats.
-  Eigen::Quaterniond ray_rotation = Eigen::Quaterniond::FromTwoVectors(
-      nominal_view_direction, view_direction);
+  Eigen::Quaternion<FloatingPoint> ray_rotation =
+      Eigen::Quaternion<FloatingPoint>::FromTwoVectors(nominal_view_direction,
+                                                       view_direction);
 
   // Now actually iterate over all pixels.
   for (int u = -camera_res.x() / 2; u < camera_res.x() / 2; ++u) {

--- a/voxblox/src/utils/timing.cc
+++ b/voxblox/src/utils/timing.cc
@@ -172,7 +172,6 @@ std::string Timing::SecondsToTimeString(double seconds) {
 }
 
 void Timing::Print(std::ostream& out) {
-  std::lock_guard<std::mutex> lock(Instance().mutex_);
   map_t& tagMap = Instance().tagMap_;
 
   if (tagMap.empty()) {

--- a/voxblox/test/test_approx_hash_array.cc
+++ b/voxblox/test/test_approx_hash_array.cc
@@ -4,7 +4,7 @@
 #include <random>
 
 #include "voxblox/core/common.h"
-#include "voxblox/cutils/approx_hash_array.h"
+#include "voxblox/utils/approx_hash_array.h"
 
 using namespace voxblox;  // NOLINT
 

--- a/voxblox/test/test_approx_hash_array.cc
+++ b/voxblox/test/test_approx_hash_array.cc
@@ -1,8 +1,7 @@
-#include <eigen-checks/entrypoint.h>
-#include <eigen-checks/gtest.h>
 #include <gtest/gtest.h>
 #include <random>
 
+#include "voxblox/core/block_hash.h"
 #include "voxblox/core/common.h"
 #include "voxblox/utils/approx_hash_array.h"
 
@@ -27,7 +26,7 @@ TEST_F(ApproxHashArrayTest, InsertValues) {
   }
 }
 
-TEST_F(ApproxHashArray, ArrayRandomWriteRead) {
+TEST_F(ApproxHashArrayTest, ArrayRandomWriteRead) {
   // storing 65536 size_ts
   ApproxHashArray<16, size_t> approx_hash_array;
 
@@ -59,7 +58,7 @@ TEST_F(ApproxHashArray, ArrayRandomWriteRead) {
   EXPECT_GT(recovered, 950);
 }
 
-TEST_F(ApproxHashArray, SetRandomWriteRead) {
+TEST_F(ApproxHashArrayTest, SetRandomWriteRead) {
   // storing 65536 size_ts
   ApproxHashSet<16, 10> approx_hash_set;
 
@@ -73,34 +72,35 @@ TEST_F(ApproxHashArray, SetRandomWriteRead) {
 
   // test insert and clearing
   for (size_t i = 0; i < 50; ++i) {
-    approx_hash_array.resetApproxSet()
+    approx_hash_set.resetApproxSet();
 
-        // insert their values
-        int inserted;
+    // insert their values
+    int inserted = 0;
     for (const AnyIndex& rand_index : rand_indexes) {
-      if (approx_hash_array.replaceHash(rand_index)) {
+      if (approx_hash_set.replaceHash(rand_index)) {
         ++inserted;
       }
     }
     // require at least a 95% success rate
-    EXPECT_GT(recovered, 950);
+    EXPECT_GT(inserted, 950);
 
     // insert a second time
-    int inserted = 0;
+    inserted = 0;
     for (const AnyIndex& rand_index : rand_indexes) {
-      if (approx_hash_array.replaceHash(rand_index)) {
+      if (approx_hash_set.replaceHash(rand_index)) {
         ++inserted;
       }
     }
     // require at least a 95% failure rate
-    EXPECT_LT(recovered, 50);
+    EXPECT_LT(inserted, 50);
   }
 
   // find out how many we can recover
   int recovered = 0;
   for (const AnyIndex& rand_index : rand_indexes) {
+    AnyIndexHash hasher;
     size_t hash = hasher(rand_index);
-    if (approx_hash_array.isHashCurrentlyPresent(hash)) {
+    if (approx_hash_set.isHashCurrentlyPresent(hash)) {
       ++recovered;
     }
   }

--- a/voxblox/test/test_approx_hash_array.cc
+++ b/voxblox/test/test_approx_hash_array.cc
@@ -71,7 +71,7 @@ TEST_F(ApproxHashArrayTest, SetRandomWriteRead) {
   }
 
   // test insert and clearing
-  for (size_t i = 0; i < 50; ++i) {
+  for (size_t i = 0; i < 50u; ++i) {
     approx_hash_set.resetApproxSet();
 
     // insert their values

--- a/voxblox/test/test_approx_hash_array.cc
+++ b/voxblox/test/test_approx_hash_array.cc
@@ -1,0 +1,119 @@
+#include <eigen-checks/entrypoint.h>
+#include <eigen-checks/gtest.h>
+#include <gtest/gtest.h>
+#include <random>
+
+#include "voxblox/core/common.h"
+#include "voxblox/cutils/approx_hash_array.h"
+
+using namespace voxblox;  // NOLINT
+
+class ApproxHashArrayTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {}
+};
+
+TEST_F(ApproxHashArrayTest, InsertValues) {
+  // storing 256 ints
+  ApproxHashArray<8, int> approx_hash_array;
+
+  // write 512 values, first 256 should be overwritten
+  for (int i = 0; i < 512; ++i) {
+    approx_hash_array.get(i) = i;
+  }
+
+  for (int i = 0; i < 256; ++i) {
+    EXPECT_EQ(approx_hash_array.get(i), i + 256);
+  }
+}
+
+TEST_F(ApproxHashArray, ArrayRandomWriteRead) {
+  // storing 65536 size_ts
+  ApproxHashArray<16, size_t> approx_hash_array;
+
+  // generate 1000 random elements
+  std::vector<AnyIndex> rand_indexes;
+  std::mt19937 gen(1);
+  std::uniform_int_distribution<> dis(1, 1000000);
+  for (int i = 0; i < 1000; ++i) {
+    rand_indexes.push_back(AnyIndex(dis(gen), dis(gen), dis(gen)));
+  }
+
+  // insert their hash
+  AnyIndexHash hasher;
+  for (const AnyIndex& rand_index : rand_indexes) {
+    size_t hash = hasher(rand_index);
+    approx_hash_array.get(rand_index) = hash;
+  }
+
+  // find out how many we can recover
+  int recovered = 0;
+  for (const AnyIndex& rand_index : rand_indexes) {
+    size_t hash = hasher(rand_index);
+    if (approx_hash_array.get(rand_index) == hash) {
+      ++recovered;
+    }
+  }
+
+  // require at least a 95% success rate
+  EXPECT_GT(recovered, 950);
+}
+
+TEST_F(ApproxHashArray, SetRandomWriteRead) {
+  // storing 65536 size_ts
+  ApproxHashSet<16, 10> approx_hash_set;
+
+  // generate 1000 random elements
+  std::vector<AnyIndex> rand_indexes;
+  std::mt19937 gen(1);
+  std::uniform_int_distribution<> dis(1, 1000000);
+  for (int i = 0; i < 1000; ++i) {
+    rand_indexes.push_back(AnyIndex(dis(gen), dis(gen), dis(gen)));
+  }
+
+  // test insert and clearing
+  for (size_t i = 0; i < 50; ++i) {
+    approx_hash_array.resetApproxSet()
+
+        // insert their values
+        int inserted;
+    for (const AnyIndex& rand_index : rand_indexes) {
+      if (approx_hash_array.replaceHash(rand_index)) {
+        ++inserted;
+      }
+    }
+    // require at least a 95% success rate
+    EXPECT_GT(recovered, 950);
+
+    // insert a second time
+    int inserted = 0;
+    for (const AnyIndex& rand_index : rand_indexes) {
+      if (approx_hash_array.replaceHash(rand_index)) {
+        ++inserted;
+      }
+    }
+    // require at least a 95% failure rate
+    EXPECT_LT(recovered, 50);
+  }
+
+  // find out how many we can recover
+  int recovered = 0;
+  for (const AnyIndex& rand_index : rand_indexes) {
+    size_t hash = hasher(rand_index);
+    if (approx_hash_array.isHashCurrentlyPresent(hash)) {
+      ++recovered;
+    }
+  }
+
+  // require at least a 95% success rate
+  EXPECT_GT(recovered, 950);
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  google::InitGoogleLogging(argv[0]);
+
+  int result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -8,7 +8,7 @@
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
-    <param name="tsdf_voxel_size" value="0.02" />
+    <param name="tsdf_voxel_size" value="0.05" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="normals" />
@@ -19,7 +19,8 @@
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
-    <!--<param name="truncation_distance" value="0.5" /> -->
+    <param name="mesh_min_weight" value="0.00000001"/>
+    <param name="truncation_distance" value="0.1" />
     <param name="verbose" value="true" />
     <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
     <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -15,7 +15,7 @@
     <param name="use_tf_transforms" value="false" />
     <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="min_time_between_msgs_sec" value="0.2" />
-    <param name="method" value="simple" />
+    <param name="method" value="fast" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -4,16 +4,16 @@
   <arg name="voxel_size" default="0.10"/>
   <arg name="generate_esdf" default="false" />
 
-  <node name="player" pkg="rosbag" type="play" output="screen" args=" -s 10 -u 30 -r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
+  <node name="player" pkg="rosbag" type="play" output="screen" args=" -d 6 -s 10 -u 30 -r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
-    <param name="tsdf_voxel_size" value="0.05" />
+    <param name="tsdf_voxel_size" value="0.03" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
-    <param name="color_mode" value="normals" />
+    <param name="color_mode" value="color" />
     <param name="use_tf_transforms" value="false" />
-    <param name="update_mesh_every_n_sec" value="1.0" />
+    <param name="update_mesh_every_n_sec" value="0.3" />
     <param name="min_time_between_msgs_sec" value="0.2" />
     <param name="method" value="fast" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -1,25 +1,24 @@
 <launch>
   <arg name="play_bag" default="true" />
   <arg name="bag_file" default="/home/z/Datasets/cow_and_lady/data.bag"/>
-  <arg name="voxel_size" default="0.10"/>
+  <arg name="voxel_size" default="0.05"/>
   <arg name="generate_esdf" default="false" />
 
-  <node name="player" pkg="rosbag" type="play" output="screen" args=" -d 6 -s 10 -u 30 -r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
+  <node name="player" pkg="rosbag" type="play" output="screen" args="-r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
-    <param name="tsdf_voxel_size" value="0.03" />
+    <param name="tsdf_voxel_size" value="$(arg voxel_size)" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="color" />
     <param name="use_tf_transforms" value="false" />
-    <param name="update_mesh_every_n_sec" value="0.3" />
+    <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="min_time_between_msgs_sec" value="0.2" />
-    <param name="method" value="fast" />
+    <param name="method" value="merged" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
-    <param name="mesh_min_weight" value="0.00000001"/>
     <param name="verbose" value="true" />
     <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
     <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -20,7 +20,7 @@
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
     <param name="mesh_min_weight" value="0.00000001"/>
-    <param name="truncation_distance" value="0.1" />
+    <param name="truncation_distance" value="0.05" />
     <param name="verbose" value="true" />
     <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
     <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -8,7 +8,7 @@
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
-    <param name="tsdf_voxel_size" value="0.05" />
+    <param name="tsdf_voxel_size" value="0.02" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="normals" />

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -21,7 +21,7 @@
     <param name="use_tf_transforms" value="true" />
     <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="min_time_between_msgs_sec" value="0.0" />
-    <param name="method" value="fast" />
+    <param name="method" value="merged" />
     <param name="generate_esdf" value="false" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -11,7 +11,7 @@
     <param name="tsdf_voxel_size" value="0.02" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
-    <param name="color_mode" value="color" />
+    <param name="color_mode" value="normals" />
     <param name="use_tf_transforms" value="false" />
     <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="min_time_between_msgs_sec" value="0.2" />

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="play_bag" default="true" />
-  <arg name="bag_file" default="/home/z/Datasets/cow_and_lady/short.bag"/>
+  <arg name="bag_file" default="/home/z/Datasets/cow_and_lady/data.bag"/>
   <arg name="voxel_size" default="0.10"/>
   <arg name="generate_esdf" default="false" />
 

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -4,32 +4,26 @@
   <arg name="voxel_size" default="0.10"/>
   <arg name="generate_esdf" default="false" />
 
-  <node name="player" pkg="rosbag" type="play" output="screen" args=" --clock /home/z/Datasets/good.bag">
-    <remap from="/lidar_1/points_out" to="/pointcloud"/>
-    <remap from="/lidar_2/points_out" to="/pointcloud"/>
-    <remap from="/lidar_3/points_out" to="/pointcloud"/>
-    <remap from="/lidar_4/points_out" to="/pointcloud"/>
-    <remap from="/lidar_5/points_out" to="/pointcloud"/>
-  </node>
+  <node name="player" pkg="rosbag" type="play" output="screen" args=" -s 10 -u 30 -r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
-    <!--<remap from="pointcloud" to="/camera/depth_registered/points"/>-->
-    <param name="tsdf_voxel_size" value="0.2" />
+    <remap from="pointcloud" to="/camera/depth_registered/points"/>
+    <param name="tsdf_voxel_size" value="0.05" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="normals" />
-    <param name="use_tf_transforms" value="true" />
+    <param name="use_tf_transforms" value="false" />
     <param name="update_mesh_every_n_sec" value="1.0" />
-    <param name="min_time_between_msgs_sec" value="0.0" />
+    <param name="min_time_between_msgs_sec" value="0.2" />
     <param name="method" value="merged" />
-    <param name="generate_esdf" value="false" />
+    <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
     <param name="mesh_min_weight" value="0.00000001"/>
-    <param name="truncation_distance" value="0.5" />
+    <param name="truncation_distance" value="0.2" />
     <param name="verbose" value="true" />
-    <param name="min_ray_length_m" value="2.0"/>
-    <param name="max_ray_length_m" value="20.0"/>
+    <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
+    <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>
     <param name="mesh_filename" value="$(find voxblox_ros)/mesh_results/$(anon cow).ply" />
   </node>
 

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -8,14 +8,14 @@
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
-    <param name="tsdf_voxel_size" value="0.05" />
+    <param name="tsdf_voxel_size" value="0.02" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="normals" />
     <param name="use_tf_transforms" value="false" />
     <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="min_time_between_msgs_sec" value="0.2" />
-    <param name="method" value="merged" />
+    <param name="method" value="fast" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -14,8 +14,8 @@
     <param name="color_mode" value="color" />
     <param name="use_tf_transforms" value="false" />
     <param name="update_mesh_every_n_sec" value="1.0" />
-    <param name="min_time_between_msgs_sec" value="0.2" />
-    <param name="method" value="merged" />
+    <param name="min_time_between_msgs_sec" value="0.0" />
+    <param name="method" value="fast" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -4,26 +4,32 @@
   <arg name="voxel_size" default="0.10"/>
   <arg name="generate_esdf" default="false" />
 
-  <node name="player" pkg="rosbag" type="play" output="screen" args=" -s 10 -u 30 -r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
+  <node name="player" pkg="rosbag" type="play" output="screen" args=" --clock /home/z/Datasets/good.bag">
+    <remap from="/lidar_1/points_out" to="/pointcloud"/>
+    <remap from="/lidar_2/points_out" to="/pointcloud"/>
+    <remap from="/lidar_3/points_out" to="/pointcloud"/>
+    <remap from="/lidar_4/points_out" to="/pointcloud"/>
+    <remap from="/lidar_5/points_out" to="/pointcloud"/>
+  </node>
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
-    <remap from="pointcloud" to="/camera/depth_registered/points"/>
+    <!--<remap from="pointcloud" to="/camera/depth_registered/points"/>-->
     <param name="tsdf_voxel_size" value="0.2" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="normals" />
-    <param name="use_tf_transforms" value="false" />
+    <param name="use_tf_transforms" value="true" />
     <param name="update_mesh_every_n_sec" value="1.0" />
-    <param name="min_time_between_msgs_sec" value="0.2" />
+    <param name="min_time_between_msgs_sec" value="0.0" />
     <param name="method" value="fast" />
-    <param name="generate_esdf" value="$(arg generate_esdf)" />
+    <param name="generate_esdf" value="false" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
     <param name="mesh_min_weight" value="0.00000001"/>
     <param name="truncation_distance" value="0.5" />
     <param name="verbose" value="true" />
-    <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
-    <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>
+    <param name="min_ray_length_m" value="2.0"/>
+    <param name="max_ray_length_m" value="20.0"/>
     <param name="mesh_filename" value="$(find voxblox_ros)/mesh_results/$(anon cow).ply" />
   </node>
 

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -8,14 +8,14 @@
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
-    <param name="tsdf_voxel_size" value="0.1" />
+    <param name="tsdf_voxel_size" value="0.02" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="color" />
     <param name="use_tf_transforms" value="false" />
     <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="min_time_between_msgs_sec" value="0.0" />
-    <param name="method" value="merged" />
+    <param name="method" value="fast" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -8,19 +8,19 @@
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
-    <param name="tsdf_voxel_size" value="0.02" />
+    <param name="tsdf_voxel_size" value="0.2" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="normals" />
     <param name="use_tf_transforms" value="false" />
     <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="min_time_between_msgs_sec" value="0.2" />
-    <param name="method" value="fast" />
+    <param name="method" value="simple" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
     <param name="mesh_min_weight" value="0.00000001"/>
-    <param name="truncation_distance" value="0.05" />
+    <param name="truncation_distance" value="0.5" />
     <param name="verbose" value="true" />
     <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
     <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -8,7 +8,7 @@
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
-    <param name="tsdf_voxel_size" value="0.02" />
+    <param name="tsdf_voxel_size" value="0.05" />
     <param name="tsdf_voxels_per_side" value="16" />
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="normals" />
@@ -20,7 +20,6 @@
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
     <param name="mesh_min_weight" value="0.00000001"/>
-    <param name="truncation_distance" value="0.2" />
     <param name="verbose" value="true" />
     <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
     <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -4,7 +4,7 @@
   <arg name="voxel_size" default="0.10"/>
   <arg name="generate_esdf" default="false" />
 
-  <node name="player" pkg="rosbag" type="play" output="screen" args=" -r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
+  <node name="player" pkg="rosbag" type="play" output="screen" args=" -s 10 -u 30 -r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
@@ -14,7 +14,7 @@
     <param name="color_mode" value="color" />
     <param name="use_tf_transforms" value="false" />
     <param name="update_mesh_every_n_sec" value="1.0" />
-    <param name="min_time_between_msgs_sec" value="0.0" />
+    <param name="min_time_between_msgs_sec" value="0.2" />
     <param name="method" value="fast" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />

--- a/voxblox_ros/src/simulation_eval.cc
+++ b/voxblox_ros/src/simulation_eval.cc
@@ -474,7 +474,11 @@ void SimulationServer::visualize() {
     MeshLayer::Ptr mesh(new MeshLayer(tsdf_gt_->block_size()));
     MeshIntegrator<TsdfVoxel> mesh_integrator(mesh_config, tsdf_gt_.get(),
                                               mesh.get());
-    mesh_integrator.generateWholeMesh();
+
+    constexpr bool only_mesh_updated_blocks = false;
+    constexpr bool clear_updated_flag = true;
+    mesh_integrator.generateMesh(only_mesh_updated_blocks, clear_updated_flag);
+
     visualization_msgs::MarkerArray marker_array;
     marker_array.markers.resize(1);
     ColorMode color_mode = ColorMode::kNormals;
@@ -486,7 +490,8 @@ void SimulationServer::visualize() {
     MeshLayer::Ptr mesh_test(new MeshLayer(tsdf_test_->block_size()));
     MeshIntegrator<TsdfVoxel> mesh_integrator_test(
         mesh_config, tsdf_test_.get(), mesh_test.get());
-    mesh_integrator_test.generateWholeMesh();
+    mesh_integrator_test.generateMesh(only_mesh_updated_blocks,
+                                      clear_updated_flag);
     marker_array.markers.clear();
     marker_array.markers.resize(1);
     fillMarkerWithMesh(mesh_test, color_mode, &marker_array.markers[0]);

--- a/voxblox_ros/src/simulation_eval.cc
+++ b/voxblox_ros/src/simulation_eval.cc
@@ -1,15 +1,15 @@
 #include <ros/ros.h>
 
-#include <voxblox/simulation/simulation_world.h>
-#include <voxblox/mesh/mesh_integrator.h>
 #include <voxblox/integrator/esdf_integrator.h>
-#include <voxblox/integrator/tsdf_integrator.h>
-#include <voxblox/integrator/occupancy_integrator.h>
 #include <voxblox/integrator/esdf_occ_integrator.h>
+#include <voxblox/integrator/occupancy_integrator.h>
+#include <voxblox/integrator/tsdf_integrator.h>
+#include <voxblox/mesh/mesh_integrator.h>
+#include <voxblox/simulation/simulation_world.h>
 
-#include "voxblox_ros/ptcloud_vis.h"
-#include "voxblox_ros/mesh_vis.h"
 #include "voxblox_ros/conversions.h"
+#include "voxblox_ros/mesh_vis.h"
+#include "voxblox_ros/ptcloud_vis.h"
 
 namespace voxblox {
 
@@ -303,9 +303,9 @@ void SimulationServer::generateSDF() {
                                       fov_h_rad, max_dist, &ptcloud, &colors);
 
     // Get T_G_C from ray origin and ray direction.
-    Transformation T_G_C(
-        view_origin, Eigen::Quaterniond::FromTwoVectors(Point(0.0, 0.0, 1.0),
-                                                        view_direction));
+    Transformation T_G_C(view_origin,
+                         Eigen::Quaternion<FloatingPoint>::FromTwoVectors(
+                             Point(0.0, 0.0, 1.0), view_direction));
 
     // Transform back into camera frame.
     Pointcloud ptcloud_C;
@@ -472,7 +472,8 @@ void SimulationServer::visualize() {
     // Generate TSDF GT mesh.
     MeshIntegrator<TsdfVoxel>::Config mesh_config;
     MeshLayer::Ptr mesh(new MeshLayer(tsdf_gt_->block_size()));
-    MeshIntegrator<TsdfVoxel> mesh_integrator(mesh_config, tsdf_gt_.get(), mesh.get());
+    MeshIntegrator<TsdfVoxel> mesh_integrator(mesh_config, tsdf_gt_.get(),
+                                              mesh.get());
     mesh_integrator.generateWholeMesh();
     visualization_msgs::MarkerArray marker_array;
     marker_array.markers.resize(1);
@@ -483,8 +484,8 @@ void SimulationServer::visualize() {
 
     // Also generate test mesh
     MeshLayer::Ptr mesh_test(new MeshLayer(tsdf_test_->block_size()));
-    MeshIntegrator<TsdfVoxel> mesh_integrator_test(mesh_config, tsdf_test_.get(),
-                                        mesh_test.get());
+    MeshIntegrator<TsdfVoxel> mesh_integrator_test(
+        mesh_config, tsdf_test_.get(), mesh_test.get());
     mesh_integrator_test.generateWholeMesh();
     marker_array.markers.clear();
     marker_array.markers.resize(1);

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -78,6 +78,12 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
                     integrator_config.use_const_weight);
   nh_private_.param("allow_clear", integrator_config.allow_clear,
                     integrator_config.allow_clear);
+  nh_private_.param("start_voxel_subsampling_factor",
+                    integrator_config.start_voxel_subsampling_factor,
+                    integrator_config.start_voxel_subsampling_factor);
+  nh_private_.param("max_consecutive_ray_collisions",
+                    integrator_config.max_consecutive_ray_collisions,
+                    integrator_config.max_consecutive_ray_collisions);
   integrator_config.default_truncation_distance =
       static_cast<float>(truncation_distance);
   integrator_config.max_weight = static_cast<float>(max_weight);

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -281,8 +281,9 @@ void TsdfServer::updateMesh() {
   }
 
   timing::Timer generate_mesh_timer("mesh/update");
-  const bool clear_updated_flag = true;
-  mesh_integrator_->generateMeshForUpdatedBlocks(clear_updated_flag);
+  constexpr bool only_mesh_updated_blocks = true;
+  constexpr bool clear_updated_flag = true;
+  mesh_integrator_->generateMesh(only_mesh_updated_blocks, clear_updated_flag);
   generate_mesh_timer.Stop();
 
   // TODO(helenol): also think about how to update markers incrementally?
@@ -299,10 +300,15 @@ bool TsdfServer::generateMesh() {
   timing::Timer generate_mesh_timer("mesh/generate");
   const bool clear_mesh = true;
   if (clear_mesh) {
-    mesh_integrator_->generateWholeMesh();
+    constexpr bool only_mesh_updated_blocks = false;
+    constexpr bool clear_updated_flag = true;
+    mesh_integrator_->generateMesh(only_mesh_updated_blocks,
+                                   clear_updated_flag);
   } else {
-    const bool clear_updated_flag = true;
-    mesh_integrator_->generateMeshForUpdatedBlocks(clear_updated_flag);
+    constexpr bool only_mesh_updated_blocks = true;
+    constexpr bool clear_updated_flag = true;
+    mesh_integrator_->generateMesh(only_mesh_updated_blocks,
+                                   clear_updated_flag);
   }
   generate_mesh_timer.Stop();
 

--- a/voxblox_ros/src/voxblox_eval.cc
+++ b/voxblox_ros/src/voxblox_eval.cc
@@ -1,4 +1,3 @@
-#include <deque>
 #include <minkindr_conversions/kindr_msg.h>
 #include <minkindr_conversions/kindr_tf.h>
 #include <minkindr_conversions/kindr_xml.h>
@@ -14,6 +13,7 @@
 #include <std_srvs/Empty.h>
 #include <tf/transform_listener.h>
 #include <visualization_msgs/MarkerArray.h>
+#include <deque>
 
 #include <voxblox/core/esdf_map.h>
 #include <voxblox/core/occupancy_map.h>
@@ -64,7 +64,7 @@ class VoxbloxEvaluator {
   ros::Publisher gt_ptcloud_pub_;
 
   // Core data to compare.
-  std::shared_ptr<Layer<TsdfVoxel> > tsdf_layer_;
+  std::shared_ptr<Layer<TsdfVoxel>> tsdf_layer_;
   pcl::PointCloud<pcl::PointXYZRGB> gt_ptcloud_;
 
   // Interpolator to get the distance at the exact point in the GT.
@@ -124,7 +124,7 @@ VoxbloxEvaluator::VoxbloxEvaluator(const ros::NodeHandle& nh,
   if (visualize_) {
     mesh_pub_ =
         nh_private_.advertise<visualization_msgs::MarkerArray>("mesh", 1, true);
-    gt_ptcloud_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZRGB> >(
+    gt_ptcloud_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZRGB>>(
         "gt_ptcloud", 1, true);
 
     std::string color_mode("color");
@@ -198,8 +198,7 @@ void VoxbloxEvaluator::evaluate() {
           tsdf_layer_->getBlockPtrByCoordinates(point);
       if (block_ptr != nullptr) {
         TsdfVoxel& voxel = block_ptr->getVoxelByCoordinates(point);
-        voxel.color =
-            grayColorMap(std::fabs(distance) / truncation_distance);
+        voxel.color = grayColorMap(std::fabs(distance) / truncation_distance);
       }
     }
 
@@ -227,9 +226,12 @@ void VoxbloxEvaluator::visualize() {
   // Generate the mesh.
   MeshIntegrator<TsdfVoxel>::Config mesh_config;
   mesh_layer_.reset(new MeshLayer(tsdf_layer_->block_size()));
-  mesh_integrator_.reset(
-      new MeshIntegrator<TsdfVoxel>(mesh_config, tsdf_layer_.get(), mesh_layer_.get()));
-  mesh_integrator_->generateWholeMesh();
+  mesh_integrator_.reset(new MeshIntegrator<TsdfVoxel>(
+      mesh_config, tsdf_layer_.get(), mesh_layer_.get()));
+
+  constexpr bool only_mesh_updated_blocks = false;
+  constexpr bool clear_updated_flag = true;
+  mesh_integrator_->generateMesh(only_mesh_updated_blocks, clear_updated_flag);
 
   // Publish mesh.
   visualization_msgs::MarkerArray marker_array;

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -297,6 +297,12 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
                     integrator_config.use_const_weight);
   nh_private_.param("allow_clear", integrator_config.allow_clear,
                     integrator_config.allow_clear);
+  nh_private_.param("start_voxel_subsampling_factor",
+                    integrator_config.start_voxel_subsampling_factor,
+                    integrator_config.start_voxel_subsampling_factor);
+  nh_private_.param("max_consecutive_ray_collisions",
+                    integrator_config.max_consecutive_ray_collisions,
+                    integrator_config.max_consecutive_ray_collisions);
   integrator_config.default_truncation_distance =
       static_cast<float>(truncation_distance);
   integrator_config.max_weight = static_cast<float>(max_weight);

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -739,10 +739,15 @@ bool VoxbloxNode::generateMeshCallback(
   timing::Timer generate_mesh_timer("mesh/generate");
   const bool clear_mesh = true;
   if (clear_mesh) {
-    mesh_integrator_->generateWholeMesh();
+    constexpr bool only_mesh_updated_blocks = false;
+    constexpr bool clear_updated_flag = true;
+    mesh_integrator_->generateMesh(only_mesh_updated_blocks,
+                                   clear_updated_flag);
   } else {
-    const bool clear_updated_flag = true;
-    mesh_integrator_->generateMeshForUpdatedBlocks(clear_updated_flag);
+    constexpr bool only_mesh_updated_blocks = true;
+    constexpr bool clear_updated_flag = true;
+    mesh_integrator_->generateMesh(only_mesh_updated_blocks,
+                                   clear_updated_flag);
   }
   generate_mesh_timer.Stop();
 
@@ -831,8 +836,10 @@ void VoxbloxNode::updateMeshEvent(const ros::TimerEvent& e) {
   }
 
   timing::Timer generate_mesh_timer("mesh/update");
-  const bool clear_updated_flag = true;
-  mesh_integrator_->generateMeshForUpdatedBlocks(clear_updated_flag);
+  constexpr bool only_mesh_updated_blocks = true;
+  constexpr bool clear_updated_flag = true;
+  mesh_integrator_->generateMesh(only_mesh_updated_blocks, clear_updated_flag);
+
   generate_mesh_timer.Stop();
 
   // TODO(helenol): also think about how to update markers incrementally?

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -1,864 +1,618 @@
-#include <minkindr_conversions/kindr_msg.h>
-#include <minkindr_conversions/kindr_tf.h>
-#include <minkindr_conversions/kindr_xml.h>
-#include <pcl/conversions.h>
-#include <pcl/filters/filter.h>
-#include <pcl/point_types.h>
-#include <pcl_conversions/pcl_conversions.h>
-#include <pcl_msgs/PolygonMesh.h>
-#include <pcl_ros/point_cloud.h>
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <std_srvs/Empty.h>
-#include <tf/transform_listener.h>
-#include <visualization_msgs/MarkerArray.h>
+#ifndef VOXBLOX_INTEGRATOR_TSDF_INTEGRATOR_H_
+#define VOXBLOX_INTEGRATOR_TSDF_INTEGRATOR_H_
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
 #include <deque>
+#include <limits>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <utility>
+#include <vector>
 
-#include <voxblox/core/esdf_map.h>
-#include <voxblox/core/occupancy_map.h>
-#include <voxblox/core/tsdf_map.h>
-#include <voxblox/integrator/esdf_integrator.h>
-#include <voxblox/integrator/occupancy_integrator.h>
-#include <voxblox/integrator/tsdf_integrator.h>
-#include <voxblox/io/layer_io.h>
-#include <voxblox/io/mesh_ply.h>
-#include <voxblox/mesh/mesh_integrator.h>
+#include <glog/logging.h>
+#include <Eigen/Core>
 
-#include <voxblox_msgs/FilePath.h>
-#include "voxblox_ros/mesh_pcl.h"
-#include "voxblox_ros/mesh_vis.h"
-#include "voxblox_ros/ptcloud_vis.h"
+#include "voxblox/core/layer.h"
+#include "voxblox/core/voxel.h"
+#include "voxblox/integrator/integrator_utils.h"
+#include "voxblox/utils/approx_hash_array.h"
+#include "voxblox/utils/timing.h"
+
+#include "voxblox/core/block_hash.h"
 
 namespace voxblox {
 
-class VoxbloxNode {
+class TsdfIntegratorBase {
  public:
-  VoxbloxNode(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+  typedef BlockHashMapType<TsdfVoxel>::type VoxelMap;
 
-  void insertPointcloudWithTf(const sensor_msgs::PointCloud2::Ptr& pointcloud);
+  struct Config {
+    float default_truncation_distance = 0.1;
+    float max_weight = 10000.0;
+    bool voxel_carving_enabled = true;
+    FloatingPoint min_ray_length_m = 0.1;
+    FloatingPoint max_ray_length_m = 5.0;
+    bool use_const_weight = false;
+    bool allow_clear = true;
+    bool use_weight_dropoff = true;
+    bool use_sparsity_compensation_factor = false;
+    float sparsity_compensation_factor = 1.0f;
+    size_t integrator_threads = std::thread::hardware_concurrency();
+    // only implemented in the merge integrator
+    bool enable_anti_grazing = false;
+  };
 
-  bool lookupTransform(const std::string& from_frame,
-                       const std::string& to_frame, const ros::Time& timestamp,
-                       Transformation* transform);
-  bool lookupTransformTf(const std::string& from_frame,
-                         const std::string& to_frame,
-                         const ros::Time& timestamp, Transformation* transform);
-  bool lookupTransformQueue(const std::string& from_frame,
-                            const std::string& to_frame,
-                            const ros::Time& timestamp,
-                            Transformation* transform);
+  TsdfIntegratorBase(const Config& config, Layer<TsdfVoxel>* layer)
+      : config_(config), layer_(layer) {
+    DCHECK(layer_);
 
-  void publishAllUpdatedTsdfVoxels();
-  void publishAllUpdatedEsdfVoxels();
-  void publishTsdfSurfacePoints();
-  void publishTsdfOccupiedNodes();
-  void publishOccupancy();
-  void publishSlices();
+    voxel_size_ = layer_->voxel_size();
+    block_size_ = layer_->block_size();
+    voxels_per_side_ = layer_->voxels_per_side();
 
-  void transformCallback(const geometry_msgs::TransformStamped& transform_msg);
+    voxel_size_inv_ = 1.0 / voxel_size_;
+    block_size_inv_ = 1.0 / block_size_;
+    voxels_per_side_inv_ = 1.0 / voxels_per_side_;
 
-  bool generateMeshCallback(std_srvs::Empty::Request& request,       // NOLINT
-                            std_srvs::Empty::Response& response);    // NOLINT
-  bool generateEsdfCallback(std_srvs::Empty::Request& request,       // NOLINT
-                            std_srvs::Empty::Response& response);    // NOLINT
-  bool saveMapCallback(voxblox_msgs::FilePath::Request& request,     // NOLINT
-                       voxblox_msgs::FilePath::Response& response);  // NOLINT
-  bool loadMapCallback(voxblox_msgs::FilePath::Request& request,     // NOLINT
-                       voxblox_msgs::FilePath::Response& response);  // NOLINT
+    if (config_.integrator_threads == 0) {
+      LOG(WARNING) << "Automatic core count failed, defaulting to 1 threads";
+      config_.integrator_threads = 1;
+    }
+  }
 
-  void updateMeshEvent(const ros::TimerEvent& e);
+  virtual void integratePointCloud(const Transformation& T_G_C,
+                                   const Pointcloud& points_C,
+                                   const Colors& colors) = 0;
 
- private:
-  ros::NodeHandle nh_;
-  ros::NodeHandle nh_private_;
+  // Returns a CONST ref of the config.
+  const Config& getConfig() const { return config_; }
 
-  bool verbose_;
+ protected:
+  bool isPointValid(const Point& point_C, bool* is_clearing) {
+    const FloatingPoint ray_distance = point_C.norm();
+    if (ray_distance < config_.min_ray_length_m) {
+      return false;
+    } else if (ray_distance > config_.max_ray_length_m) {
+      if (config_.allow_clear) {
+        *is_clearing = true;
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      *is_clearing = false;
+      return true;
+    }
+  }
 
-  // This is a debug option, more or less...
-  bool color_ptcloud_by_weight_;
+  inline TsdfVoxel* getVoxel(const VoxelIndex& global_voxel_idx,
+                             Block<TsdfVoxel>::Ptr* block,
+                             BlockIndex* last_block_idx,
+                             VoxelMap* temp_voxel_storage) {
+    BlockIndex block_idx = getBlockIndexFromGlobalVoxelIndex(
+        global_voxel_idx, voxels_per_side_inv_);
+    VoxelIndex local_voxel_idx =
+        getLocalFromGlobalVoxelIndex(global_voxel_idx, voxels_per_side_);
 
-  // Which maps to generate.
-  bool generate_esdf_;
-  bool generate_occupancy_;
+    if (block_idx != *last_block_idx) {
+      *block = layer_->getBlockPtrByIndex(block_idx);
+      *last_block_idx = block_idx;
+      if (*block != nullptr) {
+        (*block)->updated() = true;
+      }
+    }
 
-  // What output information to publish
-  bool publish_tsdf_info_;
-  bool publish_slices_;
+    // If no block at this location currently exists, we allocate a temporary
+    // voxel that will be merged into the map later
+    if (*block == nullptr) {
+      return &((*temp_voxel_storage)[global_voxel_idx]);
+    } else {
+      return &((*block)->getVoxelByVoxelIndex(local_voxel_idx));
+    }
+  }
 
-  bool output_mesh_as_pointcloud_;
-  bool output_mesh_as_pcl_mesh_;
+  void updateLayerWithStoredVoxels(const VoxelMap& temp_voxel_storage) {
+    BlockIndex last_block_idx;
+    Block<TsdfVoxel>::Ptr block = nullptr;
+    for (const std::pair<const VoxelIndex, TsdfVoxel>& temp_voxel :
+         temp_voxel_storage) {
+      BlockIndex block_idx = getBlockIndexFromGlobalVoxelIndex(
+          temp_voxel.first, voxels_per_side_inv_);
+      VoxelIndex local_voxel_idx =
+          getLocalFromGlobalVoxelIndex(temp_voxel.first, voxels_per_side_);
 
-  // Global/map coordinate frame. Will always look up TF transforms to this
-  // frame.
-  std::string world_frame_;
-  // If set, overwrite sensor frame with this value. If empty, unused.
-  std::string sensor_frame_;
-  // Whether to use TF transform resolution (true) or fixed transforms from
-  // parameters and transform topics (false).
-  bool use_tf_transforms_;
-  int64_t timestamp_tolerance_ns_;
-  // B is the body frame of the robot, C is the camera/sensor frame creating
-  // the pointclouds, and D is the 'dynamic' frame; i.e., incoming messages
-  // are assumed to be T_G_D.
-  Transformation T_B_C_;
-  Transformation T_B_D_;
+      if ((block_idx != last_block_idx) || (block == nullptr)) {
+        block = layer_->allocateBlockPtrByIndex(block_idx);
+        block->updated() = true;
+      }
 
-  // Pointcloud visualization settings.
-  double slice_level_;
+      TsdfVoxel& base_voxel = block->getVoxelByVoxelIndex(local_voxel_idx);
 
-  // Mesh output settings. Mesh is only written to file if mesh_filename_ is
-  // not empty.
-  std::string mesh_filename_;
-  // How to color the mesh.
-  ColorMode color_mode_;
+      const float new_weight = base_voxel.weight + temp_voxel.second.weight;
 
-  // Keep track of these for throttling.
-  ros::Duration min_time_between_msgs_;
-  ros::Time last_msg_time_;
+      // it is possible that both voxels have weights very close to zero
+      if (new_weight < kFloatEpsilon) {
+        continue;
+      }
+      base_voxel.color = Color::blendTwoColors(
+          base_voxel.color, base_voxel.weight, temp_voxel.second.color,
+          temp_voxel.second.weight);
+      base_voxel.distance =
+          (base_voxel.distance * base_voxel.weight +
+           temp_voxel.second.distance * temp_voxel.second.weight) /
+          new_weight;
 
-  // To be replaced (at least optionally) with odometry + static transform
-  // from IMU to visual frame.
-  tf::TransformListener tf_listener_;
+      base_voxel.weight = std::min(config_.max_weight, new_weight);
+    }
+  }
 
-  // Data subscribers.
-  ros::Subscriber pointcloud_sub_;
-  // Only used if use_tf_transforms_ set to false.
-  ros::Subscriber transform_sub_;
+  // updates tsdf_voxel. thread safe
+  inline void updateTsdfVoxel(const Point& origin, const Point& point_G,
+                              const Point& voxel_center, const Color& color,
+                              const float truncation_distance,
+                              const float weight, TsdfVoxel* tsdf_voxel) {
+    // Figure out whether the voxel is behind or in front of the surface.
+    // To do this, project the voxel_center onto the ray from origin to point G.
+    // Then check if the the magnitude of the vector is smaller or greater than
+    // the original distance...
+    Point v_voxel_origin = voxel_center - origin;
+    Point v_point_origin = point_G - origin;
 
-  // Publish markers for visualization.
-  ros::Publisher mesh_pub_;
-  ros::Publisher mesh_pointcloud_pub_;
-  ros::Publisher mesh_pcl_mesh_pub_;
-  ros::Publisher tsdf_pointcloud_pub_;
-  ros::Publisher esdf_pointcloud_pub_;
-  ros::Publisher surface_pointcloud_pub_;
-  ros::Publisher occupancy_marker_pub_;
-  ros::Publisher occupancy_layer_pub_;
-  ros::Publisher tsdf_slice_pub_;
-  ros::Publisher esdf_slice_pub_;
+    FloatingPoint dist_G = v_point_origin.norm();
+    // projection of a (v_voxel_origin) onto b (v_point_origin)
+    FloatingPoint dist_G_V = v_voxel_origin.dot(v_point_origin) / dist_G;
 
-  // Services.
-  ros::ServiceServer generate_mesh_srv_;
-  ros::ServiceServer generate_esdf_srv_;
-  ros::ServiceServer save_map_srv_;
-  ros::ServiceServer load_map_srv_;
+    float sdf = static_cast<float>(dist_G - dist_G_V);
 
-  // Timers.
-  ros::Timer update_mesh_timer_;
+    float updated_weight = weight;
+    // Compute updated weight in case we use weight dropoff. It's easier here
+    // that in getVoxelWeight as here we have the actual SDF for the voxel
+    // already computed.
+    const FloatingPoint dropoff_epsilon = voxel_size_;
+    if (config_.use_weight_dropoff && sdf < -dropoff_epsilon) {
+      updated_weight = weight * (truncation_distance + sdf) /
+                       (truncation_distance - dropoff_epsilon);
+      updated_weight = std::max(updated_weight, 0.0f);
+    }
 
-  // Maps and integrators.
-  std::shared_ptr<TsdfMap> tsdf_map_;
-  std::shared_ptr<TsdfIntegratorBase> tsdf_integrator_;
-  // ESDF maps (optional).
-  std::shared_ptr<EsdfMap> esdf_map_;
-  std::shared_ptr<EsdfIntegrator> esdf_integrator_;
-  // Occupancy maps (optional).
-  std::shared_ptr<OccupancyMap> occupancy_map_;
-  std::shared_ptr<OccupancyIntegrator> occupancy_integrator_;
-  // Mesh accessories.
-  std::shared_ptr<MeshLayer> mesh_layer_;
-  std::shared_ptr<MeshIntegrator<TsdfVoxel>> mesh_integrator_;
+    // Compute the updated weight in case we compensate for sparsity. By
+    // multiplicating the weight of occupied areas (|sdf| < truncation distance)
+    // by a factor, we prevent to easily fade out these areas with the free
+    // space parts of other rays which pass through the corresponding voxels.
+    // This can be useful for creating a TSDF map from sparse sensor data (e.g.
+    // visual features from a SLAM system). By default, this option is disabled.
+    if (config_.use_sparsity_compensation_factor) {
+      if (std::abs(sdf) < config_.default_truncation_distance) {
+        updated_weight *= config_.sparsity_compensation_factor;
+      }
+    }
 
-  // Transform queue, used only when use_tf_transforms is false.
-  std::deque<geometry_msgs::TransformStamped> transform_queue_;
+    // Grab and lock the mutex responsible for this voxel
+    std::lock_guard<std::mutex> lock(
+        mutexes_.get(getGridIndexFromPoint(point_G, voxel_size_inv_)));
+
+    const float new_weight = tsdf_voxel->weight + updated_weight;
+    tsdf_voxel->color = Color::blendTwoColors(
+        tsdf_voxel->color, tsdf_voxel->weight, color, updated_weight);
+    const float new_sdf =
+        (sdf * updated_weight + tsdf_voxel->distance * tsdf_voxel->weight) /
+        new_weight;
+
+    tsdf_voxel->distance = (new_sdf > 0.0)
+                               ? std::min(truncation_distance, new_sdf)
+                               : std::max(-truncation_distance, new_sdf);
+    tsdf_voxel->weight = std::min(config_.max_weight, new_weight);
+  }
+
+  inline float computeDistance(const Point& origin, const Point& point_G,
+                               const Point& voxel_center) {
+    Point v_voxel_origin = voxel_center - origin;
+    Point v_point_origin = point_G - origin;
+
+    FloatingPoint dist_G = v_point_origin.norm();
+    // projection of a (v_voxel_origin) onto b (v_point_origin)
+    FloatingPoint dist_G_V = v_voxel_origin.dot(v_point_origin) / dist_G;
+
+    float sdf = static_cast<float>(dist_G - dist_G_V);
+    return sdf;
+  }
+
+  inline float getVoxelWeight(const Point& point_C) const {
+    if (config_.use_const_weight) {
+      return 1.0f;
+    }
+    FloatingPoint dist_z = std::abs(point_C.z());
+    if (dist_z > kEpsilon) {
+      return 1.0f / (dist_z * dist_z);
+    }
+    return 0.0f;
+  }
+
+  Config config_;
+
+  Layer<TsdfVoxel>* layer_;
+
+  // Cached map config.
+  FloatingPoint voxel_size_;
+  size_t voxels_per_side_;
+  FloatingPoint block_size_;
+
+  // Derived types.
+  FloatingPoint voxel_size_inv_;
+  FloatingPoint voxels_per_side_inv_;
+  FloatingPoint block_size_inv_;
+
+  ApproxHashArray<12, std::mutex> mutexes_;  // 4096 locks
 };
 
-VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
-                         const ros::NodeHandle& nh_private)
-    : nh_(nh),
-      nh_private_(nh_private),
-      verbose_(true),
-      color_ptcloud_by_weight_(false),
-      generate_esdf_(false),
-      generate_occupancy_(false),
-      publish_tsdf_info_(false),
-      publish_slices_(false),
-      output_mesh_as_pointcloud_(false),
-      output_mesh_as_pcl_mesh_(false),
-      world_frame_("world"),
-      sensor_frame_(""),
-      use_tf_transforms_(true),
-      // 10 ms here:
-      timestamp_tolerance_ns_(10000000),
-      slice_level_(0.5) {
-  // Before subscribing, determine minimum time between messages.
-  // 0 by default.
-  double min_time_between_msgs_sec = 0.0;
-  nh_private_.param("min_time_between_msgs_sec", min_time_between_msgs_sec,
-                    min_time_between_msgs_sec);
-  min_time_between_msgs_.fromSec(min_time_between_msgs_sec);
+class SimpleTsdfIntegrator : public TsdfIntegratorBase {
+ public:
+  SimpleTsdfIntegrator(const Config& config, Layer<TsdfVoxel>* layer)
+      : TsdfIntegratorBase(config, layer) {}
 
-  // Determine which parts to generate.
-  nh_private_.param("generate_esdf", generate_esdf_, generate_esdf_);
-  nh_private_.param("output_mesh_as_pointcloud", output_mesh_as_pointcloud_,
-                    output_mesh_as_pointcloud_);
-  nh_private_.param("output_mesh_as_pcl_mesh", output_mesh_as_pcl_mesh_,
-                    output_mesh_as_pcl_mesh_);
-  nh_private_.param("slice_level", slice_level_, slice_level_);
-  nh_private_.param("world_frame", world_frame_, world_frame_);
-  nh_private_.param("sensor_frame", sensor_frame_, sensor_frame_);
-  nh_private_.param("publish_tsdf_info", publish_tsdf_info_,
-                    publish_tsdf_info_);
-  nh_private_.param("publish_slices", publish_slices_, publish_slices_);
+  void integratePointCloud(const Transformation& T_G_C,
+                           const Pointcloud& points_C, const Colors& colors) {
+    std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
 
-  // Advertise topics.
-  mesh_pub_ =
-      nh_private_.advertise<visualization_msgs::MarkerArray>("mesh", 1, true);
+    timing::Timer integrate_timer("integrate");
 
-  if (publish_tsdf_info_) {
-    surface_pointcloud_pub_ =
-        nh_private_.advertise<pcl::PointCloud<pcl::PointXYZRGB>>(
-            "surface_pointcloud", 1, true);
-    tsdf_pointcloud_pub_ =
-        nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI>>(
-            "tsdf_pointcloud", 1, true);
-    occupancy_marker_pub_ =
-        nh_private_.advertise<visualization_msgs::MarkerArray>("occupied_nodes",
-                                                               1, true);
-  }
+    ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
 
-  if (output_mesh_as_pointcloud_) {
-    mesh_pointcloud_pub_ =
-        nh_private_.advertise<pcl::PointCloud<pcl::PointXYZRGB>>(
-            "mesh_pointcloud", 1, true);
-  }
-
-  if (output_mesh_as_pcl_mesh_) {
-    mesh_pcl_mesh_pub_ =
-        nh_private_.advertise<pcl_msgs::PolygonMesh>("pcl_mesh", 1, true);
-  }
-
-  if (publish_slices_) {
-    tsdf_slice_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI>>(
-        "tsdf_slice", 1, true);
-
-    if (generate_esdf_) {
-      esdf_slice_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI>>(
-          "esdf_slice", 1, true);
-    }
-  }
-
-  if (generate_esdf_) {
-    esdf_pointcloud_pub_ =
-        nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI>>(
-            "esdf_pointcloud", 1, true);
-  }
-
-  if (generate_occupancy_) {
-    occupancy_layer_pub_ =
-        nh_private_.advertise<visualization_msgs::MarkerArray>(
-            "occupancy_layer", 1, true);
-  }
-
-  int pointcloud_queue_size = 1;
-  nh_private_.param("pointcloud_queue_size", pointcloud_queue_size,
-                    pointcloud_queue_size);
-
-  pointcloud_sub_ = nh_.subscribe("pointcloud", pointcloud_queue_size,
-                                  &VoxbloxNode::insertPointcloudWithTf, this);
-
-  nh_private_.param("verbose", verbose_, verbose_);
-  nh_private_.param("color_ptcloud_by_weight", color_ptcloud_by_weight_,
-                    color_ptcloud_by_weight_);
-
-  // Determine map parameters.
-  TsdfMap::Config config;
-
-  // Workaround for OS X on mac mini not having specializations for float
-  // for some reason.
-  double voxel_size = config.tsdf_voxel_size;
-  int voxels_per_side = config.tsdf_voxels_per_side;
-  nh_private_.param("tsdf_voxel_size", voxel_size, voxel_size);
-  nh_private_.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
-  config.tsdf_voxel_size = static_cast<FloatingPoint>(voxel_size);
-  config.tsdf_voxels_per_side = voxels_per_side;
-  tsdf_map_.reset(new TsdfMap(config));
-
-  // Determine integrator parameters.
-  TsdfIntegratorBase::Config integrator_config;
-  integrator_config.voxel_carving_enabled = true;
-  // Used to be * 4 according to Marius's experience, was changed to *2
-  // This should be made bigger again if behind-surface weighting is improved.
-  integrator_config.default_truncation_distance = config.tsdf_voxel_size * 2;
-
-  double truncation_distance = integrator_config.default_truncation_distance;
-  double max_weight = integrator_config.max_weight;
-  nh_private_.param("voxel_carving_enabled",
-                    integrator_config.voxel_carving_enabled,
-                    integrator_config.voxel_carving_enabled);
-  nh_private_.param("truncation_distance", truncation_distance,
-                    truncation_distance);
-  nh_private_.param("max_ray_length_m", integrator_config.max_ray_length_m,
-                    integrator_config.max_ray_length_m);
-  nh_private_.param("min_ray_length_m", integrator_config.min_ray_length_m,
-                    integrator_config.min_ray_length_m);
-  nh_private_.param("max_weight", max_weight, max_weight);
-  nh_private_.param("use_const_weight", integrator_config.use_const_weight,
-                    integrator_config.use_const_weight);
-  nh_private_.param("allow_clear", integrator_config.allow_clear,
-                    integrator_config.allow_clear);
-  integrator_config.default_truncation_distance =
-      static_cast<float>(truncation_distance);
-  integrator_config.max_weight = static_cast<float>(max_weight);
-
-  std::string method("merged");
-  nh_private_.param("method", method, method);
-  if (method.compare("simple") == 0) {
-    tsdf_integrator_.reset(new SimpleTsdfIntegrator(
-        integrator_config, tsdf_map_->getTsdfLayerPtr()));
-  } else if (method.compare("merged") == 0) {
-    integrator_config.enable_anti_grazing = false;
-    tsdf_integrator_.reset(new MergedTsdfIntegrator(
-        integrator_config, tsdf_map_->getTsdfLayerPtr()));
-  } else if (method.compare("merged_discard") == 0) {
-    integrator_config.enable_anti_grazing = true;
-    tsdf_integrator_.reset(new MergedTsdfIntegrator(
-        integrator_config, tsdf_map_->getTsdfLayerPtr()));
-  } else if (method.compare("fast") == 0) {
-    tsdf_integrator_.reset(new FastTsdfIntegrator(
-        integrator_config, tsdf_map_->getTsdfLayerPtr()));
-  } else {
-    tsdf_integrator_.reset(new SimpleTsdfIntegrator(
-        integrator_config, tsdf_map_->getTsdfLayerPtr()));
-  }
-
-  // ESDF settings.
-  if (generate_esdf_) {
-    EsdfMap::Config esdf_config;
-    // TODO(helenol): add possibility for different ESDF map sizes.
-    esdf_config.esdf_voxel_size = config.tsdf_voxel_size;
-    esdf_config.esdf_voxels_per_side = config.tsdf_voxels_per_side;
-
-    esdf_map_.reset(new EsdfMap(esdf_config));
-
-    EsdfIntegrator::Config esdf_integrator_config;
-    // Make sure that this is the same as the truncation distance OR SMALLER!
-    esdf_integrator_config.min_distance_m =
-        integrator_config.default_truncation_distance;
-    nh_private_.param("esdf_max_distance_m",
-                      esdf_integrator_config.max_distance_m,
-                      esdf_integrator_config.max_distance_m);
-    nh_private_.param("esdf_default_distance_m",
-                      esdf_integrator_config.default_distance_m,
-                      esdf_integrator_config.default_distance_m);
-
-    esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
-                                              tsdf_map_->getTsdfLayerPtr(),
-                                              esdf_map_->getEsdfLayerPtr()));
-  }
-
-  // Occupancy settings.
-  if (generate_occupancy_) {
-    OccupancyMap::Config occupancy_config;
-    // TODO(helenol): add possibility for different ESDF map sizes.
-    occupancy_config.occupancy_voxel_size = config.tsdf_voxel_size;
-    occupancy_config.occupancy_voxels_per_side = config.tsdf_voxels_per_side;
-    occupancy_map_.reset(new OccupancyMap(occupancy_config));
-
-    OccupancyIntegrator::Config occupancy_integrator_config;
-    occupancy_integrator_.reset(new OccupancyIntegrator(
-        occupancy_integrator_config, occupancy_map_->getOccupancyLayerPtr()));
-  }
-
-  // Mesh settings.
-  nh_private_.param("mesh_filename", mesh_filename_, mesh_filename_);
-  std::string color_mode("color");
-  nh_private_.param("color_mode", color_mode, color_mode);
-  if (color_mode == "color" || color_mode == "colors") {
-    color_mode_ = ColorMode::kColor;
-  } else if (color_mode == "height") {
-    color_mode_ = ColorMode::kHeight;
-  } else if (color_mode == "normals") {
-    color_mode_ = ColorMode::kNormals;
-  } else if (color_mode == "lambert") {
-    color_mode_ = ColorMode::kLambert;
-  } else {  // Default case is gray.
-    color_mode_ = ColorMode::kGray;
-  }
-
-  MeshIntegrator<TsdfVoxel>::Config mesh_config;
-  nh_private_.param("mesh_min_weight", mesh_config.min_weight,
-                    mesh_config.min_weight);
-
-  mesh_layer_.reset(new MeshLayer(tsdf_map_->block_size()));
-
-  mesh_integrator_.reset(new MeshIntegrator<TsdfVoxel>(
-      mesh_config, tsdf_map_->getTsdfLayerPtr(), mesh_layer_.get()));
-
-  // Advertise services.
-  generate_mesh_srv_ = nh_private_.advertiseService(
-      "generate_mesh", &VoxbloxNode::generateMeshCallback, this);
-  if (generate_esdf_) {
-    generate_esdf_srv_ = nh_private_.advertiseService(
-        "generate_esdf", &VoxbloxNode::generateEsdfCallback, this);
-  }
-  save_map_srv_ = nh_private_.advertiseService(
-      "save_map", &VoxbloxNode::saveMapCallback, this);
-  load_map_srv_ = nh_private_.advertiseService(
-      "load_map", &VoxbloxNode::loadMapCallback, this);
-
-  // If set, use a timer to progressively integrate the mesh.
-  double update_mesh_every_n_sec = 0.0;
-  nh_private_.param("update_mesh_every_n_sec", update_mesh_every_n_sec,
-                    update_mesh_every_n_sec);
-
-  if (update_mesh_every_n_sec > 0.0) {
-    update_mesh_timer_ =
-        nh_private_.createTimer(ros::Duration(update_mesh_every_n_sec),
-                                &VoxbloxNode::updateMeshEvent, this);
-  }
-
-  // Transform settings.
-  nh_private_.param("use_tf_transforms", use_tf_transforms_,
-                    use_tf_transforms_);
-  // If we use topic transforms, we have 2 parts: a dynamic transform from a
-  // topic and a static transform from parameters.
-  // Static transform should be T_G_D (where D is whatever sensor the
-  // dynamic coordinate frame is in) and the static should be T_D_C (where
-  // C is the sensor frame that produces the depth data). It is possible to
-  // specific T_C_D and set invert_static_tranform to true.
-  if (!use_tf_transforms_) {
-    transform_sub_ =
-        nh_.subscribe("transform", 40, &VoxbloxNode::transformCallback, this);
-    // Retrieve T_D_C from params.
-    XmlRpc::XmlRpcValue T_B_D_xml;
-    // TODO(helenol): split out into a function to avoid duplication.
-    if (nh_private_.getParam("T_B_D", T_B_D_xml)) {
-      kindr::minimal::xmlRpcToKindr(T_B_D_xml, &T_B_D_);
-
-      // See if we need to invert it.
-      bool invert_static_tranform = false;
-      nh_private_.param("invert_T_B_D", invert_static_tranform,
-                        invert_static_tranform);
-      if (invert_static_tranform) {
-        T_B_D_ = T_B_D_.inverse();
-      }
-    }
-    XmlRpc::XmlRpcValue T_B_C_xml;
-    if (nh_private_.getParam("T_B_C", T_B_C_xml)) {
-      kindr::minimal::xmlRpcToKindr(T_B_C_xml, &T_B_C_);
-
-      // See if we need to invert it.
-      bool invert_static_tranform = false;
-      nh_private_.param("invert_T_B_C", invert_static_tranform,
-                        invert_static_tranform);
-      if (invert_static_tranform) {
-        T_B_C_ = T_B_C_.inverse();
-      }
+    std::vector<std::thread> integration_threads;
+    for (size_t i = 0; i < config_.integrator_threads; ++i) {
+      integration_threads.emplace_back(&SimpleTsdfIntegrator::integrateFunction,
+                                       this, T_G_C, points_C, colors,
+                                       &index_getter, &(temp_voxel_storage[i]));
     }
 
-    ROS_INFO_STREAM("Static transforms loaded from file.\nT_B_D:\n"
-                    << T_B_D_ << "\nT_B_C:" << T_B_C_);
-  }
-
-  ros::spinOnce();
-}
-
-void VoxbloxNode::insertPointcloudWithTf(
-    const sensor_msgs::PointCloud2::Ptr& pointcloud_msg) {
-  // Figure out if we should insert this.
-  if (pointcloud_msg->header.stamp - last_msg_time_ < min_time_between_msgs_) {
-    return;
-  }
-  last_msg_time_ = pointcloud_msg->header.stamp;
-
-  // Look up transform from sensor frame to world frame.
-  Transformation T_G_C;
-  if (lookupTransform(pointcloud_msg->header.frame_id, world_frame_,
-                      pointcloud_msg->header.stamp, &T_G_C)) {
-    // Convert the PCL pointcloud into our awesome format.
-    // TODO(helenol): improve...
-    // Horrible hack fix to fix color parsing colors in PCL.
-    for (size_t d = 0; d < pointcloud_msg->fields.size(); ++d) {
-      if (pointcloud_msg->fields[d].name == std::string("rgb")) {
-        pointcloud_msg->fields[d].datatype = sensor_msgs::PointField::FLOAT32;
-      }
+    for (std::thread& thread : integration_threads) {
+      thread.join();
     }
+    integrate_timer.Stop();
 
-    pcl::PointCloud<pcl::PointXYZRGB> pointcloud_pcl;
-    // pointcloud_pcl is modified below:
-    pcl::fromROSMsg(*pointcloud_msg, pointcloud_pcl);
+    timing::Timer insertion_timer("inserting_missed_voxels");
+    for (const VoxelMap& temp_voxels : temp_voxel_storage) {
+      updateLayerWithStoredVoxels(temp_voxels);
+    }
+    insertion_timer.Stop();
+  }
 
-    timing::Timer ptcloud_timer("ptcloud_preprocess");
-
-    // Filter out NaNs. :|
-    std::vector<int> indices;
-    pcl::removeNaNFromPointCloud(pointcloud_pcl, pointcloud_pcl, indices);
-
-    Pointcloud points_C;
-    Colors colors;
-    points_C.reserve(pointcloud_pcl.size());
-    colors.reserve(pointcloud_pcl.size());
-    for (size_t i = 0; i < pointcloud_pcl.points.size(); ++i) {
-      if (!std::isfinite(pointcloud_pcl.points[i].x) ||
-          !std::isfinite(pointcloud_pcl.points[i].y) ||
-          !std::isfinite(pointcloud_pcl.points[i].z)) {
+  void integrateFunction(const Transformation& T_G_C,
+                         const Pointcloud& points_C, const Colors& colors,
+                         ThreadSafeIndex* index_getter,
+                         VoxelMap* temp_voxel_storage) {
+    size_t point_idx;
+    while (index_getter->getNextIndex(&point_idx)) {
+      const Point& point_C = points_C[point_idx];
+      const Color& color = colors[point_idx];
+      bool is_clearing;
+      if (!isPointValid(point_C, &is_clearing)) {
         continue;
       }
 
-      points_C.push_back(Point(pointcloud_pcl.points[i].x,
-                               pointcloud_pcl.points[i].y,
-                               pointcloud_pcl.points[i].z));
-      colors.push_back(
-          Color(pointcloud_pcl.points[i].r, pointcloud_pcl.points[i].g,
-                pointcloud_pcl.points[i].b, pointcloud_pcl.points[i].a));
+      const Point origin = T_G_C.getPosition();
+      const Point point_G = T_G_C * point_C;
+
+      RayCaster ray_caster(origin, point_G, is_clearing,
+                           config_.voxel_carving_enabled,
+                           config_.max_ray_length_m, voxel_size_inv_,
+                           config_.default_truncation_distance);
+
+      BlockIndex last_block_idx = BlockIndex::Zero();
+      Block<TsdfVoxel>::Ptr block;
+      VoxelIndex global_voxel_idx;
+      while (ray_caster.nextRayIndex(&global_voxel_idx)) {
+        TsdfVoxel* voxel = getVoxel(global_voxel_idx, &block, &last_block_idx,
+                                    temp_voxel_storage);
+        if (voxel != nullptr) {
+          const float weight = getVoxelWeight(point_C);
+          const Point voxel_center_G =
+              getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
+
+          updateTsdfVoxel(origin, point_G, voxel_center_G, color,
+                          config_.default_truncation_distance, weight, voxel);
+        }
+      }
     }
+  }
+};
 
-    ptcloud_timer.Stop();
+class MergedTsdfIntegrator : public TsdfIntegratorBase {
+ public:
+  MergedTsdfIntegrator(const Config& config, Layer<TsdfVoxel>* layer)
+      : TsdfIntegratorBase(config, layer) {}
 
-    if (verbose_) {
-      ROS_INFO("Integrating a pointcloud with %lu points.", points_C.size());
-    }
-    ros::WallTime start = ros::WallTime::now();
+  void integratePointCloud(const Transformation& T_G_C,
+                           const Pointcloud& points_C, const Colors& colors) {
+    timing::Timer integrate_timer("integrate");
 
-    tsdf_integrator_->integratePointCloud(T_G_C, points_C, colors);
+    // Pre-compute a list of unique voxels to end on.
+    // Create a hashmap: VOXEL INDEX -> index in original cloud.
+    BlockHashMapType<std::vector<size_t>>::type voxel_map;
+    // This is a hash map (same as above) to all the indices that need to be
+    // cleared.
+    BlockHashMapType<std::vector<size_t>>::type clear_map;
 
-    if (generate_occupancy_) {
-      occupancy_integrator_->integratePointCloud(T_G_C, points_C);
-    }
-    ros::WallTime end = ros::WallTime::now();
-    if (verbose_) {
-      ROS_INFO("Finished integrating in %f seconds, have %lu blocks.",
-               (end - start).toSec(),
-               tsdf_map_->getTsdfLayer().getNumberOfAllocatedBlocks());
-      if (generate_occupancy_) {
-        ROS_INFO("Occupancy: %lu blocks.",
-                 occupancy_map_->getOccupancyLayerPtr()
-                     ->getNumberOfAllocatedBlocks());
+    ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
+
+    bundleRays(T_G_C, points_C, colors, &index_getter, &voxel_map, &clear_map);
+
+    integrateRays(T_G_C, points_C, colors, config_.enable_anti_grazing, false,
+                  voxel_map, clear_map);
+
+    timing::Timer clear_timer("integrate/clear");
+
+    integrateRays(T_G_C, points_C, colors, config_.enable_anti_grazing, true,
+                  voxel_map, clear_map);
+
+    clear_timer.Stop();
+
+    integrate_timer.Stop();
+  }
+
+ private:
+  inline void bundleRays(
+      const Transformation& T_G_C, const Pointcloud& points_C,
+      const Colors& colors, ThreadSafeIndex* index_getter,
+      BlockHashMapType<std::vector<size_t>>::type* voxel_map,
+      BlockHashMapType<std::vector<size_t>>::type* clear_map) {
+    size_t point_idx;
+    while (index_getter->getNextIndex(&point_idx)) {
+      const Point& point_C = points_C[point_idx];
+      bool is_clearing;
+      if (!isPointValid(point_C, &is_clearing)) {
+        continue;
+      }
+
+      const Point point_G = T_G_C * point_C;
+
+      VoxelIndex voxel_index = getGridIndexFromPoint(point_G, voxel_size_inv_);
+
+      if (is_clearing) {
+        (*clear_map)[voxel_index].push_back(point_idx);
+      } else {
+        (*voxel_map)[voxel_index].push_back(point_idx);
       }
     }
 
-    if (publish_tsdf_info_) {
-      publishAllUpdatedTsdfVoxels();
-      publishTsdfSurfacePoints();
-      publishTsdfOccupiedNodes();
+    LOG(INFO) << "Went from " << points_C.size() << " points to "
+              << voxel_map->size() << " raycasts  and " << clear_map->size()
+              << " clear rays.";
+  }
+
+  void integrateVoxel(
+      const Transformation& T_G_C, const Pointcloud& points_C,
+      const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
+      const std::pair<AnyIndex, std::vector<size_t>>& kv,
+      const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
+      VoxelMap* temp_voxel_storage) {
+    if (kv.second.empty()) {
+      return;
     }
-    if (generate_occupancy_) {
-      publishOccupancy();
-    }
-    if (publish_slices_) {
-      publishSlices();
-    }
 
-    if (verbose_) {
-      ROS_INFO_STREAM("Timings: " << std::endl << timing::Timing::Print());
-      ROS_INFO_STREAM(
-          "Layer memory: " << tsdf_map_->getTsdfLayer().getMemorySize());
-    }
-  }
-}
+    const Point& origin = T_G_C.getPosition();
+    Color merged_color;
+    Point merged_point_C = Point::Zero();
+    FloatingPoint merged_weight = 0.0;
 
-void VoxbloxNode::transformCallback(
-    const geometry_msgs::TransformStamped& transform_msg) {
-  transform_queue_.push_back(transform_msg);
-}
+    for (const size_t pt_idx : kv.second) {
+      const Point& point_C = points_C[pt_idx];
+      const Color& color = colors[pt_idx];
 
-void VoxbloxNode::publishAllUpdatedTsdfVoxels() {
-  DCHECK(tsdf_map_) << "TSDF map not allocated.";
-  // Create a pointcloud with distance = intensity.
-  pcl::PointCloud<pcl::PointXYZI> pointcloud;
+      float point_weight = getVoxelWeight(point_C);
+      merged_point_C =
+          (merged_point_C * merged_weight + point_C * point_weight) /
+          (merged_weight + point_weight);
+      merged_color = Color::blendTwoColors(merged_color, merged_weight, color,
+                                           point_weight);
+      merged_weight += point_weight;
 
-  createDistancePointcloudFromTsdfLayer(tsdf_map_->getTsdfLayer(), &pointcloud);
-
-  pointcloud.header.frame_id = world_frame_;
-  tsdf_pointcloud_pub_.publish(pointcloud);
-}
-
-void VoxbloxNode::publishAllUpdatedEsdfVoxels() {
-  DCHECK(esdf_map_) << "ESDF map not allocated.";
-
-  // Create a pointcloud with distance = intensity.
-  pcl::PointCloud<pcl::PointXYZI> pointcloud;
-
-  createDistancePointcloudFromEsdfLayer(esdf_map_->getEsdfLayer(), &pointcloud);
-
-  pointcloud.header.frame_id = world_frame_;
-  esdf_pointcloud_pub_.publish(pointcloud);
-}
-
-void VoxbloxNode::publishTsdfSurfacePoints() {
-  DCHECK(tsdf_map_) << "TSDF map not allocated.";
-
-  // Create a pointcloud with distance = intensity.
-  pcl::PointCloud<pcl::PointXYZRGB> pointcloud;
-  const float surface_distance_thresh =
-      tsdf_map_->getTsdfLayer().voxel_size() * 0.75;
-  createSurfacePointcloudFromTsdfLayer(tsdf_map_->getTsdfLayer(),
-                                       surface_distance_thresh, &pointcloud);
-
-  pointcloud.header.frame_id = world_frame_;
-  surface_pointcloud_pub_.publish(pointcloud);
-}
-
-void VoxbloxNode::publishTsdfOccupiedNodes() {
-  DCHECK(tsdf_map_) << "TSDF map not allocated.";
-
-  // Create a pointcloud with distance = intensity.
-  visualization_msgs::MarkerArray marker_array;
-  createOccupancyBlocksFromTsdfLayer(tsdf_map_->getTsdfLayer(), world_frame_,
-                                     &marker_array);
-  occupancy_marker_pub_.publish(marker_array);
-}
-
-void VoxbloxNode::publishOccupancy() {
-  DCHECK(occupancy_map_) << "Occupancy map not allocated.";
-
-  // Create a pointcloud with distance = intensity.
-  visualization_msgs::MarkerArray marker_array;
-  createOccupancyBlocksFromOccupancyLayer(
-      *occupancy_map_->getOccupancyLayerPtr(), world_frame_, &marker_array);
-  occupancy_layer_pub_.publish(marker_array);
-}
-
-void VoxbloxNode::publishSlices() {
-  if (tsdf_map_) {
-    pcl::PointCloud<pcl::PointXYZI> pointcloud;
-
-    createDistancePointcloudFromTsdfLayerSlice(tsdf_map_->getTsdfLayer(), 2,
-                                               slice_level_, &pointcloud);
-
-    pointcloud.header.frame_id = world_frame_;
-    tsdf_slice_pub_.publish(pointcloud);
-  }
-  if (esdf_map_) {
-    pcl::PointCloud<pcl::PointXYZI> pointcloud;
-
-    createDistancePointcloudFromEsdfLayerSlice(esdf_map_->getEsdfLayer(), 2,
-                                               slice_level_, &pointcloud);
-
-    pointcloud.header.frame_id = world_frame_;
-    esdf_slice_pub_.publish(pointcloud);
-  }
-}
-
-bool VoxbloxNode::lookupTransform(const std::string& from_frame,
-                                  const std::string& to_frame,
-                                  const ros::Time& timestamp,
-                                  Transformation* transform) {
-  if (use_tf_transforms_) {
-    return lookupTransformTf(from_frame, to_frame, timestamp, transform);
-  } else {
-    return lookupTransformQueue(from_frame, to_frame, timestamp, transform);
-  }
-}
-
-// Stolen from octomap_manager
-bool VoxbloxNode::lookupTransformTf(const std::string& from_frame,
-                                    const std::string& to_frame,
-                                    const ros::Time& timestamp,
-                                    Transformation* transform) {
-  tf::StampedTransform tf_transform;
-  ros::Time time_to_lookup = timestamp;
-
-  // Allow overwriting the TF frame for the sensor.
-  std::string from_frame_modified = from_frame;
-  if (!sensor_frame_.empty()) {
-    from_frame_modified = sensor_frame_;
-  }
-
-  // If this transform isn't possible at the time, then try to just look up
-  // the latest (this is to work with bag files and static transform
-  // publisher, etc).
-  if (!tf_listener_.canTransform(to_frame, from_frame_modified,
-                                 time_to_lookup)) {
-    time_to_lookup = ros::Time(0);
-    ROS_WARN("Using latest TF transform instead of timestamp match.");
-  }
-
-  try {
-    tf_listener_.lookupTransform(to_frame, from_frame_modified, time_to_lookup,
-                                 tf_transform);
-  } catch (tf::TransformException& ex) {  // NOLINT
-    ROS_ERROR_STREAM(
-        "Error getting TF transform from sensor data: " << ex.what());
-    return false;
-  }
-
-  tf::transformTFToKindr(tf_transform, transform);
-  return true;
-}
-
-bool VoxbloxNode::lookupTransformQueue(const std::string& from_frame,
-                                       const std::string& to_frame,
-                                       const ros::Time& timestamp,
-                                       Transformation* transform) {
-  // Try to match the transforms in the queue.
-  bool match_found = false;
-  std::deque<geometry_msgs::TransformStamped>::iterator it =
-      transform_queue_.begin();
-  for (; it != transform_queue_.end(); ++it) {
-    // If the current transform is newer than the requested timestamp, we need
-    // to break.
-    if (it->header.stamp > timestamp) {
-      if ((it->header.stamp - timestamp).toNSec() < timestamp_tolerance_ns_) {
-        match_found = true;
+      // only take first point when clearing
+      if (clearing_ray) {
+        break;
       }
-      break;
     }
 
-    if ((timestamp - it->header.stamp).toNSec() < timestamp_tolerance_ns_) {
-      match_found = true;
-      break;
+    const Point merged_point_G = T_G_C * merged_point_C;
+
+    RayCaster ray_caster(origin, merged_point_G, clearing_ray,
+                         config_.voxel_carving_enabled,
+                         config_.max_ray_length_m, voxel_size_inv_,
+                         config_.default_truncation_distance, false);
+
+    BlockIndex last_block_idx = BlockIndex::Zero();
+    Block<TsdfVoxel>::Ptr block;
+
+    VoxelIndex global_voxel_idx;
+    while (ray_caster.nextRayIndex(&global_voxel_idx)) {
+      if (enable_anti_grazing) {
+        // Check if this one is already the the block hash map for this
+        // insertion. Skip this to avoid grazing.
+        if ((clearing_ray || global_voxel_idx != kv.first) &&
+            voxel_map.find(global_voxel_idx) != voxel_map.end()) {
+          continue;
+        }
+      }
+
+      TsdfVoxel* voxel = getVoxel(global_voxel_idx, &block, &last_block_idx,
+                                  temp_voxel_storage);
+      if (voxel != nullptr) {
+        const Point voxel_center_G =
+            getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
+
+        updateTsdfVoxel(origin, merged_point_G, voxel_center_G, merged_color,
+                        config_.default_truncation_distance, merged_weight,
+                        voxel);
+      }
     }
   }
 
-  if (match_found) {
-    Transformation T_G_D;
-    tf::transformMsgToKindr(it->transform, &T_G_D);
-
-    // If we have a static transform, apply it too.
-    // Transform should actually be T_G_C. So need to take it through the full
-    // chain.
-    *transform = T_G_D * T_B_D_.inverse() * T_B_C_;
-
-    // And also clear the queue up to this point. This leaves the current
-    // message in place.
-    transform_queue_.erase(transform_queue_.begin(), it);
-  } else {
-    ROS_WARN_STREAM_THROTTLE(
-        30, "No match found for transform timestamp: " << timestamp);
-    if (!transform_queue_.empty()) {
-      ROS_WARN_STREAM_THROTTLE(
-          30,
-          "Queue front: " << transform_queue_.front().header.stamp
-                          << " back: " << transform_queue_.back().header.stamp);
-    }
-  }
-  return match_found;
-}
-
-bool VoxbloxNode::generateMeshCallback(
-    std_srvs::Empty::Request& request,
-    std_srvs::Empty::Response& response) {  // NOLINT
-  timing::Timer generate_mesh_timer("mesh/generate");
-  const bool clear_mesh = true;
-  if (clear_mesh) {
-    mesh_integrator_->generateWholeMesh();
-  } else {
-    const bool clear_updated_flag = true;
-    mesh_integrator_->generateMeshForUpdatedBlocks(clear_updated_flag);
-  }
-  generate_mesh_timer.Stop();
-
-  timing::Timer publish_mesh_timer("mesh/publish");
-  visualization_msgs::MarkerArray marker_array;
-  marker_array.markers.resize(1);
-  fillMarkerWithMesh(mesh_layer_, color_mode_, &marker_array.markers[0]);
-  marker_array.markers[0].header.frame_id = world_frame_;
-  mesh_pub_.publish(marker_array);
-
-  if (output_mesh_as_pointcloud_) {
-    pcl::PointCloud<pcl::PointXYZRGB> pointcloud;
-    fillPointcloudWithMesh(mesh_layer_, color_mode_, &pointcloud);
-    pointcloud.header.frame_id = world_frame_;
-    mesh_pointcloud_pub_.publish(pointcloud);
-  }
-  publish_mesh_timer.Stop();
-
-  if (output_mesh_as_pcl_mesh_) {
-    pcl::PolygonMesh polygon_mesh;
-    toPCLPolygonMesh(*mesh_layer_, world_frame_, &polygon_mesh);
-    pcl_msgs::PolygonMesh mesh_msg;
-    pcl_conversions::fromPCL(polygon_mesh, mesh_msg);
-    mesh_msg.header.stamp = ros::Time::now();
-    mesh_pcl_mesh_pub_.publish(mesh_msg);
-  }
-
-  if (!mesh_filename_.empty()) {
-    timing::Timer output_mesh_timer("mesh/output");
-    bool success = outputMeshLayerAsPly(mesh_filename_, *mesh_layer_);
-    output_mesh_timer.Stop();
-    if (success) {
-      ROS_INFO("Output file as PLY: %s", mesh_filename_.c_str());
+  void integrateVoxels(
+      const Transformation& T_G_C, const Pointcloud& points_C,
+      const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
+      const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
+      const BlockHashMapType<std::vector<size_t>>::type& clear_map, size_t tid,
+      VoxelMap* temp_voxel_storage) {
+    BlockHashMapType<std::vector<size_t>>::type::const_iterator it;
+    size_t map_size;
+    if (clearing_ray) {
+      it = clear_map.begin();
+      map_size = clear_map.size();
     } else {
-      ROS_INFO("Failed to output mesh as PLY: %s", mesh_filename_.c_str());
+      it = voxel_map.begin();
+      map_size = voxel_map.size();
+    }
+
+    for (size_t i = 0; i < map_size; ++i) {
+      if (((i + tid + 1) % config_.integrator_threads) == 0) {
+        integrateVoxel(T_G_C, points_C, colors, enable_anti_grazing,
+                       clearing_ray, *it, voxel_map, temp_voxel_storage);
+      }
+      ++it;
     }
   }
 
-  ROS_INFO_STREAM("Mesh Timings: " << std::endl << timing::Timing::Print());
-  return true;
-}
+  void integrateRays(
+      const Transformation& T_G_C, const Pointcloud& points_C,
+      const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
+      const BlockHashMapType<std::vector<size_t>>::type& voxel_map,
+      const BlockHashMapType<std::vector<size_t>>::type& clear_map) {
+    const Point& origin = T_G_C.getPosition();
 
-bool VoxbloxNode::generateEsdfCallback(
-    std_srvs::Empty::Request& request,
-    std_srvs::Empty::Response& response) {  // NOLINT
-  if (!generate_esdf_) {
-    return false;
+    std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
+
+    // if only 1 thread just do function call, otherwise spawn threads
+    if (config_.integrator_threads == 1) {
+      integrateVoxels(T_G_C, points_C, colors, enable_anti_grazing,
+                      clearing_ray, voxel_map, clear_map, 0,
+                      &(temp_voxel_storage[0]));
+    } else {
+      std::vector<std::thread> integration_threads;
+      for (size_t i = 0; i < config_.integrator_threads; ++i) {
+        integration_threads.emplace_back(
+            &MergedTsdfIntegrator::integrateVoxels, this, T_G_C, points_C,
+            colors, enable_anti_grazing, clearing_ray, voxel_map, clear_map, i,
+            &(temp_voxel_storage[i]));
+      }
+
+      for (std::thread& thread : integration_threads) {
+        thread.join();
+      }
+    }
+
+    timing::Timer insertion_timer("inserting_missed_voxels");
+    for (const VoxelMap& temp_voxels : temp_voxel_storage) {
+      updateLayerWithStoredVoxels(temp_voxels);
+    }
+    insertion_timer.Stop();
   }
-  const bool clear_esdf = true;
-  if (clear_esdf) {
-    esdf_integrator_->updateFromTsdfLayerBatch();
-  } else {
-    const bool clear_updated_flag = true;
-    esdf_integrator_->updateFromTsdfLayer(clear_updated_flag);
+};
+
+class FastTsdfIntegrator : public TsdfIntegratorBase {
+ public:
+  FastTsdfIntegrator(const Config& config, Layer<TsdfVoxel>* layer)
+      : TsdfIntegratorBase(config, layer) {}
+
+  void integrateFunction(const Transformation& T_G_C,
+                         const Pointcloud& points_C, const Colors& colors,
+                         ThreadSafeIndex* index_getter,
+                         VoxelMap* temp_voxel_storage) {
+    size_t point_idx;
+    while (index_getter->getNextIndex(&point_idx)) {
+      const Point& point_C = points_C[point_idx];
+      const Color& color = colors[point_idx];
+      bool is_clearing;
+      if (!isPointValid(point_C, &is_clearing)) {
+        continue;
+      }
+
+      const Point origin = T_G_C.getPosition();
+      const Point point_G = T_G_C * point_C;
+      // immediately check if the voxel the point is in has already been ray
+      // traced (saves time setting up ray tracer for already used points)
+      AnyIndex global_voxel_idx =
+          getGridIndexFromPoint(point_G, voxel_sub_sample_ * voxel_size_inv_);
+      if (!approx_start_tester_.replaceHash(global_voxel_idx)) {
+        continue;
+      }
+
+      RayCaster ray_caster(origin, point_G, is_clearing,
+                           config_.voxel_carving_enabled,
+                           config_.max_ray_length_m, voxel_size_inv_,
+                           config_.default_truncation_distance, false);
+
+      BlockIndex last_block_idx = BlockIndex::Zero();
+      Block<TsdfVoxel>::Ptr block;
+
+      size_t consecutive_ray_collisions = 0;
+      while (ray_caster.nextRayIndex(&global_voxel_idx)) {
+        // if all a ray is doing is follow in the path of another, stop casting
+        if (!approx_ray_tester_.replaceHash(global_voxel_idx)) {
+          ++consecutive_ray_collisions;
+        } else {
+          consecutive_ray_collisions = 0;
+        }
+        if (consecutive_ray_collisions > max_consecutive_ray_collisions_) {
+          break;
+        }
+
+        TsdfVoxel* voxel = getVoxel(global_voxel_idx, &block, &last_block_idx,
+                                    temp_voxel_storage);
+        if (voxel != nullptr) {
+          const float weight = getVoxelWeight(point_C);
+          const Point voxel_center_G =
+              getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
+
+          updateTsdfVoxel(origin, point_G, voxel_center_G, color,
+                          config_.default_truncation_distance, weight, voxel);
+        }
+      }
+    }
   }
-  publishAllUpdatedEsdfVoxels();
-  publishSlices();
-  return true;
-}
 
-bool VoxbloxNode::saveMapCallback(
-    voxblox_msgs::FilePath::Request& request,
-    voxblox_msgs::FilePath::Response& response) {  // NOLINT
-  // Will only save TSDF layer for now.
-  return io::SaveLayer(tsdf_map_->getTsdfLayer(), request.file_path);
-}
+  void integratePointCloud(const Transformation& T_G_C,
+                           const Pointcloud& points_C, const Colors& colors) {
+    std::vector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
 
-bool VoxbloxNode::loadMapCallback(
-    voxblox_msgs::FilePath::Request& request,
-    voxblox_msgs::FilePath::Response& response) {  // NOLINT
-  // Will only load TSDF layer for now.
-  return io::LoadBlocksFromFile(
-      request.file_path, Layer<TsdfVoxel>::BlockMergingStrategy::kReplace,
-      tsdf_map_->getTsdfLayerPtr());
-}
+    timing::Timer integrate_timer("integrate");
 
-void VoxbloxNode::updateMeshEvent(const ros::TimerEvent& e) {
-  if (verbose_) {
-    ROS_INFO("Updating mesh.");
-  }
-  // TODO(helenol): also update the ESDF layer each time you update the mesh.
-  if (generate_esdf_) {
-    const bool clear_updated_flag_esdf = false;
-    esdf_integrator_->updateFromTsdfLayer(clear_updated_flag_esdf);
-    publishAllUpdatedEsdfVoxels();
-  }
+    approx_ray_tester_.resetApproxSet();
+    approx_start_tester_.resetApproxSet();
 
-  timing::Timer generate_mesh_timer("mesh/update");
-  const bool clear_updated_flag = true;
-  mesh_integrator_->generateMeshForUpdatedBlocks(clear_updated_flag);
-  generate_mesh_timer.Stop();
+    ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
 
-  // TODO(helenol): also think about how to update markers incrementally?
-  timing::Timer publish_mesh_timer("mesh/publish");
-  visualization_msgs::MarkerArray marker_array;
-  marker_array.markers.resize(1);
-  fillMarkerWithMesh(mesh_layer_, color_mode_, &marker_array.markers[0]);
-  marker_array.markers[0].header.frame_id = world_frame_;
-  mesh_pub_.publish(marker_array);
+    std::vector<std::thread> integration_threads;
+    for (size_t i = 0; i < config_.integrator_threads; ++i) {
+      integration_threads.emplace_back(&FastTsdfIntegrator::integrateFunction,
+                                       this, T_G_C, points_C, colors,
+                                       &index_getter, &(temp_voxel_storage[i]));
+    }
 
-  if (output_mesh_as_pointcloud_) {
-    pcl::PointCloud<pcl::PointXYZRGB> pointcloud;
-    fillPointcloudWithMesh(mesh_layer_, color_mode_, &pointcloud);
-    pointcloud.header.frame_id = world_frame_;
-    mesh_pointcloud_pub_.publish(pointcloud);
+    for (std::thread& thread : integration_threads) {
+      thread.join();
+    }
+
+    integrate_timer.Stop();
+
+    timing::Timer insertion_timer("inserting_missed_voxels");
+    for (const VoxelMap& temp_voxels : temp_voxel_storage) {
+      updateLayerWithStoredVoxels(temp_voxels);
+    }
+    insertion_timer.Stop();
   }
 
-  publish_mesh_timer.Stop();
-}
+ private:
+  static constexpr FloatingPoint voxel_sub_sample_ = 2.0f;
+  static constexpr size_t max_consecutive_ray_collisions_ = 4;
+  static constexpr size_t masked_bits_ = 20;  // 8 mb of ram per tester
+  static constexpr size_t full_reset_threshold = 10000;
+  ApproxHashSet<masked_bits_, full_reset_threshold> approx_start_tester_;
+  ApproxHashSet<masked_bits_, full_reset_threshold> approx_ray_tester_;
+};
 
 }  // namespace voxblox
 
-int main(int argc, char** argv) {
-  ros::init(argc, argv, "voxblox_node");
-  google::InitGoogleLogging(argv[0]);
-  google::ParseCommandLineFlags(&argc, &argv, false);
-  google::InstallFailureSignalHandler();
-  ros::NodeHandle nh;
-  ros::NodeHandle nh_private("~");
-
-  voxblox::VoxbloxNode node(nh, nh_private);
-
-  ros::spin();
-  return 0;
-}
+#endif  // VOXBLOX_INTEGRATOR_TSDF_INTEGRATOR_H_

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -277,10 +277,9 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
   // Determine integrator parameters.
   TsdfIntegratorBase::Config integrator_config;
   integrator_config.voxel_carving_enabled = true;
-  // Used to be * 4 according to Marius's experience, was then * 2.
-  // It is now * 3 as this makes detecting empty mesh spaces more efficient.
+  // Used to be * 4 according to Marius's experience, was changed to *2
   // This should be made bigger again if behind-surface weighting is improved.
-  integrator_config.default_truncation_distance = config.tsdf_voxel_size * 3;
+  integrator_config.default_truncation_distance = config.tsdf_voxel_size * 2;
 
   double truncation_distance = integrator_config.default_truncation_distance;
   double max_weight = integrator_config.max_weight;

--- a/voxblox_tango_interface/CMakeLists.txt
+++ b/voxblox_tango_interface/CMakeLists.txt
@@ -50,7 +50,7 @@ cs_add_library(${PROJECT_NAME}
   ${${PROJECT_NAME}_SRCS}
   ${PROTO_SRCS}
 )
-target_link_libraries(${PROJECT_NAME} ${PROTOBUF_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${PROTOBUF_LIBRARIES} pthread)
 
 ############
 # BINARIES #

--- a/voxblox_tango_interface/test/mesh_tango_tsdf.cc
+++ b/voxblox_tango_interface/test/mesh_tango_tsdf.cc
@@ -3,8 +3,8 @@
 #include <voxblox/io/mesh_ply.h>
 #include <voxblox/mesh/mesh_integrator.h>
 
-#include "voxblox_tango_interface/io/tango_layer_io.h"
 #include "voxblox_tango_interface/core/tango_layer_interface.h"
+#include "voxblox_tango_interface/io/tango_layer_io.h"
 
 using namespace voxblox;  // NOLINT
 
@@ -12,7 +12,8 @@ int main(int argc, char** argv) {
   google::InitGoogleLogging(argv[0]);
 
   if (argc != 3) {
-    throw std::runtime_error("Args: filename to load, followed by filename to save to");
+    throw std::runtime_error(
+        "Args: filename to load, followed by filename to save to");
   }
 
   const std::string file = argv[1];
@@ -20,7 +21,8 @@ int main(int argc, char** argv) {
   TangoLayerInterface::Ptr layer_from_file;
   io::TangoLoadLayer(file, &layer_from_file);
 
-  std::cout << "Layer memory size: " << layer_from_file->getMemorySize() << "\n";
+  std::cout << "Layer memory size: " << layer_from_file->getMemorySize()
+            << "\n";
 
   // Mesh accessories.
   MeshIntegrator<TsdfVoxel>::Config mesh_config;
@@ -31,8 +33,11 @@ int main(int argc, char** argv) {
   mesh_integrator_.reset(new MeshIntegrator<TsdfVoxel>(
       mesh_config, layer_from_file.get(), mesh_layer_.get()));
 
-  mesh_integrator_->generateWholeMesh();
-  std::cout << "Number of meshes: " << mesh_layer_->getNumberOfAllocatedMeshes() << "\n";
+  constexpr bool only_mesh_updated_blocks = false;
+  constexpr bool clear_updated_flag = true;
+  mesh_integrator_->generateMesh(only_mesh_updated_blocks, clear_updated_flag);
+  std::cout << "Number of meshes: " << mesh_layer_->getNumberOfAllocatedMeshes()
+            << "\n";
   bool meshSuccess = outputMeshLayerAsPly(argv[2], *mesh_layer_);
 
   if (meshSuccess == false) {


### PR DESCRIPTION
Almost certainly not ready for merging, but I will probably refer to the pr when talking about some of the more questionable hacks in it.

![peek 2017-08-07 23-05](https://user-images.githubusercontent.com/730680/29046058-212d252a-7bc6-11e7-9b21-6e5f497b21a8.gif)

Long story short this pull request makes the fast integrator 5x slower, but a hell of a lot prettier. It also threads it and the concurrency is good enough that we are only a bit slower then before.

Meshing is also over 10x faster as we were previously computing unneeded normals.
Most publishing can now be disabled as this bottlenecks high res maps.

Oh my tests we now get a reliable 5Hz on 2cm voxels with voxel carving on.