### PR TITLE
Feature/esdf speedup

### DIFF
--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -151,17 +151,6 @@ class EsdfIntegrator {
   FloatingPoint esdf_voxel_size_;
 
   IndexSet updated_blocks_;
-
-  // We need to prevent simultaneous access to the voxels in the map. We could
-  // put a single mutex on the map or on the blocks, but as voxel updating is
-  // the most expensive operation in integration and most voxels are close
-  // together, both strategies would bottleneck the system. We could make a
-  // mutex per voxel, but this is too ram heavy as one mutex = 40 bytes.
-  // Because of this we create an array that is indexed by the first n bits of
-  // the voxels hash. Assuming a uniform hash distribution, this means the
-  // chance of two threads needing the same lock for unrelated voxels is
-  // (num_threads / (2^n)). For 8 threads and 12 bits this gives 0.2%.
-  ApproxHashArray<12, std::mutex> mutexes_;
 };
 
 }  // namespace voxblox

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -11,7 +11,6 @@
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"
 #include "voxblox/integrator/integrator_utils.h"
-#include "voxblox/utils/approx_hash_array.h"
 #include "voxblox/utils/bucket_queue.h"
 #include "voxblox/utils/timing.h"
 

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -36,7 +36,7 @@ class EsdfIntegrator {
     FloatingPoint default_distance_m = 2.0;
     // For cheaper but less accurate map updates: the minimum difference in
     // a voxel distance, before the change is propagated.
-    FloatingPoint min_diff_m = 0.01;
+    FloatingPoint min_diff_m = 0.001;
     // Minimum weight to consider a TSDF value seen at.
     float min_weight = 1e-6;
     // Number of buckets for the bucketed priority queue.

--- a/voxblox/include/voxblox/utils/bucket_queue.h
+++ b/voxblox/include/voxblox/utils/bucket_queue.h
@@ -29,7 +29,6 @@ class BucketQueue {
 
   // WARNING: will CLEAR THE QUEUE!
   void setNumBuckets(int num_buckets, double max_val) {
-    std::lock_guard<std::mutex> lock(mutex_);
     max_val_ = max_val;
     num_buckets_ = num_buckets;
     buckets_.clear();
@@ -38,7 +37,6 @@ class BucketQueue {
   }
 
   void push(const T& key, double value) {
-    std::lock_guard<std::mutex> lock(mutex_);
     CHECK_NE(num_buckets_, 0);
     if (value > max_val_) {
       value = max_val_;
@@ -56,7 +54,6 @@ class BucketQueue {
   }
 
   void pop() {
-    std::lock_guard<std::mutex> lock(mutex_);
     if (empty()) {
       return;
     }
@@ -71,7 +68,6 @@ class BucketQueue {
   }
 
   T front() {
-    std::lock_guard<std::mutex> lock(mutex_);
     CHECK_NE(num_buckets_, 0);
     CHECK(!empty());
     while (buckets_[last_bucket_index_].empty() &&
@@ -82,12 +78,10 @@ class BucketQueue {
   }
 
   bool empty() {
-    std::lock_guard<std::mutex> lock(mutex_);
     return num_elements_ == 0;
   }
 
   void clear() {
-    std::lock_guard<std::mutex> lock(mutex_);
     buckets_.clear();
     buckets_.resize(num_buckets_);
     last_bucket_index_ = 0;
@@ -103,9 +97,6 @@ class BucketQueue {
   int last_bucket_index_;
   // This is also to speed up empty checks.
   size_t num_elements_;
-
-  // Lets threading happen
-  std::mutex mutex_;
 };
 
 #endif  // VOXBLOX_UTILS_BUCKET_QUEUE_H_

--- a/voxblox/include/voxblox/utils/bucket_queue.h
+++ b/voxblox/include/voxblox/utils/bucket_queue.h
@@ -3,7 +3,6 @@
 
 #include <glog/logging.h>
 #include <deque>
-#include <mutex>
 #include <queue>
 #include <vector>
 
@@ -77,9 +76,7 @@ class BucketQueue {
     return buckets_[last_bucket_index_].front();
   }
 
-  bool empty() {
-    return num_elements_ == 0;
-  }
+  bool empty() { return num_elements_ == 0; }
 
   void clear() {
     buckets_.clear();

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -520,10 +520,6 @@ void EsdfIntegrator::processRaiseSet() {
       EsdfVoxel& neighbor_voxel =
           neighbor_block->getVoxelByVoxelIndex(neighbor_voxel_index);
 
-      VoxelIndex global_voxel_index =
-          neighbor_block_index * esdf_voxels_per_side_ + neighbor_voxel_index;
-      std::lock_guard<std::mutex> lock(mutexes_.get(global_voxel_index));
-
       // Do NOT update unobserved distances.
       if (!neighbor_voxel.observed) {
         continue;
@@ -563,10 +559,6 @@ void EsdfIntegrator::processOpenSet() {
     }
 
     EsdfVoxel& esdf_voxel = esdf_block->getVoxelByVoxelIndex(kv.second);
-
-    VoxelIndex global_voxel_index =
-        kv.first * esdf_voxels_per_side_ + kv.second;
-    std::lock_guard<std::mutex> lock(mutexes_.get(global_voxel_index));
 
     // Again, no point updating unobserved voxels.
     if (!esdf_voxel.observed) {

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -2,9 +2,9 @@
   <arg name="play_bag" default="true" />
   <arg name="bag_file" default="/home/z/Datasets/cow_and_lady/data.bag"/>
   <arg name="voxel_size" default="0.05"/>
-  <arg name="generate_esdf" default="false" />
+  <arg name="generate_esdf" default="true" />
 
-  <node name="player" pkg="rosbag" type="play" output="screen" args="-r 1.0 --clock $(arg bag_file)" if="$(arg play_bag)"/>
+  <node name="player" pkg="rosbag" type="play" output="screen" args="-r 1.0 -s 10 -u 30 --clock $(arg bag_file)" if="$(arg play_bag)"/>
 
    <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
     <remap from="pointcloud" to="/camera/depth_registered/points"/>
@@ -13,8 +13,8 @@
     <param name="voxel_carving_enabled" value="true" />
     <param name="color_mode" value="color" />
     <param name="use_tf_transforms" value="false" />
-    <param name="update_mesh_every_n_sec" value="0.1" />
-    <param name="min_time_between_msgs_sec" value="0.0" />
+    <param name="update_mesh_every_n_sec" value="1.0" />
+    <param name="min_time_between_msgs_sec" value="0.2" />
     <param name="method" value="fast" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -43,6 +43,8 @@ EsdfServer::EsdfServer(const ros::NodeHandle& nh,
   nh_private_.param("esdf_default_distance_m",
                     esdf_integrator_config.default_distance_m,
                     esdf_integrator_config.default_distance_m);
+  nh_private_.param("esdf_min_diff_m", esdf_integrator_config.min_diff_m,
+                    esdf_integrator_config.min_diff_m);
 
   esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
                                             tsdf_map_->getTsdfLayerPtr(),

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -345,6 +345,8 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
     nh_private_.param("esdf_default_distance_m",
                       esdf_integrator_config.default_distance_m,
                       esdf_integrator_config.default_distance_m);
+    nh_private_.param("esdf_min_diff_m", esdf_integrator_config.min_diff_m,
+                      esdf_integrator_config.min_diff_m);
 
     esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
                                               tsdf_map_->getTsdfLayerPtr(),


### PR DESCRIPTION
@helenol  Had a look at the esdf for a bit. Turns out just implementing the diff param you had in the config makes a huge difference. Even setting it to really small values (current default = 1 mm) makes a large difference.

On the cow and lady dataset with 5 cm voxels:
Before:
esdf                         32 07.620161       (00.238130 +- 00.125271)       
esdf/propagate_tsdf          32 00.200999       (00.006281 +- 00.003060)      
esdf/raise_esdf              32 03.248260       (00.101508 +- 00.058812)      
esdf/update_esdf             32 04.170673       (00.130334 +- 00.064808)       

After:
esdf                         33 01.856199       (00.056248 +- 00.026540)    
esdf/propagate_tsdf          33 00.126689       (00.003839 +- 00.001716)   
esdf/raise_esdf              33 00.320779       (00.009721 +- 00.005105)  
esdf/update_esdf             33 01.408528       (00.042683 +- 00.021910)   

Also had a look at threading but its going to be challenging as the current layout would need a lot of locks and the overhead of them cancels out any benefit. Will leave till after ICRA.

