### PR TITLE
reimplemented ponit clearing

### DIFF
--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -76,9 +76,16 @@ class RayCaster {
             const bool cast_from_origin = true) {
     const Ray unit_ray = (point_G - origin).normalized();
 
-    const Point ray_end = is_clearing_ray
-                              ? origin + unit_ray * max_ray_length_m
-                              : point_G + unit_ray * truncation_distance;
+    Point ray_end;
+    if (is_clearing_ray) {
+      FloatingPoint ray_length = (point_G - origin).norm();
+      ray_length = std::min(std::max(ray_length - truncation_distance,
+                                     static_cast<FloatingPoint>(0.0)),
+                            max_ray_length_m);
+      ray_end = origin + unit_ray * ray_length;
+    } else {
+      ray_end = point_G + unit_ray * truncation_distance;
+    }
     const Point ray_start = voxel_carving_enabled
                                 ? origin
                                 : (point_G - unit_ray * truncation_distance);

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -61,14 +61,16 @@ class TsdfIntegratorBase {
   // NOT thread safe.
   virtual void integratePointCloud(const Transformation& T_G_C,
                                    const Pointcloud& points_C,
-                                   const Colors& colors) = 0;
+                                   const Colors& colors,
+                                   const bool freespace_points = false) = 0;
 
   // Returns a CONST ref of the config.
   const Config& getConfig() const { return config_; }
 
  protected:
   // Thread safe.
-  inline bool isPointValid(const Point& point_C, bool* is_clearing) const;
+  inline bool isPointValid(const Point& point_C, const bool freespace_point,
+                           bool* is_clearing) const;
 
   // Will return a pointer to a voxel located at global_voxel_idx in the tsdf
   // layer. Thread safe.
@@ -137,10 +139,12 @@ class SimpleTsdfIntegrator : public TsdfIntegratorBase {
       : TsdfIntegratorBase(config, layer) {}
 
   void integratePointCloud(const Transformation& T_G_C,
-                           const Pointcloud& points_C, const Colors& colors);
+                           const Pointcloud& points_C, const Colors& colors,
+                           const bool freespace_points = false);
 
   void integrateFunction(const Transformation& T_G_C,
                          const Pointcloud& points_C, const Colors& colors,
+                         const bool freespace_points,
                          ThreadSafeIndex* index_getter);
 };
 
@@ -152,12 +156,14 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
       : TsdfIntegratorBase(config, layer) {}
 
   void integratePointCloud(const Transformation& T_G_C,
-                           const Pointcloud& points_C, const Colors& colors);
+                           const Pointcloud& points_C, const Colors& colors,
+                           const bool freespace_points = false);
 
  private:
   inline void bundleRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
-      const Colors& colors, ThreadSafeIndex* index_getter,
+      const Colors& colors, const bool freespace_points,
+      ThreadSafeIndex* index_getter,
       AnyIndexHashMapType<AlignedVector<size_t>>::type* voxel_map,
       AnyIndexHashMapType<AlignedVector<size_t>>::type* clear_map);
 
@@ -190,10 +196,12 @@ class FastTsdfIntegrator : public TsdfIntegratorBase {
 
   void integrateFunction(const Transformation& T_G_C,
                          const Pointcloud& points_C, const Colors& colors,
+                         const bool freespace_points,
                          ThreadSafeIndex* index_getter);
 
   void integratePointCloud(const Transformation& T_G_C,
-                           const Pointcloud& points_C, const Colors& colors);
+                           const Pointcloud& points_C, const Colors& colors,
+                           const bool freespace_points = false);
 
  private:
   // Two approximate sets are used below. The limitations of these sets are

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -9,8 +9,9 @@
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <std_srvs/Empty.h>
-#include <string>
 #include <visualization_msgs/MarkerArray.h>
+#include <memory>
+#include <string>
 
 #include <voxblox/core/tsdf_map.h>
 #include <voxblox/integrator/tsdf_integrator.h>
