### PR TITLE
account for fact first block might be at (0,0,0)

### DIFF
--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -64,7 +64,7 @@ inline TsdfVoxel* TsdfIntegratorBase::allocateStorageAndGetVoxelPtr(
   const BlockIndex block_idx =
       getBlockIndexFromGlobalVoxelIndex(global_voxel_idx, voxels_per_side_inv_);
 
-  if (block_idx != *last_block_idx) {
+  if ((block_idx != *last_block_idx) || (*last_block == nullptr)) {
     *last_block = layer_->getBlockPtrByIndex(block_idx);
     *last_block_idx = block_idx;
   }


### PR DESCRIPTION
Fixes error that if the first block is at (0,0,0) then last_block is not assigned a valid pointer. 