### PR TITLE
improved block allocation logic

### DIFF
--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -136,6 +136,16 @@ class Layer {
     return allocateNewBlock(computeBlockIndexFromCoordinates(coords));
   }
 
+  inline void insertBlock(
+      const std::pair<const BlockIndex, Block<TsdfVoxel>::Ptr>& block_pair) {
+    auto insert_status = block_map_.insert(block_pair);
+
+    DCHECK(insert_status.second) << "Block already exists when inserting at "
+                                 << insert_status.first->first.transpose();
+
+    DCHECK(insert_status.first->second);
+  }
+
   void removeBlock(const BlockIndex& index) { block_map_.erase(index); }
   void removeAllBlocks() { block_map_.clear(); }
 

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -118,10 +118,10 @@ class Layer {
   }
 
   typename BlockType::Ptr allocateNewBlock(const BlockIndex& index) {
-    auto insert_status = block_map_.insert(std::make_pair(
-        index, std::shared_ptr<BlockType>(new BlockType(
+    auto insert_status = block_map_.emplace(
+        index, std::make_shared<BlockType>(
                    voxels_per_side_, voxel_size_,
-                   getOriginPointFromGridIndex(index, block_size_)))));
+                   getOriginPointFromGridIndex(index, block_size_)));
 
     DCHECK(insert_status.second)
         << "Block already exists when allocating at " << index.transpose();

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -73,15 +73,15 @@ class TsdfIntegratorBase {
   // Will return a pointer to a voxel located at global_voxel_idx in the tsdf
   // layer. Thread safe.
   // Takes in the last_block_idx and last_block to prevent unneeded map lookups.
-  // If the block this voxel would be in has not been allocated, a block in
+  // If this voxel belongs to a block that has not been allocated, a block in
   // temp_block_map_ is created/accessed and a voxel from this map is returned
   // instead. Unlike the layer, accessing temp_block_map_ is controlled via a
   // mutex allowing it to grow during integration.
   // These temporary blocks can be merged into the layer later by calling
   // updateLayerWithStoredBlocks()
-  inline TsdfVoxel* getVoxelPtr(const VoxelIndex& global_voxel_idx,
-                                Block<TsdfVoxel>::Ptr* last_block,
-                                BlockIndex* last_block_idx);
+  inline TsdfVoxel* allocateStorageAndGetVoxelPtr(
+      const VoxelIndex& global_voxel_idx, Block<TsdfVoxel>::Ptr* last_block,
+      BlockIndex* last_block_idx);
 
   // NOT thread safe
   inline void updateLayerWithStoredBlocks();

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -33,8 +33,6 @@ class TsdfIntegratorBase {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  typedef AnyIndexHashMapType<TsdfVoxel>::type VoxelMap;
-
   struct Config {
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
@@ -75,16 +73,18 @@ class TsdfIntegratorBase {
   // Will return a pointer to a voxel located at global_voxel_idx in the tsdf
   // layer. Thread safe.
   // Takes in the last_block_idx and last_block to prevent unneeded map lookups.
-  // If the block this voxel would be in has not been allocated, a voxel in
-  // temp_voxel_storage is allocated and returned instead.
-  // This can be merged into the layer later by calling
-  // updateLayerWithStoredVoxels(temp_voxel_storage)
-  inline TsdfVoxel* findOrTempAllocateVoxelPtr(
-      const VoxelIndex& global_voxel_idx, Block<TsdfVoxel>::Ptr* last_block,
-      BlockIndex* last_block_idx, VoxelMap* temp_voxel_storage) const;
+  // If the block this voxel would be in has not been allocated, a block in
+  // temp_block_map_ is created/accessed and a voxel from this map is returned
+  // instead. Unlike the layer, accessing temp_block_map_ is controlled via a
+  // mutex allowing it to grow during integration.
+  // These temporary blocks can be merged into the layer later by calling
+  // updateLayerWithStoredBlocks()
+  inline TsdfVoxel* getVoxelPtr(const VoxelIndex& global_voxel_idx,
+                                Block<TsdfVoxel>::Ptr* last_block,
+                                BlockIndex* last_block_idx);
 
   // NOT thread safe
-  inline void updateLayerWithStoredVoxels(const VoxelMap& temp_voxel_storage);
+  inline void updateLayerWithStoredBlocks();
 
   // Updates tsdf_voxel. Thread safe.
   inline void updateTsdfVoxel(const Point& origin, const Point& point_G,
@@ -112,6 +112,11 @@ class TsdfIntegratorBase {
   FloatingPoint voxels_per_side_inv_;
   FloatingPoint block_size_inv_;
 
+  // Temporary block storage, used to hold blocks that need to be created while
+  // integrating a new pointcloud
+  std::mutex temp_block_mutex_;
+  Layer<TsdfVoxel>::BlockHashMap temp_block_map_;
+
   // We need to prevent simultaneous access to the voxels in the map. We could
   // put a single mutex on the map or on the blocks, but as voxel updating is
   // the most expensive operation in integration and most voxels are close
@@ -136,8 +141,7 @@ class SimpleTsdfIntegrator : public TsdfIntegratorBase {
 
   void integrateFunction(const Transformation& T_G_C,
                          const Pointcloud& points_C, const Colors& colors,
-                         ThreadSafeIndex* index_getter,
-                         VoxelMap* temp_voxel_storage);
+                         ThreadSafeIndex* index_getter);
 };
 
 class MergedTsdfIntegrator : public TsdfIntegratorBase {
@@ -161,15 +165,14 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
       const std::pair<AnyIndex, AlignedVector<size_t>>& kv,
-      const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
-      VoxelMap* temp_voxel_storage);
+      const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map);
 
   void integrateVoxels(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
       const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
       const AnyIndexHashMapType<AlignedVector<size_t>>::type& clear_map,
-      size_t thread_idx, VoxelMap* temp_voxel_storage);
+      size_t thread_idx);
 
   void integrateRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
@@ -187,8 +190,7 @@ class FastTsdfIntegrator : public TsdfIntegratorBase {
 
   void integrateFunction(const Transformation& T_G_C,
                          const Pointcloud& points_C, const Colors& colors,
-                         ThreadSafeIndex* index_getter,
-                         VoxelMap* temp_voxel_storage);
+                         ThreadSafeIndex* index_getter);
 
   void integratePointCloud(const Transformation& T_G_C,
                            const Pointcloud& points_C, const Colors& colors);

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -49,14 +49,15 @@ inline bool TsdfIntegratorBase::isPointValid(const Point& point_C,
 // Will return a pointer to a voxel located at global_voxel_idx in the tsdf
 // layer. Thread safe.
 // Takes in the last_block_idx and last_block to prevent unneeded map lookups.
-// If the block this voxel would be in has not been allocated, a voxel in
-// temp_voxel_storage is allocated and returned instead.
-// This can be merged into the layer later by calling
-// updateLayerWithStoredVoxels(temp_voxel_storage)
-inline TsdfVoxel* TsdfIntegratorBase::findOrTempAllocateVoxelPtr(
+// If the block this voxel would be in has not been allocated, a block in
+// temp_block_map_ is created/accessed and a voxel from this map is returned
+// instead. Unlike the layer, accessing temp_block_map_ is controlled via a
+// mutex allowing it to grow during integration.
+// These temporary blocks can be merged into the layer later by calling
+// updateLayerWithStoredBlocks()
+inline TsdfVoxel* TsdfIntegratorBase::getVoxelPtr(
     const VoxelIndex& global_voxel_idx, Block<TsdfVoxel>::Ptr* last_block,
-    BlockIndex* last_block_idx, VoxelMap* temp_voxel_storage) const {
-  DCHECK(temp_voxel_storage != nullptr);
+    BlockIndex* last_block_idx) {
   DCHECK(last_block != nullptr);
   DCHECK(last_block_idx != nullptr);
 
@@ -66,67 +67,51 @@ inline TsdfVoxel* TsdfIntegratorBase::findOrTempAllocateVoxelPtr(
   if (block_idx != *last_block_idx) {
     *last_block = layer_->getBlockPtrByIndex(block_idx);
     *last_block_idx = block_idx;
-    if (*last_block != nullptr) {
-      (*last_block)->updated() = true;
-    }
   }
 
   // If no block at this location currently exists, we allocate a temporary
   // voxel that will be merged into the map later
   if (*last_block == nullptr) {
-    return &((*temp_voxel_storage)[global_voxel_idx]);
-  } else {
-    const VoxelIndex local_voxel_idx =
-        getLocalFromGlobalVoxelIndex(global_voxel_idx, voxels_per_side_);
+    // To allow temp_block_map_ to grow we can only let one thread in at once
+    std::lock_guard<std::mutex> lock(temp_block_mutex_);
 
-    return &((*last_block)->getVoxelByVoxelIndex(local_voxel_idx));
+    typename Layer<TsdfVoxel>::BlockHashMap::iterator it =
+        temp_block_map_.find(block_idx);
+    if (it != temp_block_map_.end()) {
+      *last_block = it->second;
+    } else {
+      auto insert_status = temp_block_map_.insert(std::make_pair(
+          block_idx,
+          std::shared_ptr<Block<TsdfVoxel>>(new Block<TsdfVoxel>(
+              voxels_per_side_, voxel_size_,
+              getOriginPointFromGridIndex(block_idx, block_size_)))));
+
+      DCHECK(insert_status.second) << "Block already exists when allocating at "
+                                   << block_idx.transpose();
+
+      *last_block = insert_status.first->second;
+    }
   }
+
+  (*last_block)->updated() = true;
+
+  const VoxelIndex local_voxel_idx =
+      getLocalFromGlobalVoxelIndex(global_voxel_idx, voxels_per_side_);
+
+  return &((*last_block)->getVoxelByVoxelIndex(local_voxel_idx));
 }
 
 // NOT thread safe
-inline void TsdfIntegratorBase::updateLayerWithStoredVoxels(
-    const VoxelMap& temp_voxel_storage) {
+inline void TsdfIntegratorBase::updateLayerWithStoredBlocks() {
   BlockIndex last_block_idx;
   Block<TsdfVoxel>::Ptr block = nullptr;
 
-  for (const std::pair<const VoxelIndex, TsdfVoxel>& temp_voxel :
-       temp_voxel_storage) {
-    const BlockIndex block_idx = getBlockIndexFromGlobalVoxelIndex(
-        temp_voxel.first, voxels_per_side_inv_);
-    const VoxelIndex local_voxel_idx =
-        getLocalFromGlobalVoxelIndex(temp_voxel.first, voxels_per_side_);
-
-    if ((block_idx != last_block_idx) || (block == nullptr)) {
-      block = layer_->allocateBlockPtrByIndex(block_idx);
-      block->updated() = true;
-    }
-
-    TsdfVoxel& base_voxel = block->getVoxelByVoxelIndex(local_voxel_idx);
-
-    const float new_weight = base_voxel.weight + temp_voxel.second.weight;
-
-    // it is possible that both voxels have weights very close to zero, due to
-    // the limited precision of floating points dividing by this small value can
-    // cause nans
-    if (new_weight < kFloatEpsilon) {
-      continue;
-    }
-
-    // color blending is expensive only do it close to the surface
-    if (std::abs(temp_voxel.second.distance) <
-        config_.default_truncation_distance) {
-      base_voxel.color = Color::blendTwoColors(
-          base_voxel.color, base_voxel.weight, temp_voxel.second.color,
-          temp_voxel.second.weight);
-    }
-
-    base_voxel.distance =
-        (base_voxel.distance * base_voxel.weight +
-         temp_voxel.second.distance * temp_voxel.second.weight) /
-        new_weight;
-
-    base_voxel.weight = std::min(config_.max_weight, new_weight);
+  for (const std::pair<const BlockIndex, Block<TsdfVoxel>::Ptr>&
+           temp_block_pair : temp_block_map_) {
+    layer_->insertBlock(temp_block_pair);
   }
+
+  temp_block_map_.clear();
 }
 
 // Updates tsdf_voxel. Thread safe.
@@ -222,8 +207,6 @@ inline float TsdfIntegratorBase::getVoxelWeight(const Point& point_C) const {
 void SimpleTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
                                                const Pointcloud& points_C,
                                                const Colors& colors) {
-  AlignedVector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
-
   timing::Timer integrate_timer("integrate");
 
   ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
@@ -232,7 +215,7 @@ void SimpleTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
   for (size_t i = 0; i < config_.integrator_threads; ++i) {
     integration_threads.emplace_back(&SimpleTsdfIntegrator::integrateFunction,
                                      this, T_G_C, points_C, colors,
-                                     &index_getter, &(temp_voxel_storage[i]));
+                                     &index_getter);
   }
 
   for (std::thread& thread : integration_threads) {
@@ -240,20 +223,16 @@ void SimpleTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
   }
   integrate_timer.Stop();
 
-  timing::Timer insertion_timer("inserting_missed_voxels");
-  for (const VoxelMap& temp_voxels : temp_voxel_storage) {
-    updateLayerWithStoredVoxels(temp_voxels);
-  }
+  timing::Timer insertion_timer("inserting_missed_blocks");
+  updateLayerWithStoredBlocks();
   insertion_timer.Stop();
 }
 
 void SimpleTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
                                              const Pointcloud& points_C,
                                              const Colors& colors,
-                                             ThreadSafeIndex* index_getter,
-                                             VoxelMap* temp_voxel_storage) {
+                                             ThreadSafeIndex* index_getter) {
   DCHECK(index_getter != nullptr);
-  DCHECK(temp_voxel_storage != nullptr);
 
   size_t point_idx;
   while (index_getter->getNextIndex(&point_idx)) {
@@ -276,8 +255,7 @@ void SimpleTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
     BlockIndex block_idx;
     VoxelIndex global_voxel_idx;
     while (ray_caster.nextRayIndex(&global_voxel_idx)) {
-      TsdfVoxel* voxel = findOrTempAllocateVoxelPtr(
-          global_voxel_idx, &block, &block_idx, temp_voxel_storage);
+      TsdfVoxel* voxel = getVoxelPtr(global_voxel_idx, &block, &block_idx);
 
       const float weight = getVoxelWeight(point_C);
       const Point voxel_center_G =
@@ -353,10 +331,7 @@ void MergedTsdfIntegrator::integrateVoxel(
     const Transformation& T_G_C, const Pointcloud& points_C,
     const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
     const std::pair<AnyIndex, AlignedVector<size_t>>& kv,
-    const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
-    VoxelMap* temp_voxel_storage) {
-  DCHECK(temp_voxel_storage != nullptr);
-
+    const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map) {
   if (kv.second.empty()) {
     return;
   }
@@ -402,8 +377,7 @@ void MergedTsdfIntegrator::integrateVoxel(
 
     Block<TsdfVoxel>::Ptr block = nullptr;
     BlockIndex block_idx;
-    TsdfVoxel* voxel = findOrTempAllocateVoxelPtr(
-        global_voxel_idx, &block, &block_idx, temp_voxel_storage);
+    TsdfVoxel* voxel = getVoxelPtr(global_voxel_idx, &block, &block_idx);
     const Point voxel_center_G =
         getCenterPointFromGridIndex(global_voxel_idx, voxel_size_);
 
@@ -417,9 +391,7 @@ void MergedTsdfIntegrator::integrateVoxels(
     const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
     const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
     const AnyIndexHashMapType<AlignedVector<size_t>>::type& clear_map,
-    size_t thread_idx, VoxelMap* temp_voxel_storage) {
-  DCHECK(temp_voxel_storage != nullptr);
-
+    size_t thread_idx) {
   AnyIndexHashMapType<AlignedVector<size_t>>::type::const_iterator it;
   size_t map_size;
   if (clearing_ray) {
@@ -433,7 +405,7 @@ void MergedTsdfIntegrator::integrateVoxels(
   for (size_t i = 0; i < map_size; ++i) {
     if (((i + thread_idx + 1) % config_.integrator_threads) == 0) {
       integrateVoxel(T_G_C, points_C, colors, enable_anti_grazing, clearing_ray,
-                     *it, voxel_map, temp_voxel_storage);
+                     *it, voxel_map);
     }
     ++it;
   }
@@ -446,19 +418,16 @@ void MergedTsdfIntegrator::integrateRays(
     const AnyIndexHashMapType<AlignedVector<size_t>>::type& clear_map) {
   const Point& origin = T_G_C.getPosition();
 
-  AlignedVector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
-
   // if only 1 thread just do function call, otherwise spawn threads
   if (config_.integrator_threads == 1) {
     integrateVoxels(T_G_C, points_C, colors, enable_anti_grazing, clearing_ray,
-                    voxel_map, clear_map, 0, &(temp_voxel_storage[0]));
+                    voxel_map, clear_map, 0);
   } else {
     AlignedVector<std::thread> integration_threads;
     for (size_t i = 0; i < config_.integrator_threads; ++i) {
       integration_threads.emplace_back(
           &MergedTsdfIntegrator::integrateVoxels, this, T_G_C, points_C, colors,
-          enable_anti_grazing, clearing_ray, voxel_map, clear_map, i,
-          &(temp_voxel_storage[i]));
+          enable_anti_grazing, clearing_ray, voxel_map, clear_map, i);
     }
 
     for (std::thread& thread : integration_threads) {
@@ -466,20 +435,17 @@ void MergedTsdfIntegrator::integrateRays(
     }
   }
 
-  timing::Timer insertion_timer("inserting_missed_voxels");
-  for (const VoxelMap& temp_voxels : temp_voxel_storage) {
-    updateLayerWithStoredVoxels(temp_voxels);
-  }
+  timing::Timer insertion_timer("inserting_missed_blocks");
+  updateLayerWithStoredBlocks();
+
   insertion_timer.Stop();
 }
 
 void FastTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
                                            const Pointcloud& points_C,
                                            const Colors& colors,
-                                           ThreadSafeIndex* index_getter,
-                                           VoxelMap* temp_voxel_storage) {
+                                           ThreadSafeIndex* index_getter) {
   DCHECK(index_getter != nullptr);
-  DCHECK(temp_voxel_storage != nullptr);
 
   size_t point_idx;
   while (index_getter->getNextIndex(&point_idx)) {
@@ -527,8 +493,7 @@ void FastTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
         break;
       }
 
-      TsdfVoxel* voxel = findOrTempAllocateVoxelPtr(
-          global_voxel_idx, &block, &block_idx, temp_voxel_storage);
+      TsdfVoxel* voxel = getVoxelPtr(global_voxel_idx, &block, &block_idx);
 
       const float weight = getVoxelWeight(point_C);
       const Point voxel_center_G =
@@ -542,8 +507,6 @@ void FastTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
 void FastTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
                                              const Pointcloud& points_C,
                                              const Colors& colors) {
-  AlignedVector<VoxelMap> temp_voxel_storage(config_.integrator_threads);
-
   timing::Timer integrate_timer("integrate");
 
   start_voxel_approx_set_.resetApproxSet();
@@ -555,7 +518,7 @@ void FastTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
   for (size_t i = 0; i < config_.integrator_threads; ++i) {
     integration_threads.emplace_back(&FastTsdfIntegrator::integrateFunction,
                                      this, T_G_C, points_C, colors,
-                                     &index_getter, &(temp_voxel_storage[i]));
+                                     &index_getter);
   }
 
   for (std::thread& thread : integration_threads) {
@@ -564,10 +527,8 @@ void FastTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
 
   integrate_timer.Stop();
 
-  timing::Timer insertion_timer("inserting_missed_voxels");
-  for (const VoxelMap& temp_voxels : temp_voxel_storage) {
-    updateLayerWithStoredVoxels(temp_voxels);
-  }
+  timing::Timer insertion_timer("inserting_missed_blocks");
+  updateLayerWithStoredBlocks();
   insertion_timer.Stop();
 }
 


### PR DESCRIPTION
Changed how blocks not present in the map are handeled.
Previously I created a local map to store the voxels. After the integration was done I then went through and integrated these voxels. This had a very high cost for the first frame and caused noticeable delays with sub-maps.

Now I have a second temporary block map. This map is shared between frames and access is controlled by a mutex. This means in the worst case with an empty layer, all blocks will come from this temporary mutex controlled map and performance will be similar to things running single threaded.

The change also cuts down on copy operations which @mfehr previously noted could be expensive in some cases.

Timings before change:
inserting_missed_voxels     625 00.916614       (00.001467 +- 00.000207)        [00.000671,00.016069]
integrate                   625 12.345203       (00.019752 +- 00.001661)        [00.014607,00.034242]

Timings after change:
inserting_missed_blocks     634 00.017504       (00.000028 +- 00.000005)        [00.000011,00.000094]
integrate                   634 11.797627       (00.018608 +- 00.001380)        [00.013368,00.028746]


