### PR TITLE
Fix/brute force eigen alignment fix

### DIFF
--- a/voxblox/include/voxblox/core/block_hash.h
+++ b/voxblox/include/voxblox/core/block_hash.h
@@ -12,6 +12,8 @@
 namespace voxblox {
 
 struct AnyIndexHash {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   static constexpr size_t prime1 = 73856093;
   static constexpr size_t prime2 = 19349663;
   static constexpr size_t prime3 = 83492791;
@@ -24,6 +26,8 @@ struct AnyIndexHash {
 
 template <typename ValueType>
 struct AnyIndexHashMapType {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::unordered_map<
       BlockIndex, ValueType, AnyIndexHash, std::equal_to<BlockIndex>,
       Eigen::aligned_allocator<std::pair<const BlockIndex, ValueType> > >

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -1,6 +1,7 @@
 #ifndef VOXBLOX_CORE_COMMON_H_
 #define VOXBLOX_CORE_COMMON_H_
 
+#include <deque>
 #include <memory>
 #include <set>
 #include <unordered_map>
@@ -13,6 +14,19 @@
 #include <Eigen/Core>
 
 namespace voxblox {
+
+// Aligned Eigen containers
+template <typename Type>
+using AlignedVector = std::vector<Type, Eigen::aligned_allocator<Type>>;
+template <typename Type>
+using AlignedDeque = std::deque<Type, Eigen::aligned_allocator<Type>>;
+
+template <typename Type, typename... Arguments>
+inline std::shared_ptr<Type> aligned_shared(Arguments&&... arguments) {
+  typedef typename std::remove_const<Type>::type TypeNonConst;
+  return std::allocate_shared<Type>(Eigen::aligned_allocator<TypeNonConst>(),
+                                    std::forward<Arguments>(arguments)...);
+}
 
 // Types.
 typedef double FloatingPoint;
@@ -27,7 +41,7 @@ typedef AnyIndex BlockIndex;
 
 typedef std::pair<BlockIndex, VoxelIndex> VoxelKey;
 
-typedef std::vector<AnyIndex, Eigen::aligned_allocator<AnyIndex>> IndexVector;
+typedef AlignedVector<AnyIndex> IndexVector;
 typedef IndexVector BlockIndexList;
 typedef IndexVector VoxelIndexList;
 
@@ -35,16 +49,15 @@ struct Color;
 typedef uint32_t Label;
 
 // Pointcloud types for external interface.
-typedef std::vector<Point, Eigen::aligned_allocator<Point>> Pointcloud;
-typedef std::vector<Color> Colors;
-typedef std::vector<Label> Labels;
+typedef AlignedVector<Point> Pointcloud;
+typedef AlignedVector<Color> Colors;
+typedef AlignedVector<Label> Labels;
 
 // For triangle meshing/vertex access.
 typedef size_t VertexIndex;
-typedef std::vector<VertexIndex> VertexIndexList;
+typedef AlignedVector<VertexIndex> VertexIndexList;
 typedef Eigen::Matrix<FloatingPoint, 3, 3> Triangle;
-typedef std::vector<Triangle, Eigen::aligned_allocator<Triangle>>
-    TriangleVector;
+typedef AlignedVector<Triangle> TriangleVector;
 
 // Transformation type for defining sensor orientation.
 typedef kindr::minimal::QuatTransformationTemplate<FloatingPoint>
@@ -194,12 +207,6 @@ inline float probabilityFromLogOdds(float log_odds) {
   return 1.0 - (1.0 / (1.0 + exp(log_odds)));
 }
 
-template <typename Type, typename... Arguments>
-inline std::shared_ptr<Type> aligned_shared(Arguments&&... arguments) {
-  typedef typename std::remove_const<Type>::type TypeNonConst;
-  return std::allocate_shared<Type>(Eigen::aligned_allocator<TypeNonConst>(),
-                                    std::forward<Arguments>(arguments)...);
-}
 }  // namespace voxblox
 
 #endif  // VOXBLOX_CORE_COMMON_H_

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -2,8 +2,11 @@
 #define VOXBLOX_CORE_COMMON_H_
 
 #include <deque>
+#include <list>
 #include <memory>
+#include <queue>
 #include <set>
+#include <stack>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -20,6 +23,12 @@ template <typename Type>
 using AlignedVector = std::vector<Type, Eigen::aligned_allocator<Type>>;
 template <typename Type>
 using AlignedDeque = std::deque<Type, Eigen::aligned_allocator<Type>>;
+template <typename Type>
+using AlignedQueue = std::queue<Type, AlignedDeque<Type>>;
+template <typename Type>
+using AlignedStack = std::stack<Type, AlignedDeque<Type>>;
+template <typename Type>
+using AlignedList = std::list<Type, Eigen::aligned_allocator<Type>>;
 
 template <typename Type, typename... Arguments>
 inline std::shared_ptr<Type> aligned_shared(Arguments&&... arguments) {

--- a/voxblox/include/voxblox/core/esdf_map.h
+++ b/voxblox/include/voxblox/core/esdf_map.h
@@ -3,6 +3,7 @@
 
 #include <glog/logging.h>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "voxblox/core/common.h"
@@ -16,9 +17,13 @@ namespace voxblox {
 
 class EsdfMap {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::shared_ptr<EsdfMap> Ptr;
 
   struct Config {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     FloatingPoint esdf_voxel_size = 0.2;
     size_t esdf_voxels_per_side = 16u;
   };
@@ -45,7 +50,7 @@ class EsdfMap {
 
   // Creates a new EsdfMap based on a COPY of this layer.
   explicit EsdfMap(const Layer<EsdfVoxel>& layer)
-      : EsdfMap(std::make_shared<Layer<EsdfVoxel>>(layer)) {}
+      : EsdfMap(aligned_shared<Layer<EsdfVoxel>>(layer)) {}
 
   // Creates a new EsdfMap that contains this layer.
   explicit EsdfMap(Layer<EsdfVoxel>::Ptr layer)

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -17,6 +17,8 @@ namespace voxblox {
 template <typename VoxelType>
 class Layer {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::shared_ptr<Layer> Ptr;
   typedef Block<VoxelType> BlockType;
   typedef

--- a/voxblox/include/voxblox/core/occupancy_map.h
+++ b/voxblox/include/voxblox/core/occupancy_map.h
@@ -13,9 +13,13 @@ namespace voxblox {
 
 class OccupancyMap {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::shared_ptr<OccupancyMap> Ptr;
 
   struct Config {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     FloatingPoint occupancy_voxel_size = 0.2;
     size_t occupancy_voxels_per_side = 16u;
   };
@@ -29,7 +33,7 @@ class OccupancyMap {
 
   // Creates a new OccupancyMap based on a COPY of this layer.
   explicit OccupancyMap(const Layer<OccupancyVoxel>& layer)
-      : OccupancyMap(std::make_shared<Layer<OccupancyVoxel>>(layer)) {}
+      : OccupancyMap(aligned_shared<Layer<OccupancyVoxel>>(layer)) {}
 
   // Creates a new OccupancyMap that contains this layer.
   explicit OccupancyMap(Layer<OccupancyVoxel>::Ptr layer)

--- a/voxblox/include/voxblox/core/tsdf_map.h
+++ b/voxblox/include/voxblox/core/tsdf_map.h
@@ -13,9 +13,13 @@ namespace voxblox {
 
 class TsdfMap {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::shared_ptr<TsdfMap> Ptr;
 
   struct Config {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     FloatingPoint tsdf_voxel_size = 0.2;
     size_t tsdf_voxels_per_side = 16u;
   };
@@ -28,7 +32,7 @@ class TsdfMap {
 
   // Creates a new TsdfMap based on a COPY of this layer.
   explicit TsdfMap(const Layer<TsdfVoxel>& layer)
-      : TsdfMap(std::make_shared<Layer<TsdfVoxel>>(layer)) {}
+      : TsdfMap(aligned_shared<Layer<TsdfVoxel>>(layer)) {}
 
   // Creates a new TsdfMap that contains this layer.
   explicit TsdfMap(Layer<TsdfVoxel>::Ptr layer) : tsdf_layer_(layer) {

--- a/voxblox/include/voxblox/core/voxel.h
+++ b/voxblox/include/voxblox/core/voxel.h
@@ -2,13 +2,16 @@
 #define VOXBLOX_CORE_VOXEL_H_
 
 #include <cstdint>
+#include <string>
 
-#include "voxblox/core/common.h"
 #include "voxblox/core/color.h"
+#include "voxblox/core/common.h"
 
 namespace voxblox {
 
 struct TsdfVoxel {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   float distance = 0.0f;
   float weight = 0.0f;
   Color color;
@@ -27,16 +30,18 @@ struct EsdfVoxel {
 };
 
 struct OccupancyVoxel {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   float probability_log = 0.0f;
   bool observed = false;
 };
 
 // Used for serialization only.
 namespace voxel_types {
-  const std::string kNotSerializable = "not_serializable";
-  const std::string kTsdf = "tsdf";
-  const std::string kEsdf = "esdf";
-  const std::string kOccupancy = "occupancy";
+const std::string kNotSerializable = "not_serializable";
+const std::string kTsdf = "tsdf";
+const std::string kEsdf = "esdf";
+const std::string kOccupancy = "occupancy";
 }  // namespace voxel_types
 
 template <typename Type>

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -123,7 +123,7 @@ class EsdfIntegrator {
   void clear() {
     updated_blocks_.clear();
     open_.clear();
-    raise_ = std::queue<VoxelKey>();
+    raise_ = AlignedQueue<VoxelKey>();
   }
 
  protected:
@@ -144,7 +144,7 @@ class EsdfIntegrator {
   // Raise set for updates; these are values that used to be in the fixed
   // frontier and now have a higher value, or their children which need to
   // have their values invalidated.
-  std::queue<VoxelKey> raise_;
+  AlignedQueue<VoxelKey> raise_;
 
   size_t esdf_voxels_per_side_;
   FloatingPoint esdf_voxel_size_;

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -100,11 +100,10 @@ class EsdfIntegrator {
   // Directions is the direction that the neighbor voxel lives in. If you
   // need the direction FROM the neighbor voxel TO the current voxel, take
   // negative of the given direction.
-  void getNeighborsAndDistances(const BlockIndex& block_index,
-                                const VoxelIndex& voxel_index,
-                                std::vector<VoxelKey>* neighbors,
-                                std::vector<float>* distances,
-                                std::vector<Eigen::Vector3i>* directions) const;
+  void getNeighborsAndDistances(
+      const BlockIndex& block_index, const VoxelIndex& voxel_index,
+      AlignedVector<VoxelKey>* neighbors, AlignedVector<float>* distances,
+      AlignedVector<Eigen::Vector3i>* directions) const;
   // Get a single neighbor in a particular direction.
   void getNeighbor(const BlockIndex& block_index, const VoxelIndex& voxel_index,
                    const Eigen::Vector3i& direction,

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -20,7 +20,11 @@ namespace voxblox {
 // https://arxiv.org/abs/1611.03631
 class EsdfIntegrator {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   struct Config {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     // Maximum distance to calculate the actual distance to.
     // Any values above this will be set to default_distance_m.
     FloatingPoint max_distance_m = 2.0;

--- a/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
@@ -69,7 +69,7 @@ class EsdfOccIntegrator {
   // Raise set for updates; these are values that used to be in the fixed
   // frontier and now have a higher value, or their children which need to have
   // their values invalidated.
-  std::queue<VoxelKey> raise_;
+  AlignedQueue<VoxelKey> raise_;
 
   size_t esdf_voxels_per_side_;
   FloatingPoint esdf_voxel_size_;

--- a/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
@@ -47,11 +47,10 @@ class EsdfOccIntegrator {
   // Directions is the direction that the neighbor voxel lives in. If you
   // need the direction FROM the neighbor voxel TO the current voxel, take
   // negative of the given direction.
-  void getNeighborsAndDistances(const BlockIndex& block_index,
-                                const VoxelIndex& voxel_index,
-                                std::vector<VoxelKey>* neighbors,
-                                std::vector<float>* distances,
-                                std::vector<Eigen::Vector3i>* directions) const;
+  void getNeighborsAndDistances(
+      const BlockIndex& block_index, const VoxelIndex& voxel_index,
+      AlignedVector<VoxelKey>* neighbors, AlignedVector<float>* distances,
+      AlignedVector<Eigen::Vector3i>* directions) const;
   void getNeighbor(const BlockIndex& block_index, const VoxelIndex& voxel_index,
                    const Eigen::Vector3i& direction,
                    BlockIndex* neighbor_block_index,

--- a/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
@@ -18,7 +18,11 @@ namespace voxblox {
 
 class EsdfOccIntegrator {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   struct Config {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     // Maximum distance to calculate the actual distance to.
     // Any values above this will be set to default_distance_m.
     FloatingPoint max_distance_m = 2.0;

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -171,9 +171,8 @@ class RayCaster {
 // This function assumes PRE-SCALED coordinates, where one unit = one voxel
 // size. The indices are also returned in this scales coordinate system, which
 // should map to voxel indices.
-inline void castRay(
-    const Point& start_scaled, const Point& end_scaled,
-    std::vector<AnyIndex, Eigen::aligned_allocator<AnyIndex> >* indices) {
+inline void castRay(const Point& start_scaled, const Point& end_scaled,
+                    AlignedVector<AnyIndex>* indices) {
   CHECK_NOTNULL(indices);
 
   RayCaster ray_caster(start_scaled, end_scaled);

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -19,6 +19,8 @@ namespace voxblox {
 // time a thread must wait on a lock is minimized.
 class ThreadSafeIndex {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   ThreadSafeIndex(const size_t number_of_points, const size_t number_of_threads)
       : number_of_points_(number_of_points),
         number_of_threads_(number_of_threads),
@@ -64,6 +66,8 @@ class ThreadSafeIndex {
 // map to voxel indices.
 class RayCaster {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   RayCaster(const Point& origin, const Point& point_G,
             const bool is_clearing_ray, const bool voxel_carving_enabled,
             const FloatingPoint max_ray_length_m,

--- a/voxblox/include/voxblox/integrator/merge_integrator.h
+++ b/voxblox/include/voxblox/integrator/merge_integrator.h
@@ -16,6 +16,8 @@ namespace voxblox {
 
 class MergeIntegrator {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   // all methods are static so the class does not need a constructor
   MergeIntegrator() = delete;
 

--- a/voxblox/include/voxblox/integrator/occupancy_integrator.h
+++ b/voxblox/include/voxblox/integrator/occupancy_integrator.h
@@ -17,7 +17,11 @@ namespace voxblox {
 
 class OccupancyIntegrator {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   struct Config {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     float probability_hit = 0.65f;
     float probability_miss = 0.4f;
     float threshold_min = 0.12f;

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -31,9 +31,13 @@ namespace voxblox {
 // accessed by other threads.
 class TsdfIntegratorBase {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef AnyIndexHashMapType<TsdfVoxel>::type VoxelMap;
 
   struct Config {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     float default_truncation_distance = 0.1;
     float max_weight = 10000.0;
     bool voxel_carving_enabled = true;
@@ -122,6 +126,8 @@ class TsdfIntegratorBase {
 
 class SimpleTsdfIntegrator : public TsdfIntegratorBase {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   SimpleTsdfIntegrator(const Config& config, Layer<TsdfVoxel>* layer)
       : TsdfIntegratorBase(config, layer) {}
 
@@ -136,6 +142,8 @@ class SimpleTsdfIntegrator : public TsdfIntegratorBase {
 
 class MergedTsdfIntegrator : public TsdfIntegratorBase {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   MergedTsdfIntegrator(const Config& config, Layer<TsdfVoxel>* layer)
       : TsdfIntegratorBase(config, layer) {}
 
@@ -172,6 +180,8 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
 
 class FastTsdfIntegrator : public TsdfIntegratorBase {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   FastTsdfIntegrator(const Config& config, Layer<TsdfVoxel>* layer)
       : TsdfIntegratorBase(config, layer) {}
 

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -154,28 +154,28 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
   inline void bundleRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, ThreadSafeIndex* index_getter,
-      AnyIndexHashMapType<std::vector<size_t>>::type* voxel_map,
-      AnyIndexHashMapType<std::vector<size_t>>::type* clear_map);
+      AnyIndexHashMapType<AlignedVector<size_t>>::type* voxel_map,
+      AnyIndexHashMapType<AlignedVector<size_t>>::type* clear_map);
 
   void integrateVoxel(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
-      const std::pair<AnyIndex, std::vector<size_t>>& kv,
-      const AnyIndexHashMapType<std::vector<size_t>>::type& voxel_map,
+      const std::pair<AnyIndex, AlignedVector<size_t>>& kv,
+      const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
       VoxelMap* temp_voxel_storage);
 
   void integrateVoxels(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
-      const AnyIndexHashMapType<std::vector<size_t>>::type& voxel_map,
-      const AnyIndexHashMapType<std::vector<size_t>>::type& clear_map,
+      const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
+      const AnyIndexHashMapType<AlignedVector<size_t>>::type& clear_map,
       size_t thread_idx, VoxelMap* temp_voxel_storage);
 
   void integrateRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
-      const AnyIndexHashMapType<std::vector<size_t>>::type& voxel_map,
-      const AnyIndexHashMapType<std::vector<size_t>>::type& clear_map);
+      const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
+      const AnyIndexHashMapType<AlignedVector<size_t>>::type& clear_map);
 };
 
 class FastTsdfIntegrator : public TsdfIntegratorBase {

--- a/voxblox/include/voxblox/interpolator/interpolator.h
+++ b/voxblox/include/voxblox/interpolator/interpolator.h
@@ -12,6 +12,8 @@ namespace voxblox {
 template <typename VoxelType>
 class Interpolator {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::shared_ptr<Interpolator> Ptr;
 
   explicit Interpolator(const Layer<VoxelType>* layer);

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -194,8 +194,7 @@ typename Layer<VoxelType>::Ptr LoadOrCreateLayerHeader(
   if (success) {
     layer_ptr = aligned_shared<Layer<VoxelType> >(layer_proto);
   } else {
-    layer_ptr =
-        std::make_shared<Layer<VoxelType> >(voxel_size, voxels_per_side);
+    layer_ptr = aligned_shared<Layer<VoxelType> >(voxel_size, voxels_per_side);
   }
   CHECK(layer_ptr);
 

--- a/voxblox/include/voxblox/io/ply_writer.h
+++ b/voxblox/include/voxblox/io/ply_writer.h
@@ -15,6 +15,8 @@ namespace io {
 //  http://paulbourke.net/dataformats/ply/
 class PlyWriter {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   explicit PlyWriter(const std::string& filename)
       : header_written_(false),
         parameters_set_(false),

--- a/voxblox/include/voxblox/mesh/marching_cubes.h
+++ b/voxblox/include/voxblox/mesh/marching_cubes.h
@@ -29,6 +29,8 @@ namespace voxblox {
 
 class MarchingCubes {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   static int kTriangleTable[256][16];
   static int kEdgeIndexPairs[12][2];
 

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -92,7 +92,7 @@ class MeshIntegrator {
     ThreadSafeIndex index_getter(all_tsdf_blocks.size(),
                                  config_.integrator_threads);
 
-    std::vector<std::thread> integration_threads;
+    AlignedVector<std::thread> integration_threads;
     for (size_t i = 0; i < config_.integrator_threads; ++i) {
       integration_threads.emplace_back(
           &MeshIntegrator::generateMeshBlocksFunction, this, all_tsdf_blocks,

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -43,7 +43,11 @@ namespace voxblox {
 template <typename VoxelType>
 class MeshIntegrator {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   struct Config {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     bool use_color = true;
     float min_weight = 1e-4;
     size_t integrator_threads = std::thread::hardware_concurrency();

--- a/voxblox/include/voxblox/mesh/mesh_layer.h
+++ b/voxblox/include/voxblox/mesh/mesh_layer.h
@@ -14,6 +14,8 @@ namespace voxblox {
 // as a layer of blocks, but only contains a single thing, not a set of voxels.
 class MeshLayer {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::shared_ptr<MeshLayer> Ptr;
   typedef std::shared_ptr<const MeshLayer> ConstPtr;
   typedef typename AnyIndexHashMapType<Mesh::Ptr>::type MeshMap;

--- a/voxblox/include/voxblox/simulation/objects.h
+++ b/voxblox/include/voxblox/simulation/objects.h
@@ -15,6 +15,8 @@ namespace voxblox {
 // Should this be full virtual?
 class Object {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   // A wall is an infinite plane.
   enum Type { kSphere = 0, kCube, kPlane, kCylinder };
 
@@ -47,6 +49,8 @@ class Object {
 
 class Sphere : public Object {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Sphere(const Point& center, FloatingPoint radius)
       : Object(center, Type::kSphere), radius_(radius) {}
   Sphere(const Point& center, FloatingPoint radius, const Color& color)
@@ -98,6 +102,8 @@ class Sphere : public Object {
 
 class Cube : public Object {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Cube(const Point& center, const Point& size)
       : Object(center, Type::kCube), size_(size) {}
   Cube(const Point& center, const Point& size, const Color& color)
@@ -195,6 +201,8 @@ class Cube : public Object {
 // Requires normal being passed in to ALREADY BE NORMALIZED!!!!
 class Plane : public Object {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Plane(const Point& center, const Point& normal)
       : Object(center, Type::kPlane), normal_(normal) {}
   Plane(const Point& center, const Point& normal, const Color& color)
@@ -244,6 +252,8 @@ class Plane : public Object {
 
 class Cylinder : public Object {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Cylinder(const Point& center, FloatingPoint radius, FloatingPoint height)
       : Object(center, Type::kCylinder), radius_(radius), height_(height) {}
   Cylinder(const Point& center, FloatingPoint radius, FloatingPoint height,

--- a/voxblox/include/voxblox/simulation/simulation_world.h
+++ b/voxblox/include/voxblox/simulation/simulation_world.h
@@ -12,6 +12,8 @@ namespace voxblox {
 
 class SimulationWorld {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   SimulationWorld();
   virtual ~SimulationWorld() {}
 

--- a/voxblox/include/voxblox/simulation/simulation_world.h
+++ b/voxblox/include/voxblox/simulation/simulation_world.h
@@ -65,7 +65,7 @@ class SimulationWorld {
   void setVoxel(FloatingPoint dist, const Color& color, VoxelType* voxel) const;
 
   // Vector storing pointers to all the objects in this world.
-  std::vector<std::unique_ptr<Object> > objects_;
+  AlignedVector<std::unique_ptr<Object> > objects_;
 
   // World boundaries... Can be changed arbitrarily, just sets ground truth
   // generation and visualization bounds, accurate only up to block size.

--- a/voxblox/include/voxblox/test/layer_test_utils.h
+++ b/voxblox/include/voxblox/test/layer_test_utils.h
@@ -12,6 +12,8 @@ namespace test {
 template <typename VoxelType>
 class LayerTest {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   void CompareLayers(const Layer<VoxelType>& layer_A,
                      const Layer<VoxelType>& layer_B) const {
     EXPECT_NEAR(layer_A.voxel_size(), layer_B.voxel_size(), kTolerance);

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -29,6 +29,8 @@ namespace voxblox {
 template <size_t unmasked_bits, typename StoredElement>
 class ApproxHashArray {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   StoredElement& get(const size_t& hash) {
     return pseudo_map_[hash & bit_mask_];
   }
@@ -65,6 +67,8 @@ class ApproxHashArray {
 template <size_t unmasked_bits, size_t full_reset_threshold>
 class ApproxHashSet {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   ApproxHashSet() : reset_counter_(0) {
     pseudo_set_ptr_ = &pseudo_set_[reset_counter_++];
 

--- a/voxblox/include/voxblox/utils/bucket_queue.h
+++ b/voxblox/include/voxblox/utils/bucket_queue.h
@@ -2,6 +2,7 @@
 #define VOXBLOX_UTILS_BUCKET_QUEUE_H_
 
 #include <glog/logging.h>
+#include <deque>
 #include <queue>
 #include <vector>
 
@@ -12,6 +13,8 @@
 template <typename T>
 class BucketQueue {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   BucketQueue() : last_bucket_index_(0) {}
   explicit BucketQueue(int num_buckets, double max_val)
       : num_buckets_(num_buckets),

--- a/voxblox/include/voxblox/utils/bucket_queue.h
+++ b/voxblox/include/voxblox/utils/bucket_queue.h
@@ -6,6 +6,8 @@
 #include <queue>
 #include <vector>
 
+#include "voxblox/core/common.h"
+
 // Bucketed priority queue, mostly following L. Yatziv et al in
 // O(N) Implementation of the Fast Marching Algorithm, though skipping the
 // circular aspect (don't care about a bit more memory used for this).
@@ -86,7 +88,8 @@ class BucketQueue {
  private:
   int num_buckets_;
   double max_val_;
-  std::vector<std::queue<T, std::deque<T, Eigen::aligned_allocator<T>>>>
+  voxblox::AlignedVector<
+      std::queue<T, std::deque<T, Eigen::aligned_allocator<T>>>>
       buckets_;
 
   // Speed up retrivals.

--- a/voxblox/include/voxblox/utils/bucket_queue.h
+++ b/voxblox/include/voxblox/utils/bucket_queue.h
@@ -88,9 +88,7 @@ class BucketQueue {
  private:
   int num_buckets_;
   double max_val_;
-  voxblox::AlignedVector<
-      std::queue<T, std::deque<T, Eigen::aligned_allocator<T>>>>
-      buckets_;
+  voxblox::AlignedVector<voxblox::AlignedQueue<T>> buckets_;
 
   // Speed up retrivals.
   int last_bucket_index_;

--- a/voxblox/include/voxblox/utils/camera_model.h
+++ b/voxblox/include/voxblox/utils/camera_model.h
@@ -7,6 +7,8 @@
 #include <kindr/minimal/quat-transformation.h>
 #include <Eigen/Core>
 
+#include "voxblox/core/common.h"
+
 namespace voxblox {
 
 // Transformation type for defining sensor orientation.
@@ -74,11 +76,11 @@ class CameraModel {
 
   // The original vertices of the frustum, in the axis-aligned coordinate frame
   // (before rotation).
-  std::vector<Eigen::Vector3d> untransformed_corners_;
+  AlignedVector<Eigen::Vector3d> untransformed_corners_;
 
   // The 6 bounding planes for the current camera pose, and their corresponding
   // AABB (Axis Aligned Bounding Box).
-  std::vector<Plane> bounding_planes_;
+  AlignedVector<Plane> bounding_planes_;
   Eigen::Vector3d aabb_min_;
   Eigen::Vector3d aabb_max_;
 };

--- a/voxblox/include/voxblox/utils/camera_model.h
+++ b/voxblox/include/voxblox/utils/camera_model.h
@@ -17,6 +17,8 @@ typedef kindr::minimal::RotationQuaternionTemplate<double> Rotation;
 // distance calculations to points.
 class Plane {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Plane() : normal_(Eigen::Vector3d::Identity()), distance_(0) {}
   virtual ~Plane() {}
 
@@ -37,6 +39,8 @@ class Plane {
 
 class CameraModel {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   CameraModel() : initialized_(false) {}
   virtual ~CameraModel() {}
 

--- a/voxblox/include/voxblox/utils/timing.h
+++ b/voxblox/include/voxblox/utils/timing.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include <Eigen/Core>
+
 namespace voxblox {
 
 namespace timing {
@@ -35,6 +37,8 @@ namespace timing {
 template <typename T, typename Total, int N>
 class Accumulator {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Accumulator()
       : window_samples_(0),
         totalsamples_(0),
@@ -111,8 +115,11 @@ struct TimerMapValue {
 // timing. Because all of the functions are inline, they should just disappear.
 class DummyTimer {
  public:
-  DummyTimer(size_t /*handle*/, bool /*constructStopped*/ = false) {}
-  DummyTimer(std::string const& /*tag*/, bool /*constructStopped*/ = false) {}
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  explicit DummyTimer(size_t /*handle*/, bool /*constructStopped*/ = false) {}
+  explicit DummyTimer(std::string const& /*tag*/,
+                      bool /*constructStopped*/ = false) {}
   ~DummyTimer() {}
 
   void Start() {}
@@ -122,6 +129,8 @@ class DummyTimer {
 
 class Timer {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Timer(size_t handle, bool constructStopped = false);
   Timer(std::string const& tag, bool constructStopped = false);
   ~Timer();
@@ -139,6 +148,8 @@ class Timer {
 
 class Timing {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::map<std::string, size_t> map_t;
   friend class Timer;
   // Definition of static functions to query the timers.

--- a/voxblox/include/voxblox/utils/timing.h
+++ b/voxblox/include/voxblox/utils/timing.h
@@ -28,7 +28,7 @@
 #include <string>
 #include <vector>
 
-#include <Eigen/Core>
+#include "voxblox/core/common.h"
 
 namespace voxblox {
 
@@ -183,7 +183,7 @@ class Timing {
   Timing();
   ~Timing();
 
-  typedef std::vector<TimerMapValue> list_t;
+  typedef AlignedVector<TimerMapValue> list_t;
 
   list_t timers_;
   map_t tagMap_;

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -440,9 +440,9 @@ void EsdfIntegrator::updateFromTsdfBlocksAsOccupancy(
 
 void EsdfIntegrator::pushNeighborsToOpen(const BlockIndex& block_index,
                                          const VoxelIndex& voxel_index) {
-  std::vector<VoxelKey> neighbors;
-  std::vector<float> distances;
-  std::vector<Eigen::Vector3i> directions;
+  AlignedVector<VoxelKey> neighbors;
+  AlignedVector<float> distances;
+  AlignedVector<Eigen::Vector3i> directions;
   getNeighborsAndDistances(block_index, voxel_index, &neighbors, &distances,
                            &directions);
 
@@ -486,9 +486,9 @@ void EsdfIntegrator::processRaiseSet() {
         esdf_layer_->getBlockPtrByIndex(kv.first);
 
     // See if you can update the neighbors.
-    std::vector<VoxelKey> neighbors;
-    std::vector<float> distances;
-    std::vector<Eigen::Vector3i> directions;
+    AlignedVector<VoxelKey> neighbors;
+    AlignedVector<float> distances;
+    AlignedVector<Eigen::Vector3i> directions;
     getNeighborsAndDistances(kv.first, kv.second, &neighbors, &distances,
                              &directions);
 
@@ -566,9 +566,9 @@ void EsdfIntegrator::processOpenSet() {
       continue;
     }
     // See if you can update the neighbors.
-    std::vector<VoxelKey> neighbors;
-    std::vector<float> distances;
-    std::vector<Eigen::Vector3i> directions;
+    AlignedVector<VoxelKey> neighbors;
+    AlignedVector<float> distances;
+    AlignedVector<Eigen::Vector3i> directions;
     getNeighborsAndDistances(kv.first, kv.second, &neighbors, &distances,
                              &directions);
 
@@ -712,9 +712,9 @@ void EsdfIntegrator::processOpenSetFullEuclidean() {
         esdf_voxel.distance - esdf_voxel.parent.norm() * esdf_voxel_size_;
 
     // See if you can update the neighbors.
-    std::vector<VoxelKey> neighbors;
-    std::vector<float> distances;
-    std::vector<Eigen::Vector3i> directions;
+    AlignedVector<VoxelKey> neighbors;
+    AlignedVector<float> distances;
+    AlignedVector<Eigen::Vector3i> directions;
     getNeighborsAndDistances(kv.first, kv.second, &neighbors, &distances,
                              &directions);
 
@@ -793,8 +793,8 @@ void EsdfIntegrator::processOpenSetFullEuclidean() {
 // negative of the given direction.
 void EsdfIntegrator::getNeighborsAndDistances(
     const BlockIndex& block_index, const VoxelIndex& voxel_index,
-    std::vector<VoxelKey>* neighbors, std::vector<float>* distances,
-    std::vector<Eigen::Vector3i>* directions) const {
+    AlignedVector<VoxelKey>* neighbors, AlignedVector<float>* distances,
+    AlignedVector<Eigen::Vector3i>* directions) const {
   CHECK_NOTNULL(neighbors);
   CHECK_NOTNULL(distances);
   CHECK_NOTNULL(directions);

--- a/voxblox/src/integrator/esdf_occ_integrator.cc
+++ b/voxblox/src/integrator/esdf_occ_integrator.cc
@@ -125,9 +125,9 @@ void EsdfOccIntegrator::processOpenSet() {
       continue;
     }
     // See if you can update the neighbors.
-    std::vector<VoxelKey> neighbors;
-    std::vector<float> distances;
-    std::vector<Eigen::Vector3i> directions;
+    AlignedVector<VoxelKey> neighbors;
+    AlignedVector<float> distances;
+    AlignedVector<Eigen::Vector3i> directions;
     getNeighborsAndDistances(kv.first, kv.second, &neighbors, &distances,
                              &directions);
 
@@ -201,8 +201,8 @@ void EsdfOccIntegrator::processOpenSet() {
 // negative of the given direction.
 void EsdfOccIntegrator::getNeighborsAndDistances(
     const BlockIndex& block_index, const VoxelIndex& voxel_index,
-    std::vector<VoxelKey>* neighbors, std::vector<float>* distances,
-    std::vector<Eigen::Vector3i>* directions) const {
+    AlignedVector<VoxelKey>* neighbors, AlignedVector<float>* distances,
+    AlignedVector<Eigen::Vector3i>* directions) const {
   CHECK_NOTNULL(neighbors);
   CHECK_NOTNULL(distances);
   CHECK_NOTNULL(directions);

--- a/voxblox/src/io/mesh_ply.cc
+++ b/voxblox/src/io/mesh_ply.cc
@@ -27,7 +27,7 @@ namespace voxblox {
 bool outputMeshLayerAsPly(const std::string& filename,
                           const MeshLayer& mesh_layer) {
   Mesh::Ptr combined_mesh =
-      std::make_shared<Mesh>(mesh_layer.block_size(), Point::Zero());
+      aligned_shared<Mesh>(mesh_layer.block_size(), Point::Zero());
   mesh_layer.combineMesh(combined_mesh);
 
   bool success = outputMeshAsPly(filename, *combined_mesh);

--- a/voxblox/src/utils/camera_model.cc
+++ b/voxblox/src/utils/camera_model.cc
@@ -112,7 +112,7 @@ void CameraModel::calculateBoundingPlanes() {
     bounding_planes_.resize(6);
   }
 
-  std::vector<Eigen::Vector3d> transformed_corners;
+  AlignedVector<Eigen::Vector3d> transformed_corners;
   transformed_corners.resize(untransformed_corners_.size());
 
   // Transform all the points.

--- a/voxblox/test/test_approx_hash_array.cc
+++ b/voxblox/test/test_approx_hash_array.cc
@@ -31,7 +31,7 @@ TEST_F(ApproxHashArrayTest, ArrayRandomWriteRead) {
   ApproxHashArray<16, size_t> approx_hash_array;
 
   // generate 1000 random elements
-  std::vector<AnyIndex> rand_indexes;
+  AlignedVector<AnyIndex> rand_indexes;
   std::mt19937 gen(1);
   std::uniform_int_distribution<> dis(1, 1000000);
   for (int i = 0; i < 1000; ++i) {
@@ -63,7 +63,7 @@ TEST_F(ApproxHashArrayTest, SetRandomWriteRead) {
   ApproxHashSet<16, 10> approx_hash_set;
 
   // generate 1000 random elements
-  std::vector<AnyIndex> rand_indexes;
+  AlignedVector<AnyIndex> rand_indexes;
   std::mt19937 gen(1);
   std::uniform_int_distribution<> dis(1, 1000000);
   for (int i = 0; i < 1000; ++i) {

--- a/voxblox/test/test_tsdf_interpolator.cc
+++ b/voxblox/test/test_tsdf_interpolator.cc
@@ -145,7 +145,7 @@ TEST_F(TsdfMergeIntegratorTest, BetweenBlocks) {
   Interpolator<TsdfVoxel> interpolator(&tsdf_layer);
 
   // Points to interpolate (below origin block)
-  std::vector<Point> points_below;
+  AlignedVector<Point> points_below;
   points_below.push_back(Point(1.0, 1.0, 0.5));
   points_below.push_back(Point(1.0, 1.0, 0.25));
   points_below.push_back(Point(1.0, 1.0, 0.0));

--- a/voxblox/test/test_tsdf_map.cc
+++ b/voxblox/test/test_tsdf_map.cc
@@ -12,7 +12,7 @@ class TsdfMapTest : public ::testing::Test {
     TsdfMap::Config config;
     config.tsdf_voxel_size = 0.1f;
     config.tsdf_voxels_per_side = 8u;
-    map_ = std::make_shared<TsdfMap>(config);
+    map_ = aligned_shared<TsdfMap>(config);
   }
 
   TsdfMap::Ptr map_;

--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -11,6 +11,8 @@ namespace voxblox {
 
 class EsdfServer : public TsdfServer {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   EsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
   virtual ~EsdfServer() {}
 

--- a/voxblox_ros/include/voxblox_ros/interactive_slider.h
+++ b/voxblox_ros/include/voxblox_ros/interactive_slider.h
@@ -13,6 +13,8 @@ namespace voxblox {
 // InteractiveSlider class which can be used for visualizing voxel map slices.
 class InteractiveSlider {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   InteractiveSlider(
       const std::string& slider_name,
       const std::function<void(const double& slice_level)>& slider_callback,

--- a/voxblox_ros/include/voxblox_ros/mesh_pcl.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_pcl.h
@@ -24,6 +24,9 @@
 #ifndef VOXBLOX_ROS_MESH_PCL_H_
 #define VOXBLOX_ROS_MESH_PCL_H_
 
+#include <string>
+#include <vector>
+
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl_ros/point_cloud.h>
@@ -40,8 +43,7 @@ inline void toPCLPolygonMesh(const MeshLayer& mesh_layer,
   pcl::PointCloud<pcl::PointXYZ> pointcloud;
   std::vector<pcl::Vertices> polygons;
 
-  Mesh::Ptr mesh =
-      std::make_shared<Mesh>(mesh_layer.block_size(), Point::Zero());
+  Mesh::Ptr mesh = aligned_shared<Mesh>(mesh_layer.block_size(), Point::Zero());
   mesh_layer.combineMesh(mesh);
 
   // add points
@@ -53,7 +55,7 @@ inline void toPCLPolygonMesh(const MeshLayer& mesh_layer,
   }
   // add triangles
   pcl::Vertices vertices_idx;
-  polygons.reserve(mesh->indices.size()/3);
+  polygons.reserve(mesh->indices.size() / 3);
   for (const VertexIndex& idx : mesh->indices) {
     vertices_idx.vertices.push_back(idx);
 

--- a/voxblox_ros/include/voxblox_ros/transformer.h
+++ b/voxblox_ros/include/voxblox_ros/transformer.h
@@ -1,7 +1,6 @@
 #ifndef VOXBLOX_ROS_TRANSFORMER_H_
 #define VOXBLOX_ROS_TRANSFORMER_H_
 
-#include <deque>
 #include <geometry_msgs/TransformStamped.h>
 #include <string>
 #include <tf/transform_listener.h>
@@ -66,7 +65,7 @@ class Transformer {
   ros::Subscriber transform_sub_;
 
   // Transform queue, used only when use_tf_transforms is false.
-  std::deque<geometry_msgs::TransformStamped> transform_queue_;
+  AlignedDeque<geometry_msgs::TransformStamped> transform_queue_;
 };
 
 }  // namespace voxblox

--- a/voxblox_ros/include/voxblox_ros/transformer.h
+++ b/voxblox_ros/include/voxblox_ros/transformer.h
@@ -14,6 +14,8 @@ namespace voxblox {
 // ROS parameter server, depending on settings loaded from ROS params.
 class Transformer {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   Transformer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
 
   bool lookupTransform(const std::string& from_frame,
@@ -69,4 +71,4 @@ class Transformer {
 
 }  // namespace voxblox
 
-#endif  // VOXBLOX_ROS_TSDF_SERVER_H_
+#endif  // VOXBLOX_ROS_TRANSFORMER_H_

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -27,6 +27,7 @@ namespace voxblox {
 
 class TsdfServer {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   TsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
   virtual ~TsdfServer() {}

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -12,7 +12,6 @@
 #include <std_srvs/Empty.h>
 #include <tf/transform_listener.h>
 #include <visualization_msgs/MarkerArray.h>
-#include <deque>
 
 #include <voxblox/core/esdf_map.h>
 #include <voxblox/core/occupancy_map.h>
@@ -160,7 +159,7 @@ class VoxbloxNode {
   std::shared_ptr<MeshIntegrator<TsdfVoxel>> mesh_integrator_;
 
   // Transform queue, used only when use_tf_transforms is false.
-  std::deque<geometry_msgs::TransformStamped> transform_queue_;
+  AlignedDeque<geometry_msgs::TransformStamped> transform_queue_;
 };
 
 VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
@@ -690,7 +689,7 @@ bool VoxbloxNode::lookupTransformQueue(const std::string& from_frame,
                                        Transformation* transform) {
   // Try to match the transforms in the queue.
   bool match_found = false;
-  std::deque<geometry_msgs::TransformStamped>::iterator it =
+  AlignedDeque<geometry_msgs::TransformStamped>::iterator it =
       transform_queue_.begin();
   for (; it != transform_queue_.end(); ++it) {
     // If the current transform is newer than the requested timestamp, we need

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/ntsdf_voxel.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/ntsdf_voxel.h
@@ -2,6 +2,7 @@
 #define VOXBLOX_TANGO_INTERFACE_CORE_VOXEL_H_
 
 #include <cstdint>
+#include <string>
 
 #include "voxblox/core/common.h"
 #include "voxblox/core/color.h"
@@ -14,6 +15,8 @@ namespace voxblox {
  * a Layer<TsdfVoxel>
  */
 struct NtsdfVoxel {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   uint32_t ntsdf = 0;
   uint32_t color = 0;
 

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface.h
@@ -1,28 +1,29 @@
 #ifndef VOXBLOX_TANGO_INTERFACE_CORE_BLOCK_H_
 #define VOXBLOX_TANGO_INTERFACE_CORE_BLOCK_H_
 
-#include "voxblox/core/voxel.h"
 #include "voxblox/core/block.h"
+#include "voxblox/core/voxel.h"
 
 #include "./Volume.pb.h"
 
 namespace voxblox {
 
 class TangoBlockInterface : public Block<TsdfVoxel> {
-public:
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   TangoBlockInterface(size_t voxels_per_side, FloatingPoint voxel_size,
-                                          const Point& origin,
-                                          unsigned int max_ntsdf_voxel_weight,
-                                          FloatingPoint meters_to_ntsdf)
+                      const Point& origin, unsigned int max_ntsdf_voxel_weight,
+                      FloatingPoint meters_to_ntsdf)
       : Block<TsdfVoxel>(voxels_per_side, voxel_size, origin),
         max_ntsdf_voxel_weight_(max_ntsdf_voxel_weight),
-        meters_to_ntsdf_(meters_to_ntsdf) {  }
+        meters_to_ntsdf_(meters_to_ntsdf) {}
 
-  TangoBlockInterface(const tsdf2:: VolumeProto& proto,
+  TangoBlockInterface(const tsdf2::VolumeProto& proto,
                       unsigned int max_ntsdf_voxel_weight,
                       FloatingPoint meters_to_ntsdf);
 
-private:
+ private:
   void deserializeProto(const tsdf2::VolumeProto& proto);
   void deserializeFromIntegers(const std::vector<uint32_t>& data);
 

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface.h
@@ -25,7 +25,7 @@ class TangoBlockInterface : public Block<TsdfVoxel> {
 
  private:
   void deserializeProto(const tsdf2::VolumeProto& proto);
-  void deserializeFromIntegers(const std::vector<uint32_t>& data);
+  void deserializeFromIntegers(const AlignedVector<uint32_t>& data);
 
   unsigned int max_ntsdf_voxel_weight_;
   FloatingPoint meters_to_ntsdf_;

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface_inl.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_block_interface_inl.h
@@ -6,36 +6,38 @@
 namespace voxblox {
 
 inline TangoBlockInterface::TangoBlockInterface(
-                                    const tsdf2::VolumeProto& proto,
-                                    unsigned int max_ntsdf_voxel_weight,
-                                    FloatingPoint meters_to_ntsdf)
-    : TangoBlockInterface(
-            proto.voxels_per_side(), proto.voxel_size(),
-            proto.has_origin() ?
-            Point(proto.origin().x(), proto.origin().y(), proto.origin().z()) :
-            /* NOTE(mereweth@jpl.nasa.gov) - origin field seems to be deprecated
-             * as of 2017/06/15
-             * Without it, loading of old TSDF2 dumps is broken, so we
-             * pass it if present in the protobuf dump
-             */
-            Point(proto.index().x() * proto.voxel_size() * proto.voxels_per_side(),
-                  proto.index().y() * proto.voxel_size() * proto.voxels_per_side(),
-                  proto.index().z() * proto.voxel_size() * proto.voxels_per_side()),
-            max_ntsdf_voxel_weight,
-            meters_to_ntsdf) {
-
+    const tsdf2::VolumeProto& proto, unsigned int max_ntsdf_voxel_weight,
+    FloatingPoint meters_to_ntsdf)
+    : TangoBlockInterface(proto.voxels_per_side(), proto.voxel_size(),
+                          proto.has_origin()
+                              ? Point(proto.origin().x(), proto.origin().y(),
+                                      proto.origin().z())
+                              :
+                              /* NOTE(mereweth@jpl.nasa.gov) - origin field
+                               * seems to be deprecated
+                               * as of 2017/06/15
+                               * Without it, loading of old TSDF2 dumps is
+                               * broken, so we
+                               * pass it if present in the protobuf dump
+                               */
+                              Point(proto.index().x() * proto.voxel_size() *
+                                        proto.voxels_per_side(),
+                                    proto.index().y() * proto.voxel_size() *
+                                        proto.voxels_per_side(),
+                                    proto.index().z() * proto.voxel_size() *
+                                        proto.voxels_per_side()),
+                          max_ntsdf_voxel_weight, meters_to_ntsdf) {
   has_data_ = proto.has_data();
 
   // Convert the data into a vector of integers.
-  std::vector<uint32_t> data;
+  AlignedVector<uint32_t> data;
   data.reserve(proto.ntsdf_voxels_size());
 
   auto ntsdf_word = proto.ntsdf_voxels().begin();
   auto color_word = proto.color_voxels().begin();
-  for(; ntsdf_word != proto.ntsdf_voxels().end() &&
-        color_word != proto.color_voxels().end();
-        ++ntsdf_word, ++color_word)
-  {
+  for (; ntsdf_word != proto.ntsdf_voxels().end() &&
+         color_word != proto.color_voxels().end();
+       ++ntsdf_word, ++color_word) {
     data.push_back(*ntsdf_word);
     data.push_back(*color_word);
   }

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_layer_interface.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_layer_interface.h
@@ -11,7 +11,9 @@
 namespace voxblox {
 
 class TangoLayerInterface : public Layer<TsdfVoxel> {
-public:
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   // NOTE(mereweth@jpl.nasa.gov) - need this typedef
   typedef std::shared_ptr<TangoLayerInterface> Ptr;
 
@@ -21,7 +23,8 @@ public:
   bool isCompatible(const tsdf2::VolumeProto& block_proto) const;
   bool addBlockFromProto(const tsdf2::VolumeProto& block_proto,
                          TangoLayerInterface::BlockMergingStrategy strategy);
-private:
+
+ private:
   unsigned int max_ntsdf_voxel_weight_;
   FloatingPoint meters_to_ntsdf_;
 };

--- a/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_layer_interface_inl.h
+++ b/voxblox_tango_interface/include/voxblox_tango_interface/core/tango_layer_interface_inl.h
@@ -6,7 +6,8 @@
 
 namespace voxblox {
 
-inline TangoLayerInterface::TangoLayerInterface(const tsdf2::MapHeaderProto& proto)
+inline TangoLayerInterface::TangoLayerInterface(
+    const tsdf2::MapHeaderProto& proto)
     : Layer<TsdfVoxel>(proto.voxel_size(), proto.voxels_per_volume_side()),
       max_ntsdf_voxel_weight_(proto.max_ntsdf_voxel_weight()),
       meters_to_ntsdf_(proto.meters_to_ntsdf()) {
@@ -24,16 +25,15 @@ inline TangoLayerInterface::TangoLayerInterface(const tsdf2::MapHeaderProto& pro
 /* TODO (mereweth@jpl.nasa.gov) - is there a way to reuse some of
  * Layer::addBlockFromProto easily?
  */
-inline bool TangoLayerInterface ::
-    addBlockFromProto(const tsdf2::VolumeProto& block_proto,
-                      TangoLayerInterface::BlockMergingStrategy strategy) {
+inline bool TangoLayerInterface::addBlockFromProto(
+    const tsdf2::VolumeProto& block_proto,
+    TangoLayerInterface::BlockMergingStrategy strategy) {
   CHECK_EQ(getType().compare(voxel_types::kTsdf), 0)
       << "The voxel type of this layer is not TsdfVoxel!";
 
   if (isCompatible(block_proto)) {
-    TangoBlockInterface::Ptr block_ptr(new TangoBlockInterface(block_proto,
-                                                    max_ntsdf_voxel_weight_,
-                                                    meters_to_ntsdf_));
+    TangoBlockInterface::Ptr block_ptr(new TangoBlockInterface(
+        block_proto, max_ntsdf_voxel_weight_, meters_to_ntsdf_));
 
     const BlockIndex block_index =
         getGridIndexFromOriginPoint(block_ptr->origin(), block_size_inv_);
@@ -42,7 +42,7 @@ inline bool TangoLayerInterface ::
         CHECK_EQ(block_map_.count(block_index), 0u)
             << "Block collision at index: " << block_index;
         block_map_[block_index] = block_ptr;
-      break;
+        break;
       case TangoLayerInterface::BlockMergingStrategy::kReplace:
         block_map_[block_index] = block_ptr;
         break;
@@ -73,7 +73,7 @@ inline bool TangoLayerInterface ::
 }
 
 inline bool TangoLayerInterface::isCompatible(
-                              const tsdf2::MapHeaderProto& layer_proto) const {
+    const tsdf2::MapHeaderProto& layer_proto) const {
   bool compatible = true;
   compatible &= (layer_proto.voxel_size() == voxel_size_);
   compatible &= (layer_proto.voxels_per_volume_side() == voxels_per_side_);
@@ -81,7 +81,7 @@ inline bool TangoLayerInterface::isCompatible(
 }
 
 inline bool TangoLayerInterface::isCompatible(
-                                  const tsdf2::VolumeProto& block_proto) const {
+    const tsdf2::VolumeProto& block_proto) const {
   bool compatible = true;
   compatible &= (block_proto.voxel_size() == voxel_size_);
   compatible &= (block_proto.voxels_per_side() == voxels_per_side_);

--- a/voxblox_tango_interface/src/core/tango_block_interface.cc
+++ b/voxblox_tango_interface/src/core/tango_block_interface.cc
@@ -5,7 +5,7 @@
 namespace voxblox {
 
 void TangoBlockInterface::deserializeFromIntegers(
-    const std::vector<uint32_t>& data) {
+    const AlignedVector<uint32_t>& data) {
   constexpr size_t kNumDataPacketsPerVoxel = 2u;
   const size_t num_data_packets = data.size();
 
@@ -20,12 +20,11 @@ void TangoBlockInterface::deserializeFromIntegers(
 
     // TODO(mereweth@jpl.nasa.gov) - is this the best way to unpack NTSDF?
 
-    voxel.distance = static_cast<int16_t>(bytes_1 >> 16)
-                     * meters_to_ntsdf_;
+    voxel.distance = static_cast<int16_t>(bytes_1 >> 16) * meters_to_ntsdf_;
 
-    voxel.weight = static_cast<float>(max_ntsdf_voxel_weight_)
-                   / static_cast<float>(UINT16_MAX)
-                   * static_cast<uint16_t>(bytes_1 & 0x0000FFFF);
+    voxel.weight = static_cast<float>(max_ntsdf_voxel_weight_) /
+                   static_cast<float>(UINT16_MAX) *
+                   static_cast<uint16_t>(bytes_1 & 0x0000FFFF);
 
     voxel.color.r = static_cast<uint8_t>(bytes_2 >> 24);
     voxel.color.g = static_cast<uint8_t>((bytes_2 & 0x00FF0000) >> 16);
@@ -34,4 +33,4 @@ void TangoBlockInterface::deserializeFromIntegers(
   }
 }
 
-}
+}  // namespace voxblox


### PR DESCRIPTION
Voxblox has eigen alignment issues again. They show up when multiple instances of the integrator are run.

At least two classes had issues (CameraModel and RayCaster), but there was probably more. Rather then comb through and fix the issues one by one I am now taking a brute force approach.

This pull request does the following:
* Adds EIGEN_MAKE_ALIGNED_OPERATOR_NEW to every single class and struct
* Creates new aligned types for all the common std containers
* Uses these aligned containers everywhere (with the exception of the serialization and pcl indexes)
* Uses eigens aligned allocator instead of make_shared
* Fixs a large number of small layout issues, as linker picks up a lot when you change most of the files

While blatantly excessive if we make these changes and enforce the use of EIGEN_MAKE_ALIGNED_OPERATOR_NEW and using the aligned containers we should never have to worry about subtle Eigen alignment issues again.