### PR TITLE
Speed hacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ A summary of the user setable voxblox_node parameters:
 | `max_weight` | The upper limit for the weight assigned to a voxel | 10000.0 |
 | `use_const_weight` | If true all points along a ray have equal weighting | false |
 | `allow_clear` | If true points beyond the `max_ray_length_m` will be integrated up to this distance | true |
+| `start_voxel_subsampling_factor` | Only used by the fast integrator. Before integration points are inserted into a sub-voxel, only one point is allowed per sub-voxel. This can be thought of as subsampling the pointcloud. The edge length of the sub-voxel is the voxel edge length divided by `start_voxel_subsampling_factor`. | 2 |
+| `max_consecutive_ray_collisions` | Only used by the fast integrator. When a ray is cast by this integrator it detects if any other ray has already passed through the current voxel this scan. If it passes through more than `max_consecutive_ray_collisions` voxels other rays have seen in a row, it is taken to be adding no new information and the casting stops  | 2 |
+| `clear_checks_every_n_frames` | Only used by the fast integrator. Governs how often the sets that indicate if a sub-voxel is full or a voxel has had a ray passed through it are cleared. | 1 |
 | `esdf_max_distance_m` | The maximum distance that the esdf will be calculated out to | 2.0 |
 | `esdf_default_distance_m` | Default distance set for unknown values and values >`esdf_max_distance_m` | 2.0 |
 | `mesh_filename` | Filename output mesh will be saved to, leave blank if no file should be generated | "" |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ A summary of the user setable voxblox_node parameters:
 | `color_ptcloud_by_weight` | If the pointcloud should be colored by the voxel weighting | false |
 | `method` | Method to use for integrating new readings into the tsdf. Options are "merged", "simple", "merged_discard" and "fast" | "merged" |
 | `tsdf_voxel_size` | The size of the tsdf voxels | 0.2 |
-| `tsdf_voxels_per_side` | TSDF voxels per side of an allocated block | 16 |
+| `tsdf_voxels_per_side` | TSDF voxels per side of an allocated block. Must be a power of 2 | 16 |
 | `voxel_carving_enabled` | If true, the entire length of a ray is integrated, if false only the region inside the trunaction distance is used. | true |
 | `truncation_distance` | The truncation distance for the TSDF | 2`tsdf_voxel_size` |
 | `max_ray_length_m` | The maximum range out to which a ray will be cast | 5.0 |

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -187,20 +187,20 @@ inline BlockIndex getBlockIndexFromGlobalVoxelIndex(
                  voxels_per_side_inv_));
 }
 
+inline bool isPowerOfTwo(int x) { return (x & (x - 1)) == 0; }
+
 inline VoxelIndex getLocalFromGlobalVoxelIndex(const AnyIndex& global_voxel_idx,
                                                int voxels_per_side) {
-  VoxelIndex local_voxel_idx(global_voxel_idx.x() % voxels_per_side,
-                             global_voxel_idx.y() % voxels_per_side,
-                             global_voxel_idx.z() % voxels_per_side);
+  // add a big number to the index to make it positive
+  constexpr int offset = 1 << (8 * sizeof(IndexElement) - 1);
 
-  // Make sure we're within bounds.
-  for (unsigned int i = 0u; i < 3u; ++i) {
-    if (local_voxel_idx(i) < 0) {
-      local_voxel_idx(i) += voxels_per_side;
-    }
-  }
+  DCHECK(isPowerOfTwo(voxels_per_side));
 
-  return local_voxel_idx;
+  // assume that voxels_per_side is a power of 2 and use bit shifting as a
+  // computationally cheap substitute for the modulus operator
+  return VoxelIndex((global_voxel_idx.x() + offset) & (voxels_per_side - 1),
+                    (global_voxel_idx.y() + offset) & (voxels_per_side - 1),
+                    (global_voxel_idx.z() + offset) & (voxels_per_side - 1));
 }
 
 // Math functions.

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -38,7 +38,7 @@ inline std::shared_ptr<Type> aligned_shared(Arguments&&... arguments) {
 }
 
 // Types.