@@ -33,11 +34,18 @@ class TsdfServer {
   TsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
   virtual ~TsdfServer() {}
 
-  virtual void insertPointcloud(
+  void insertPointcloud(const sensor_msgs::PointCloud2::Ptr& pointcloud);
+
+  void insertFreespacePointcloud(
       const sensor_msgs::PointCloud2::Ptr& pointcloud);
 
+  virtual void processPointCloudMessageAndInsert(
+      const sensor_msgs::PointCloud2::Ptr& pointcloud_msg,
+      const bool is_freespace_pointcloud);
+
   void integratePointcloud(const Transformation& T_G_C,
-                           const Pointcloud& ptcloud_C, const Colors& colors);
+                           const Pointcloud& ptcloud_C, const Colors& colors,
+                           const bool is_freespace_pointcloud = false);
   virtual void newPoseCallback(const Transformation& new_pose) {}
 
   void publishAllUpdatedTsdfVoxels();
@@ -79,18 +87,25 @@ class TsdfServer {
   // Pointcloud visualization settings.
   double slice_level_;
 
+  // If the system should subscribe to a pointcloud giving points in freespace
+  bool use_freespace_pointcloud_;
+
   // Mesh output settings. Mesh is only written to file if mesh_filename_ is
   // not empty.
   std::string mesh_filename_;
   // How to color the mesh.
   ColorMode color_mode_;
 
-  // Keep track of these for throttling.
+  // Will throttle to this message rate.
   ros::Duration min_time_between_msgs_;
-  ros::Time last_msg_time_;
+
+  // What output information to publish
+  bool publish_tsdf_info_;
+  bool publish_slices_;
 
   // Data subscribers.
   ros::Subscriber pointcloud_sub_;
+  ros::Subscriber freespace_pointcloud_sub_;
 
   // Publish markers for visualization.
   ros::Publisher mesh_pub_;

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -9,6 +9,9 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
       verbose_(true),
       world_frame_("world"),
       slice_level_(0.5),
+      use_freespace_pointcloud_(false),
+      publish_tsdf_info_(false),
+      publish_slices_(false),
       transformer_(nh, nh_private) {
   // Before subscribing, determine minimum time between messages.
   // 0 by default.
@@ -19,6 +22,9 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
 
   nh_private_.param("slice_level", slice_level_, slice_level_);
   nh_private_.param("world_frame", world_frame_, world_frame_);
+  nh_private_.param("publish_tsdf_info", publish_tsdf_info_,
+                    publish_tsdf_info_);
+  nh_private_.param("publish_slices", publish_slices_, publish_slices_);
 
   // Advertise topics.
   mesh_pub_ = nh_private_.advertise<voxblox_msgs::Mesh>("mesh", 1, true);
@@ -39,6 +45,16 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
                     pointcloud_queue_size);
   pointcloud_sub_ = nh_.subscribe("pointcloud", pointcloud_queue_size,
                                   &TsdfServer::insertPointcloud, this);
+
+  nh_private_.param("use_freespace_pointcloud", use_freespace_pointcloud_,
+                    use_freespace_pointcloud_);
+  if (use_freespace_pointcloud_) {
+    // points that are not inside an object, but may also not be on a surface.
+    // These will only be used to mark freespace beyond the truncation distance.
+    freespace_pointcloud_sub_ =
+        nh_.subscribe("freespace_pointcloud", pointcloud_queue_size,
+                      &TsdfServer::insertFreespacePointcloud, this);
+  }
 
   nh_private_.param("verbose", verbose_, verbose_);
 
@@ -155,14 +171,9 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
   }
 }
 
