### PR TITLE
better naming and dropping normals

### DIFF
--- a/voxblox_msgs/msg/Triangle.msg
+++ b/voxblox_msgs/msg/Triangle.msg
@@ -5,11 +5,6 @@ float32[3] x
 float32[3] y
 float32[3] z
 
-# Normals
-float32[3] nx
-float32[3] ny
-float32[3] nz
-
 # Color
 uint8[3] r
 uint8[3] g

--- a/voxblox_ros/include/voxblox_ros/mesh_vis.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_vis.h
@@ -156,10 +156,6 @@ inline void generateVoxbloxMeshMsg(const MeshLayer::Ptr& mesh_layer,
         triangle.y[local_vert_idx] = mesh->vertices[global_vert_idx].y();
         triangle.z[local_vert_idx] = mesh->vertices[global_vert_idx].z();
 
-        triangle.nx[local_vert_idx] = mesh->normals[global_vert_idx].x();
-        triangle.ny[local_vert_idx] = mesh->normals[global_vert_idx].y();
-        triangle.nz[local_vert_idx] = mesh->normals[global_vert_idx].z();
-
         std_msgs::ColorRGBA color_msg =
             getVertexColor(mesh, color_mode, global_vert_idx);
 

--- a/voxblox_rviz_plugin/include/voxblox_rviz_plugin/voxblox_mesh_visual.h
+++ b/voxblox_rviz_plugin/include/voxblox_rviz_plugin/voxblox_mesh_visual.h
@@ -25,8 +25,8 @@ class VoxbloxMeshVisual {
   Ogre::SceneNode* frame_node_;
   Ogre::SceneManager* scene_manager_;
 
-  uint instance_number_;
-  static uint instance_counter_;
+  unsigned int instance_number_;
+  static unsigned int instance_counter_;
 
   voxblox::AnyIndexHashMapType<Ogre::ManualObject*>::type object_map_;
 };

--- a/voxblox_rviz_plugin/include/voxblox_rviz_plugin/voxblox_mesh_visual.h
+++ b/voxblox_rviz_plugin/include/voxblox_rviz_plugin/voxblox_mesh_visual.h
@@ -25,6 +25,9 @@ class VoxbloxMeshVisual {
   Ogre::SceneNode* frame_node_;
   Ogre::SceneManager* scene_manager_;
 
+  uint instance_number_;
+  static uint instance_counter_;
+
   voxblox::AnyIndexHashMapType<Ogre::ManualObject*>::type object_map_;
 };
 

--- a/voxblox_rviz_plugin/src/voxblox_mesh_visual.cc
+++ b/voxblox_rviz_plugin/src/voxblox_mesh_visual.cc
@@ -5,7 +5,7 @@
 
 namespace voxblox_rviz_plugin {
 
-uint VoxbloxMeshVisual::instance_counter_ = 0;
+unsigned int VoxbloxMeshVisual::instance_counter_ = 0;
 
 VoxbloxMeshVisual::VoxbloxMeshVisual(Ogre::SceneManager* scene_manager,
                                      Ogre::SceneNode* parent_node) {

--- a/voxblox_rviz_plugin/src/voxblox_mesh_visual.cc
+++ b/voxblox_rviz_plugin/src/voxblox_mesh_visual.cc
@@ -5,10 +5,13 @@
 
 namespace voxblox_rviz_plugin {
 
+uint VoxbloxMeshVisual::instance_counter_ = 0;
+
 VoxbloxMeshVisual::VoxbloxMeshVisual(Ogre::SceneManager* scene_manager,
                                      Ogre::SceneNode* parent_node) {
   scene_manager_ = scene_manager;
   frame_node_ = parent_node->createChildSceneNode();
+  instance_number_ = instance_counter_++;
 }
 
 VoxbloxMeshVisual::~VoxbloxMeshVisual() {
@@ -33,7 +36,8 @@ void VoxbloxMeshVisual::setMessage(const voxblox_msgs::Mesh::ConstPtr& msg) {
     } else {
       std::string object_name = std::to_string(index.x()) + std::string(" ") +
                                 std::to_string(index.y()) + std::string(" ") +
-                                std::to_string(index.z());
+                                std::to_string(index.z()) + std::string(" ") +
+                                std::to_string(instance_number_);
       ogre_object = scene_manager_->createManualObject(object_name);
       object_map_.insert(std::make_pair(index, ogre_object));
 
@@ -50,10 +54,8 @@ void VoxbloxMeshVisual::setMessage(const voxblox_msgs::Mesh::ConstPtr& msg) {
       for (size_t i = 0; i < 3; ++i) {
         // sanity checks
         if (std::isfinite(triangle.x[i]) && std::isfinite(triangle.y[i]) &&
-            std::isfinite(triangle.z[i]) && std::isfinite(triangle.nx[i]) &&
-            std::isfinite(triangle.ny[i]) && std::isfinite(triangle.nz[i])) {
+            std::isfinite(triangle.z[i])) {
           ogre_object->position(triangle.x[i], triangle.y[i], triangle.z[i]);
-          ogre_object->normal(triangle.nx[i], triangle.ny[i], triangle.nz[i]);
 
           constexpr float color_conv_factor = 1.0f / 255.0f;
           ogre_object->colour(


### PR DESCRIPTION
Ensures multiple instances have unique names in rviz, preventing a crash when using multiple instances of voxblox.
Also took the opportunity to drop the normals from the message, turns out rviz doesn't need them.