-typedef double FloatingPoint;
+typedef float FloatingPoint;
 typedef int IndexElement;
 
 typedef Eigen::Matrix<FloatingPoint, 3, 1> Point;

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -196,7 +196,7 @@ inline VoxelIndex getLocalFromGlobalVoxelIndex(const AnyIndex& global_voxel_idx,
 
   DCHECK(isPowerOfTwo(voxels_per_side));
 
-  // assume that voxels_per_side is a power of 2 and use bit shifting as a
+  // assume that voxels_per_side is a power of 2 and uses a bitwise and as a
   // computationally cheap substitute for the modulus operator
   return VoxelIndex((global_voxel_idx.x() + offset) & (voxels_per_side - 1),
                     (global_voxel_idx.y() + offset) & (voxels_per_side - 1),

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -120,10 +120,10 @@ class RayCaster {
     const AnyIndex end_index = getGridIndexFromPoint(end_scaled);
     const AnyIndex diff_index = end_index - curr_index_;
 
+    current_step_ = 0;
+
     ray_length_in_steps_ = std::abs(diff_index.x()) + std::abs(diff_index.y()) +
                            std::abs(diff_index.z());
-
-    current_step_ = 0;
 
     const Ray ray_scaled = end_scaled - start_scaled;
 

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -54,6 +54,7 @@ class TsdfIntegratorBase {
     // fast integrator specific
     float start_voxel_subsampling_factor = 2.0f;
     int max_consecutive_ray_collisions = 2;
+    int clear_checks_every_n_frames = 1;
   };
 
   TsdfIntegratorBase(const Config& config, Layer<TsdfVoxel>* layer);

--- a/voxblox/include/voxblox/utils/camera_model.h
+++ b/voxblox/include/voxblox/utils/camera_model.h
@@ -11,31 +11,26 @@
 
 namespace voxblox {
 
-// Transformation type for defining sensor orientation.
-typedef kindr::minimal::QuatTransformationTemplate<double> Transformation;
-typedef kindr::minimal::RotationQuaternionTemplate<double> Rotation;
-
 // Represents a plane in Hesse normal form (normal + distance) for faster
 // distance calculations to points.
 class Plane {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  Plane() : normal_(Eigen::Vector3d::Identity()), distance_(0) {}
+  Plane() : normal_(Point::Identity()), distance_(0) {}
   virtual ~Plane() {}
 
-  void setFromPoints(const Eigen::Vector3d& p1, const Eigen::Vector3d& p2,
-                     const Eigen::Vector3d& p3);
-  void setFromDistanceNormal(const Eigen::Vector3d& normal, double distance);
+  void setFromPoints(const Point& p1, const Point& p2, const Point& p3);
+  void setFromDistanceNormal(const Point& normal, double distance);
 
   // I guess more correctly, is the point on the correct side of the plane.
-  bool isPointInside(const Eigen::Vector3d& point) const;
+  bool isPointInside(const Point& point) const;
 
-  Eigen::Vector3d normal() const { return normal_; }
+  Point normal() const { return normal_; }
   double distance() const { return distance_; }
 
  private:
-  Eigen::Vector3d normal_;
+  Point normal_;
   double distance_;
 };
 
@@ -47,9 +42,9 @@ class CameraModel {
   virtual ~CameraModel() {}
 
   // Set up the camera model, intrinsics and extrinsics.
-  void setIntrinsicsFromFocalLength(const Eigen::Vector2d& resolution,
-                                    double focal_length, double min_distance,
-                                    double max_distance);
+  void setIntrinsicsFromFocalLength(
+      const Eigen::Matrix<FloatingPoint, 2, 1>& resolution, double focal_length,
+      double min_distance, double max_distance);
   void setIntrinsicsFromFoV(double horizontal_fov, double vertical_fov,
                             double min_distance, double max_distance);
   void setExtrinsics(const Transformation& T_C_B);
@@ -63,8 +58,8 @@ class CameraModel {
   void setBodyPose(const Transformation& body_pose);
 
   // Check whether a point belongs in the current view.
-  void getAabb(Eigen::Vector3d* aabb_min, Eigen::Vector3d* aabb_max) const;
-  bool isPointInView(const Eigen::Vector3d& point) const;
+  void getAabb(Point* aabb_min, Point* aabb_max) const;
+  bool isPointInView(const Point& point) const;
 
  private:
   void calculateBoundingPlanes();
@@ -76,13 +71,13 @@ class CameraModel {
 
   // The original vertices of the frustum, in the axis-aligned coordinate frame
   // (before rotation).
-  AlignedVector<Eigen::Vector3d> untransformed_corners_;
+  AlignedVector<Point> untransformed_corners_;
 
   // The 6 bounding planes for the current camera pose, and their corresponding
   // AABB (Axis Aligned Bounding Box).
   AlignedVector<Plane> bounding_planes_;
-  Eigen::Vector3d aabb_min_;
-  Eigen::Vector3d aabb_max_;
+  Point aabb_min_;
+  Point aabb_max_;
 };
 }  // namespace voxblox
 

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -1,4 +1,5 @@
 #include "voxblox/integrator/tsdf_integrator.h"
+#include <iostream>
 
 namespace voxblox {
 
@@ -509,8 +510,12 @@ void FastTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
                                              const Colors& colors) {
   timing::Timer integrate_timer("integrate");
 
-  start_voxel_approx_set_.resetApproxSet();
-  voxel_observed_approx_set_.resetApproxSet();
+  static size_t reset_counter = 0;
+  if ((++reset_counter) >= config_.clear_checks_every_n_frames) {
+    reset_counter = 0;
+    start_voxel_approx_set_.resetApproxSet();
+    voxel_observed_approx_set_.resetApproxSet();
+  }
 
   ThreadSafeIndex index_getter(points_C.size(), config_.integrator_threads);
 

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -4,7 +4,7 @@
   <arg name="voxel_size" default="0.05"/>
   <arg name="generate_esdf" default="false" />
 
-  <node name="player" pkg="rosbag" type="play" output="screen" args="-r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
+  <node name="player" pkg="rosbag" type="play" output="screen" args="-r 1.0 -s 10 -u 30 --clock $(arg bag_file)" if="$(arg play_bag)"/>
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
@@ -13,13 +13,14 @@
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="color" />
     <param name="use_tf_transforms" value="false" />
-    <param name="update_mesh_every_n_sec" value="0.1" />
+    <param name="update_mesh_every_n_sec" value="0.5" />
     <param name="min_time_between_msgs_sec" value="0.0" />
     <param name="method" value="fast" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
     <param name="verbose" value="true" />
+    <param name="clear_checks_every_n_frames" value="1"/>
     <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
     <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>
     <param name="mesh_filename" value="$(find voxblox_ros)/mesh_results/$(anon cow).ply" />

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -28,6 +28,10 @@ EsdfServer::EsdfServer(const ros::NodeHandle& nh,
   // workaround.
   int voxels_per_side = esdf_config.esdf_voxels_per_side;
   nh_private_.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
+  if (!isPowerOfTwo(voxels_per_side)) {
+    ROS_ERROR("voxels_per_side must be a power of 2, setting to default value");
+    voxels_per_side = esdf_config.esdf_voxels_per_side;
+  }
   esdf_config.esdf_voxels_per_side = voxels_per_side;
 
   esdf_map_.reset(new EsdfMap(esdf_config));

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -50,6 +50,11 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
   int voxels_per_side = config.tsdf_voxels_per_side;
   nh_private_.param("tsdf_voxel_size", voxel_size, voxel_size);
   nh_private_.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
+  if (!isPowerOfTwo(voxels_per_side)) {
+    ROS_ERROR("voxels_per_side must be a power of 2, setting to default value");
+    voxels_per_side = config.tsdf_voxels_per_side;
+  }
+
   config.tsdf_voxel_size = static_cast<FloatingPoint>(voxel_size);
   config.tsdf_voxels_per_side = voxels_per_side;
   tsdf_map_.reset(new TsdfMap(config));

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -83,6 +83,9 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
   nh_private_.param("max_consecutive_ray_collisions",
                     integrator_config.max_consecutive_ray_collisions,
                     integrator_config.max_consecutive_ray_collisions);
+  nh_private_.param("clear_checks_every_n_frames",
+                    integrator_config.clear_checks_every_n_frames,
+                    integrator_config.clear_checks_every_n_frames);
   integrator_config.default_truncation_distance =
       static_cast<float>(truncation_distance);
   integrator_config.max_weight = static_cast<float>(max_weight);

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -191,15 +191,17 @@ void TsdfServer::insertPointcloud(
 
     timing::Timer ptcloud_timer("ptcloud_preprocess");
 
-    // Filter out NaNs. :|
-    std::vector<int> indices;
-    pcl::removeNaNFromPointCloud(pointcloud_pcl, pointcloud_pcl, indices);
-
     Pointcloud points_C;
     Colors colors;
     points_C.reserve(pointcloud_pcl.size());
     colors.reserve(pointcloud_pcl.size());
     for (size_t i = 0; i < pointcloud_pcl.points.size(); ++i) {
+      if (!std::isfinite(pointcloud_pcl.points[i].x) ||
+          !std::isfinite(pointcloud_pcl.points[i].y) ||
+          !std::isfinite(pointcloud_pcl.points[i].z)) {
+        continue;
+      }
+
       points_C.push_back(Point(pointcloud_pcl.points[i].x,
                                pointcloud_pcl.points[i].y,
                                pointcloud_pcl.points[i].z));

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -301,6 +301,9 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
   nh_private_.param("max_consecutive_ray_collisions",
                     integrator_config.max_consecutive_ray_collisions,
                     integrator_config.max_consecutive_ray_collisions);
+  nh_private_.param("clear_checks_every_n_frames",
+                    integrator_config.clear_checks_every_n_frames,
+                    integrator_config.clear_checks_every_n_frames);
   integrator_config.default_truncation_distance =
       static_cast<float>(truncation_distance);
   integrator_config.max_weight = static_cast<float>(max_weight);
@@ -484,10 +487,6 @@ void VoxbloxNode::insertPointcloudWithTf(
     pcl::fromROSMsg(*pointcloud_msg, pointcloud_pcl);
 
     timing::Timer ptcloud_timer("ptcloud_preprocess");
-
-    // Filter out NaNs. :|
-    std::vector<int> indices;
-    pcl::removeNaNFromPointCloud(pointcloud_pcl, pointcloud_pcl, indices);
 
     Pointcloud points_C;
     Colors colors;

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -268,6 +268,10 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
   int voxels_per_side = config.tsdf_voxels_per_side;
   nh_private_.param("tsdf_voxel_size", voxel_size, voxel_size);
   nh_private_.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
+  if (!isPowerOfTwo(voxels_per_side)) {
+    ROS_ERROR("voxels_per_side must be a power of 2, setting to default value");
+    voxels_per_side = config.tsdf_voxels_per_side;
+  }
   config.tsdf_voxel_size = static_cast<FloatingPoint>(voxel_size);
   config.tsdf_voxels_per_side = voxels_per_side;
   tsdf_map_.reset(new TsdfMap(config));


### PR DESCRIPTION
Looked at getting the cpu usage running voxblox down and ended up doing some more optimization.

There are five changes in this pr to speed things up. Let me know if you disagree with these changes (especially 1 and 2 as they could be considered over-optimization)

1) Switched from doubles to floats as the FloatingPoint type. This required changing types in CameraModel

2) When running the fast integrator getLocalFromGlobalVoxelIndex is the third most expensive function in voxblox (1. ApproxHashSet::replaceHash, 2. TsdfIntegratorBase::updateTsdfVoxel). This is due to the modulus operator. I constrained voxels_per_side to be a power of two and replaced this with a bitwise and.

3) Removed the pointer used to index the approx_array and just added an offset. Code is a bit cleaner and a bit faster

4) We were filtering nans twice in pointcloud preprocessing, removed the unneeded one.

5) Add flag to let the fast integrator use the same collision checking for multiple frames. Will give much nosier results but speeds things up if needed (just set to clear checks every frame by default)

Timings on one of the ros bags from jays flight last week:
Before:
inserting_missed_blocks     149  00.014100    
integrate                              149  06.616214   
ptcloud_preprocess             149  00.741457       

After:
inserting_missed_blocks     149  00.012957      
integrate                              149  05.251077       
ptcloud_preprocess             149  00.726723       