-void TsdfServer::insertPointcloud(
-    const sensor_msgs::PointCloud2::Ptr& pointcloud_msg) {
-  // Figure out if we should insert this.
-  if (pointcloud_msg->header.stamp - last_msg_time_ < min_time_between_msgs_) {
-    return;
-  }
-  last_msg_time_ = pointcloud_msg->header.stamp;
-
+void TsdfServer::processPointCloudMessageAndInsert(
+    const sensor_msgs::PointCloud2::Ptr& pointcloud_msg,
+    const bool is_freespace_pointcloud) {
   // Look up transform from sensor frame to world frame.
   Transformation T_G_C;
   if (transformer_.lookupTransform(pointcloud_msg->header.frame_id,
@@ -206,7 +217,7 @@ void TsdfServer::insertPointcloud(
       ROS_INFO("Integrating a pointcloud with %lu points.", points_C.size());
     }
     ros::WallTime start = ros::WallTime::now();
-    integratePointcloud(T_G_C, points_C, colors);
+    integratePointcloud(T_G_C, points_C, colors, is_freespace_pointcloud);
     ros::WallTime end = ros::WallTime::now();
     if (verbose_) {
       ROS_INFO("Finished integrating in %f seconds, have %lu blocks.",
@@ -214,24 +225,58 @@ void TsdfServer::insertPointcloud(
                tsdf_map_->getTsdfLayer().getNumberOfAllocatedBlocks());
     }
 
+    // Callback for inheriting classes.
+    newPoseCallback(T_G_C);
+  }
+}
+
+void TsdfServer::insertPointcloud(
+    const sensor_msgs::PointCloud2::Ptr& pointcloud_msg) {
+  // Figure out if we should insert this.
+  static ros::Time last_msg_time;
+  if (pointcloud_msg->header.stamp - last_msg_time < min_time_between_msgs_) {
+    return;
+  }
+  last_msg_time = pointcloud_msg->header.stamp;
+
+  constexpr bool is_freespace_pointcloud = false;
+  processPointCloudMessageAndInsert(pointcloud_msg, is_freespace_pointcloud);
+
+  if (publish_tsdf_info_) {
     publishAllUpdatedTsdfVoxels();
     publishTsdfSurfacePoints();
     publishTsdfOccupiedNodes();
-    publishSlices();
-
-    // Callback for inheriting classes.
-    newPoseCallback(T_G_C);
-
-    if (verbose_) {
-      ROS_INFO_STREAM("Timings: " << std::endl << timing::Timing::Print());
-    }
   }
+  if (publish_slices_) {
+    publishSlices();
+  }
+
+  if (verbose_) {
+    ROS_INFO_STREAM("Timings: " << std::endl << timing::Timing::Print());
+    ROS_INFO_STREAM(
+        "Layer memory: " << tsdf_map_->getTsdfLayer().getMemorySize());
+  }
+}
+
+void TsdfServer::insertFreespacePointcloud(
+    const sensor_msgs::PointCloud2::Ptr& pointcloud_msg) {
+  // Figure out if we should insert this.
+  static ros::Time last_msg_time;
+  if (pointcloud_msg->header.stamp - last_msg_time < min_time_between_msgs_) {
+    return;
+  }
+  last_msg_time = pointcloud_msg->header.stamp;
+
+  constexpr bool is_freespace_pointcloud = true;
+  processPointCloudMessageAndInsert(pointcloud_msg, is_freespace_pointcloud);
 }
 
 void TsdfServer::integratePointcloud(const Transformation& T_G_C,
                                      const Pointcloud& ptcloud_C,
-                                     const Colors& colors) {
-  tsdf_integrator_->integratePointCloud(T_G_C, ptcloud_C, colors);
+                                     const Colors& colors,
+                                     const bool is_freespace_pointcloud) {
+  tsdf_integrator_->integratePointCloud(T_G_C, ptcloud_C, colors,
+                                        is_freespace_pointcloud);
 }
 
 void TsdfServer::publishAllUpdatedTsdfVoxels() {


### PR DESCRIPTION
I waited way too long to sort the issues with pr #78 and all the internal changes I made to the TSDF integrator meant I pretty much needed to redo it all.

So this pr does that. It also adds the flags to disable publishing slices and tsdf into to the TSDF server as I saw they were missing.