### PR TITLE
Clean up ros param handling

### DIFF
--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -1,6 +1,8 @@
 #ifndef VOXBLOX_ROS_ESDF_SERVER_H_
 #define VOXBLOX_ROS_ESDF_SERVER_H_
 
+#include <memory>
+
 #include <voxblox/core/esdf_map.h>
 #include <voxblox/integrator/esdf_integrator.h>
 #include <voxblox_msgs/Layer.h>
@@ -14,6 +16,11 @@ class EsdfServer : public TsdfServer {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   EsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+  EsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private,
+             const EsdfMap::Config& esdf_config,
+             const EsdfIntegrator::Config& esdf_integrator_config,
+             const TsdfMap::Config& tsdf_config,
+             const TsdfIntegratorBase::Config& tsdf_integrator_config);
   virtual ~EsdfServer() {}
 
   void publishAllUpdatedEsdfVoxels();

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -1,0 +1,127 @@
+#ifndef VOXBLOX_ROS_ROS_PARAMS_H_
+#define VOXBLOX_ROS_ROS_PARAMS_H_
+
+#include <voxblox/core/esdf_map.h>
+#include <voxblox/core/tsdf_map.h>
+#include <voxblox/integrator/esdf_integrator.h>
+#include <voxblox/integrator/tsdf_integrator.h>
+
+namespace voxblox {
+
+inline TsdfMap::Config getTsdfMapConfigFromRosParam(
+    const ros::NodeHandle& nh_private) {
+  TsdfMap::Config tsdf_config;
+
+  // Workaround for OS X on mac mini not having specializations for float
+  // for some reason.
+  double voxel_size = tsdf_config.tsdf_voxel_size;
+  int voxels_per_side = tsdf_config.tsdf_voxels_per_side;
+  nh_private.param("tsdf_voxel_size", voxel_size, voxel_size);
+  nh_private.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
+  if (!isPowerOfTwo(voxels_per_side)) {
+    ROS_ERROR("voxels_per_side must be a power of 2, setting to default value");
+    voxels_per_side = tsdf_config.tsdf_voxels_per_side;
+  }
+
+  tsdf_config.tsdf_voxel_size = static_cast<FloatingPoint>(voxel_size);
+  tsdf_config.tsdf_voxels_per_side = voxels_per_side;
+
+  return tsdf_config;
+}
+
+inline TsdfIntegratorBase::Config getTsdfIntegratorConfigFromRosParam(
+    const ros::NodeHandle& nh_private) {
+  TsdfIntegratorBase::Config integrator_config;
+
+  integrator_config.voxel_carving_enabled = true;
+
+  // Used to be * 4 according to Marius's experience, now * 2.
+  // This should be made bigger again if behind-surface weighting is improved.
+  TsdfMap::Config tsdf_config;
+  nh_private.param("tsdf_voxel_size", tsdf_config.tsdf_voxel_size,
+                   tsdf_config.tsdf_voxel_size);
+  integrator_config.default_truncation_distance =
+      tsdf_config.tsdf_voxel_size * 4;
+
+  double truncation_distance = integrator_config.default_truncation_distance;
+  double max_weight = integrator_config.max_weight;
+  nh_private.param("voxel_carving_enabled",
+                   integrator_config.voxel_carving_enabled,
+                   integrator_config.voxel_carving_enabled);
+  nh_private.param("truncation_distance", truncation_distance,
+                   truncation_distance);
+  nh_private.param("max_ray_length_m", integrator_config.max_ray_length_m,
+                   integrator_config.max_ray_length_m);
+  nh_private.param("min_ray_length_m", integrator_config.min_ray_length_m,
+                   integrator_config.min_ray_length_m);
+  nh_private.param("max_weight", max_weight, max_weight);
+  nh_private.param("use_const_weight", integrator_config.use_const_weight,
+                   integrator_config.use_const_weight);
+  nh_private.param("allow_clear", integrator_config.allow_clear,
+                   integrator_config.allow_clear);
+  nh_private.param("start_voxel_subsampling_factor",
+                   integrator_config.start_voxel_subsampling_factor,
+                   integrator_config.start_voxel_subsampling_factor);
+  nh_private.param("max_consecutive_ray_collisions",
+                   integrator_config.max_consecutive_ray_collisions,
+                   integrator_config.max_consecutive_ray_collisions);
+  nh_private.param("clear_checks_every_n_frames",
+                   integrator_config.clear_checks_every_n_frames,
+                   integrator_config.clear_checks_every_n_frames);
+  nh_private.param("max_integration_time_s",
+                   integrator_config.max_integration_time_s,
+                   integrator_config.max_integration_time_s);
+  nh_private.param("anti_grazing", integrator_config.enable_anti_grazing,
+                   integrator_config.enable_anti_grazing);
+  integrator_config.default_truncation_distance =
+      static_cast<float>(truncation_distance);
+  integrator_config.max_weight = static_cast<float>(max_weight);
+
+  return integrator_config;
+}
+
+inline EsdfMap::Config getEsdfMapConfigFromRosParam(
+    const ros::NodeHandle& nh_private) {
+  EsdfMap::Config esdf_config;
+
+  // TODO(helenol): in the future allow different ESDF and TSDF voxel sizes...
+  nh_private.param("tsdf_voxel_size", esdf_config.esdf_voxel_size,
+                   esdf_config.esdf_voxel_size);
+
+  // No specialization for ros param for size_t, so have to do this annoying
+  // workaround.
+  int voxels_per_side = esdf_config.esdf_voxels_per_side;
+  nh_private.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
+  if (!isPowerOfTwo(voxels_per_side)) {
+    ROS_ERROR("voxels_per_side must be a power of 2, setting to default value");
+    voxels_per_side = esdf_config.esdf_voxels_per_side;
+  }
+  esdf_config.esdf_voxels_per_side = voxels_per_side;
+
+  return esdf_config;
+}
+
+inline EsdfIntegrator::Config getEsdfIntegratorConfigFromRosParam(
+    const ros::NodeHandle& nh_private) {
+  EsdfIntegrator::Config esdf_integrator_config;
+
+  // TODO(helenol): in the future allow different ESDF and TSDF voxel sizes...
+  // Make sure that this is the same as the truncation distance OR SMALLER!
+  nh_private.param("tsdf_voxel_size", esdf_integrator_config.min_distance_m,
+                   esdf_integrator_config.min_distance_m);
+  nh_private.param("esdf_max_distance_m", esdf_integrator_config.max_distance_m,
+                   esdf_integrator_config.max_distance_m);
+  nh_private.param("esdf_default_distance_m",
+                   esdf_integrator_config.default_distance_m,
+                   esdf_integrator_config.default_distance_m);
+  nh_private.param("esdf_min_diff_m", esdf_integrator_config.min_diff_m,
+                   esdf_integrator_config.min_diff_m);
+
+  return esdf_integrator_config;
+}
+
+}  // namespace voxblox
+
+#endif  // VOXBLOX_ROS_ROS_PARAMS_H_
+
+#include "voxblox_ros/conversions_inl.h"

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -35,8 +35,6 @@ inline TsdfIntegratorBase::Config getTsdfIntegratorConfigFromRosParam(
 
   integrator_config.voxel_carving_enabled = true;
 
-  // Used to be * 4 according to Marius's experience, now * 2.
-  // This should be made bigger again if behind-surface weighting is improved.
   TsdfMap::Config tsdf_config;
   nh_private.param("tsdf_voxel_size", tsdf_config.tsdf_voxel_size,
                    tsdf_config.tsdf_voxel_size);
@@ -109,6 +107,7 @@ inline EsdfIntegrator::Config getEsdfIntegratorConfigFromRosParam(
   // Make sure that this is the same as the truncation distance OR SMALLER!
   nh_private.param("tsdf_voxel_size", esdf_integrator_config.min_distance_m,
                    esdf_integrator_config.min_distance_m);
+
   nh_private.param("esdf_max_distance_m", esdf_integrator_config.max_distance_m,
                    esdf_integrator_config.max_distance_m);
   nh_private.param("esdf_default_distance_m",
@@ -123,5 +122,3 @@ inline EsdfIntegrator::Config getEsdfIntegratorConfigFromRosParam(
 }  // namespace voxblox
 
 #endif  // VOXBLOX_ROS_ROS_PARAMS_H_
-
-#include "voxblox_ros/conversions_inl.h"

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -32,7 +32,12 @@ class TsdfServer {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   TsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+  TsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private,
+             const TsdfMap::Config& config,
+             const TsdfIntegratorBase::Config& integrator_config);
   virtual ~TsdfServer() {}
+
+  void getServerConfigFromRosParam(const ros::NodeHandle& nh_private);
 
   void insertPointcloud(const sensor_msgs::PointCloud2::Ptr& pointcloud);
 
@@ -106,6 +111,9 @@ class TsdfServer {
   // Data subscribers.
   ros::Subscriber pointcloud_sub_;
   ros::Subscriber freespace_pointcloud_sub_;
+
+  // Subscriber settings.
+  int pointcloud_queue_size_;
 
   // Publish markers for visualization.
   ros::Publisher mesh_pub_;

--- a/voxblox_ros/launch/cow_dataset_bag.launch
+++ b/voxblox_ros/launch/cow_dataset_bag.launch
@@ -16,6 +16,7 @@
     <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="min_time_between_msgs_sec" value="0.2" />
     <param name="method" value="merged" />
+    <param name="anti_grazing" value="false">
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />

--- a/voxblox_ros/launch/euroc_dataset_bag.launch
+++ b/voxblox_ros/launch/euroc_dataset_bag.launch
@@ -57,6 +57,7 @@
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="slice_level" value="1.0" />
     <param name="method" value="merged" />
+    <param name="anti_grazing" value="false">
     <param name="use_const_weight" value="false" />
 
     <rosparam file="$(find voxblox_ros)/cfg/euroc_dataset.yaml"/>

--- a/voxblox_ros/launch/kitti_dataset.launch
+++ b/voxblox_ros/launch/kitti_dataset.launch
@@ -34,7 +34,8 @@
     <param name="esdf_default_distance_m" value="5.0" />
     <param name="min_time_between_msgs_sec" value="0.2" />
     <param name="slice_level" value="1.0" />
-    <param name="method" value="merged_discard" />
+    <param name="method" value="merged" />
+    <param name="anti_grazing" value="true">
     <param name="use_const_weight" value="true" />
     <param name="mesh_filename" value="$(find voxblox_ros)/mesh_results/$(anon kitti).ply" />
   </node>

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -1,58 +1,69 @@
 #include <voxblox_ros/conversions.h>
 
 #include "voxblox_ros/esdf_server.h"
+#include "voxblox_ros/ros_params.h"
 
 namespace voxblox {
 
 EsdfServer::EsdfServer(const ros::NodeHandle& nh,
-                       const ros::NodeHandle& nh_private)
-    : TsdfServer(nh, nh_private), clear_sphere_for_planning_(false) {
+                       const ros::NodeHandle& nh_private,
+                       const EsdfMap::Config& esdf_config,
+                       const EsdfIntegrator::Config& esdf_integrator_config,
+                       const TsdfMap::Config& tsdf_config,
+                       const TsdfIntegratorBase::Config& tsdf_integrator_config)
+    : TsdfServer(nh, nh_private, tsdf_config, tsdf_integrator_config),
+      clear_sphere_for_planning_(false) {
+  // Set up map and integrator.
+  esdf_map_.reset(new EsdfMap(esdf_config));
+  esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
+                                            tsdf_map_->getTsdfLayerPtr(),
+                                            esdf_map_->getEsdfLayerPtr()));
+
+  // Set up publisher.
   esdf_pointcloud_pub_ =
       nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI> >("esdf_pointcloud",
                                                               1, true);
   esdf_slice_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI> >(
       "esdf_slice", 1, true);
-
   esdf_map_pub_ =
       nh_private_.advertise<voxblox_msgs::Layer>("esdf_map_out", 1, false);
 
+  // Set up subscriber.
   esdf_map_sub_ = nh_private_.subscribe("esdf_map_in", 1,
                                         &EsdfServer::esdfMapCallback, this);
 
-  EsdfMap::Config esdf_config;
+  // Whether to clear each new pose as it comes in, and then set a sphere
+  // around it to occupied.
+  nh_private_.param("clear_sphere_for_planning", clear_sphere_for_planning_,
+                    clear_sphere_for_planning_);
+}
 
-  // TODO(helenol): in the future allow different ESDF and TSDF voxel sizes...
-  nh_private_.param("tsdf_voxel_size", esdf_config.esdf_voxel_size,
-                    esdf_config.esdf_voxel_size);
-  // No specialization for ros param for size_t, so have to do this annoying
-  // workaround.
-  int voxels_per_side = esdf_config.esdf_voxels_per_side;
-  nh_private_.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
-  if (!isPowerOfTwo(voxels_per_side)) {
-    ROS_ERROR("voxels_per_side must be a power of 2, setting to default value");
-    voxels_per_side = esdf_config.esdf_voxels_per_side;
-  }
-  esdf_config.esdf_voxels_per_side = voxels_per_side;
+EsdfServer::EsdfServer(const ros::NodeHandle& nh,
+                       const ros::NodeHandle& nh_private)
+    : TsdfServer(nh, nh_private), clear_sphere_for_planning_(false) {
+  // Get config from ros params.
+  EsdfIntegrator::Config esdf_integrator_config =
+      getEsdfIntegratorConfigFromRosParam(nh_private_);
+  EsdfMap::Config esdf_config = getEsdfMapConfigFromRosParam(nh_private_);
 
+  // Set up map and integrator.
   esdf_map_.reset(new EsdfMap(esdf_config));
-
-  EsdfIntegrator::Config esdf_integrator_config;
-  // Make sure that this is the same as the truncation distance OR SMALLER!
-  esdf_integrator_config.min_distance_m = esdf_config.esdf_voxel_size;
-  // esdf_integrator_config.min_distance_m =
-  //    tsdf_integrator_->getConfig().default_truncation_distance;
-  nh_private_.param("esdf_max_distance_m",
-                    esdf_integrator_config.max_distance_m,
-                    esdf_integrator_config.max_distance_m);
-  nh_private_.param("esdf_default_distance_m",
-                    esdf_integrator_config.default_distance_m,
-                    esdf_integrator_config.default_distance_m);
-  nh_private_.param("esdf_min_diff_m", esdf_integrator_config.min_diff_m,
-                    esdf_integrator_config.min_diff_m);
-
   esdf_integrator_.reset(new EsdfIntegrator(esdf_integrator_config,
                                             tsdf_map_->getTsdfLayerPtr(),
                                             esdf_map_->getEsdfLayerPtr()));
+
+  // Set up publisher.
+  esdf_pointcloud_pub_ =
+      nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI> >("esdf_pointcloud",
+                                                              1, true);
+  esdf_slice_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI> >(
+      "esdf_slice", 1, true);
+  esdf_map_pub_ =
+      nh_private_.advertise<voxblox_msgs::Layer>("esdf_map_out", 1, false);
+
+  // Set up subscriber.
+  esdf_map_sub_ = nh_private_.subscribe("esdf_map_in", 1,
+                                        &EsdfServer::esdfMapCallback, this);
 
   // Whether to clear each new pose as it comes in, and then set a sphere
   // around it to occupied.

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -1,11 +1,62 @@
 #include "voxblox_ros/tsdf_server.h"
 
+#include "voxblox_ros/ros_params.h"
+
 namespace voxblox {
 
 TsdfServer::TsdfServer(const ros::NodeHandle& nh,
                        const ros::NodeHandle& nh_private)
+    : TsdfServer(nh, nh_private, getTsdfMapConfigFromRosParam(nh_private),
+                 getTsdfIntegratorConfigFromRosParam(nh_private)) {}
+
+void TsdfServer::getServerConfigFromRosParam(
+    const ros::NodeHandle& nh_private) {
+  // Before subscribing, determine minimum time between messages.
+  // 0 by default.
+  double min_time_between_msgs_sec = 0.0;
+  nh_private.param("min_time_between_msgs_sec", min_time_between_msgs_sec,
+                   min_time_between_msgs_sec);
+  min_time_between_msgs_.fromSec(min_time_between_msgs_sec);
+
+  nh_private.param("slice_level", slice_level_, slice_level_);
+  nh_private.param("world_frame", world_frame_, world_frame_);
+  nh_private.param("publish_tsdf_info", publish_tsdf_info_, publish_tsdf_info_);
+  nh_private.param("publish_slices", publish_slices_, publish_slices_);
+
+  nh_private.param("use_freespace_pointcloud", use_freespace_pointcloud_,
+                   use_freespace_pointcloud_);
+
+  nh_private.param("pointcloud_queue_size", pointcloud_queue_size_,
+                   pointcloud_queue_size_);
+
+  nh_private.param("verbose", verbose_, verbose_);
+
+  // Mesh settings.
+  nh_private.param("mesh_filename", mesh_filename_, mesh_filename_);
+  std::string color_mode("color");
+  nh_private.param("color_mode", color_mode, color_mode);
+  if (color_mode == "color" || color_mode == "colors") {
+    color_mode_ = ColorMode::kColor;
+  } else if (color_mode == "height") {
+    color_mode_ = ColorMode::kHeight;
+  } else if (color_mode == "normals") {
+    color_mode_ = ColorMode::kNormals;
+  } else if (color_mode == "lambert") {
+    color_mode_ = ColorMode::kLambert;
+  } else if (color_mode == "lambert_color") {
+    color_mode_ = ColorMode::kLambertColor;
+  } else {  // Default case is gray.
+    color_mode_ = ColorMode::kGray;
+  }
+}
+
+TsdfServer::TsdfServer(const ros::NodeHandle& nh,
+                       const ros::NodeHandle& nh_private,
+                       const TsdfMap::Config& config,
+                       const TsdfIntegratorBase::Config& integrator_config)
     : nh_(nh),
       nh_private_(nh_private),
+      pointcloud_queue_size_(1),
       verbose_(true),
       world_frame_("world"),
       slice_level_(0.5),
@@ -13,18 +64,7 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
       publish_tsdf_info_(false),
       publish_slices_(false),
       transformer_(nh, nh_private) {
-  // Before subscribing, determine minimum time between messages.
-  // 0 by default.
-  double min_time_between_msgs_sec = 0.0;
-  nh_private_.param("min_time_between_msgs_sec", min_time_between_msgs_sec,
-                    min_time_between_msgs_sec);
-  min_time_between_msgs_.fromSec(min_time_between_msgs_sec);
-
-  nh_private_.param("slice_level", slice_level_, slice_level_);
-  nh_private_.param("world_frame", world_frame_, world_frame_);
-  nh_private_.param("publish_tsdf_info", publish_tsdf_info_,
-                    publish_tsdf_info_);
-  nh_private_.param("publish_slices", publish_slices_, publish_slices_);
+  getServerConfigFromRosParam(nh_private);
 
   // Advertise topics.
   mesh_pub_ = nh_private_.advertise<voxblox_msgs::Mesh>("mesh", 1, true);
@@ -40,79 +80,21 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
   tsdf_slice_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI> >(
       "tsdf_slice", 1, true);
 
-  int pointcloud_queue_size = 1;
-  nh_private_.param("pointcloud_queue_size", pointcloud_queue_size,
-                    pointcloud_queue_size);
-  pointcloud_sub_ = nh_.subscribe("pointcloud", pointcloud_queue_size,
+  nh_private_.param("pointcloud_queue_size_", pointcloud_queue_size_,
+                    pointcloud_queue_size_);
+  pointcloud_sub_ = nh_.subscribe("pointcloud", pointcloud_queue_size_,
                                   &TsdfServer::insertPointcloud, this);
 
-  nh_private_.param("use_freespace_pointcloud", use_freespace_pointcloud_,
-                    use_freespace_pointcloud_);
   if (use_freespace_pointcloud_) {
     // points that are not inside an object, but may also not be on a surface.
     // These will only be used to mark freespace beyond the truncation distance.
     freespace_pointcloud_sub_ =
-        nh_.subscribe("freespace_pointcloud", pointcloud_queue_size,
+        nh_.subscribe("freespace_pointcloud", pointcloud_queue_size_,
                       &TsdfServer::insertFreespacePointcloud, this);
   }
 
-  nh_private_.param("verbose", verbose_, verbose_);
-
-  // Determine map parameters.
-  TsdfMap::Config config;
-  // Workaround for OS X on mac mini not having specializations for float
-  // for some reason.
-  double voxel_size = config.tsdf_voxel_size;
-  int voxels_per_side = config.tsdf_voxels_per_side;
-  nh_private_.param("tsdf_voxel_size", voxel_size, voxel_size);
-  nh_private_.param("tsdf_voxels_per_side", voxels_per_side, voxels_per_side);
-  if (!isPowerOfTwo(voxels_per_side)) {
-    ROS_ERROR("voxels_per_side must be a power of 2, setting to default value");
-    voxels_per_side = config.tsdf_voxels_per_side;
-  }
-
-  config.tsdf_voxel_size = static_cast<FloatingPoint>(voxel_size);
-  config.tsdf_voxels_per_side = voxels_per_side;
+  // Initialize TSDF Map and integrator.
   tsdf_map_.reset(new TsdfMap(config));
-
-  // Determine integrator parameters.
-  TsdfIntegratorBase::Config integrator_config;
-  integrator_config.voxel_carving_enabled = true;
-  // Used to be * 4 according to Marius's experience, now * 2.
-  // This should be made bigger again if behind-surface weighting is improved.
-  integrator_config.default_truncation_distance = config.tsdf_voxel_size * 4;
-
-  double truncation_distance = integrator_config.default_truncation_distance;
-  double max_weight = integrator_config.max_weight;
-  nh_private_.param("voxel_carving_enabled",
-                    integrator_config.voxel_carving_enabled,
-                    integrator_config.voxel_carving_enabled);
-  nh_private_.param("truncation_distance", truncation_distance,
-                    truncation_distance);
-  nh_private_.param("max_ray_length_m", integrator_config.max_ray_length_m,
-                    integrator_config.max_ray_length_m);
-  nh_private_.param("min_ray_length_m", integrator_config.min_ray_length_m,
-                    integrator_config.min_ray_length_m);
-  nh_private_.param("max_weight", max_weight, max_weight);
-  nh_private_.param("use_const_weight", integrator_config.use_const_weight,
-                    integrator_config.use_const_weight);
-  nh_private_.param("allow_clear", integrator_config.allow_clear,
-                    integrator_config.allow_clear);
-  nh_private_.param("start_voxel_subsampling_factor",
-                    integrator_config.start_voxel_subsampling_factor,
-                    integrator_config.start_voxel_subsampling_factor);
-  nh_private_.param("max_consecutive_ray_collisions",
-                    integrator_config.max_consecutive_ray_collisions,
-                    integrator_config.max_consecutive_ray_collisions);
-  nh_private_.param("clear_checks_every_n_frames",
-                    integrator_config.clear_checks_every_n_frames,
-                    integrator_config.clear_checks_every_n_frames);
-  nh_private_.param("max_integration_time_s",
-                    integrator_config.max_integration_time_s,
-                    integrator_config.max_integration_time_s);
-  integrator_config.default_truncation_distance =
-      static_cast<float>(truncation_distance);
-  integrator_config.max_weight = static_cast<float>(max_weight);
 
   std::string method("merged");
   nh_private_.param("method", method, method);
@@ -120,11 +102,6 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
     tsdf_integrator_.reset(new SimpleTsdfIntegrator(
         integrator_config, tsdf_map_->getTsdfLayerPtr()));
   } else if (method.compare("merged") == 0) {
-    integrator_config.enable_anti_grazing = false;
-    tsdf_integrator_.reset(new MergedTsdfIntegrator(
-        integrator_config, tsdf_map_->getTsdfLayerPtr()));
-  } else if (method.compare("merged_discard") == 0) {
-    integrator_config.enable_anti_grazing = true;
     tsdf_integrator_.reset(new MergedTsdfIntegrator(
         integrator_config, tsdf_map_->getTsdfLayerPtr()));
   } else if (method.compare("fast") == 0) {
@@ -133,24 +110,6 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
   } else {
     tsdf_integrator_.reset(new SimpleTsdfIntegrator(
         integrator_config, tsdf_map_->getTsdfLayerPtr()));
-  }
-
-  // Mesh settings.
-  nh_private_.param("mesh_filename", mesh_filename_, mesh_filename_);
-  std::string color_mode("color");
-  nh_private_.param("color_mode", color_mode, color_mode);
-  if (color_mode == "color" || color_mode == "colors") {
-    color_mode_ = ColorMode::kColor;
-  } else if (color_mode == "height") {
-    color_mode_ = ColorMode::kHeight;
-  } else if (color_mode == "normals") {
-    color_mode_ = ColorMode::kNormals;
-  } else if (color_mode == "lambert") {
-    color_mode_ = ColorMode::kLambert;
-  } else if (color_mode == "lambert_color") {
-    color_mode_ = ColorMode::kLambertColor;
-  } else {  // Default case is gray.
-    color_mode_ = ColorMode::kGray;
   }
 
   MeshIntegrator<TsdfVoxel>::Config mesh_config;


### PR DESCRIPTION
I wanted to create a EsdfServer object and configure it using the config structs, but the constructors are all mixing up the config structs with the ros params. I therefore added an option to pass the config structs to the constructors and tried to isolate the ros-params-to-config struct logic a bit. I think it's cleaner this way, if you disagree, ping me and we can discuss it offline.