### PR TITLE
Fix/casting and meshing

### DIFF
--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -199,13 +199,6 @@ class MeshIntegrator {
     DCHECK(next_mesh_index != nullptr);
     DCHECK(mesh != nullptr);
 
-    // If the distance to the surface is greater than the length of two voxels,
-    // the mesh will be empty.
-    if ((2.0 * block.voxel_size()) <=
-        std::abs(block.getVoxelByVoxelIndex(index).distance)) {
-      return;
-    }
-
     Eigen::Matrix<FloatingPoint, 3, 8> cube_coord_offsets =
         cube_index_offsets_.cast<FloatingPoint>() * voxel_size_;
     Eigen::Matrix<FloatingPoint, 3, 8> corner_coords;
@@ -234,13 +227,6 @@ class MeshIntegrator {
                            const VoxelIndex& index, const Point& coords,
                            VertexIndex* next_mesh_index, Mesh* mesh) {
     DCHECK(mesh != nullptr);
-
-    // If the distance to the surface is greater than the length of two voxels,
-    // the mesh will be empty.
-    if ((2.0 * block.voxel_size()) <=
-        std::abs(block.getVoxelByVoxelIndex(index).distance)) {
-      return;
-    }
 
     Eigen::Matrix<FloatingPoint, 3, 8> cube_coord_offsets =
         cube_index_offsets_.cast<FloatingPoint>() * voxel_size_;
@@ -317,8 +303,7 @@ class MeshIntegrator {
       if (block.isValidVoxelIndex(voxel_index)) {
         const VoxelType& voxel = block.getVoxelByVoxelIndex(voxel_index);
 
-        if (((2.0 * block.voxel_size()) > std::abs(voxel.distance)) &&
-            (voxel.weight >= config_.min_weight)) {
+        if (voxel.weight >= config_.min_weight) {
           mesh->colors[i] = voxel.color;
         }
       } else {


### PR DESCRIPTION
Two bug fixes

1) Better ray casting end detection.
Currently rays end when they reach the end index. However due to the limited precision of floating point that just scrapes along the boundary of a voxel might miss the end voxel and go on forever. Because of this I have modified the caster to count the number of voxels passed through and stop things when it should have ended.

2) Reverted distance check in mesher
I had thought that if a point was over 2 voxels away from a surface it didn't need to be meshed. But if the system only observes a surface at a shallow (like the road in the kitti dataset) this is a terrible assumption.