### PR TITLE
Allow loading older maps.

### DIFF
--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -216,17 +216,19 @@ bool Layer<VoxelType>::isCompatible(const LayerProto& layer_proto) const {
   compatible &= (getType().compare(layer_proto.type()) == 0);
 
   if (!compatible) {
-    LOG(INFO) << "Voxel size of the loaded map is: " << layer_proto.voxel_size()
-              << " but the current map is: " << voxel_size_ << " check passed? "
-              << (layer_proto.voxel_size() == voxel_size_)
-              << "\nVPS of the loaded map is: " << layer_proto.voxels_per_side()
-              << " but the current map is: " << voxels_per_side_
-              << " check passed? "
-              << (layer_proto.voxels_per_side() == voxels_per_side_)
-              << "\nLayer type of the loaded map is: " << getType()
-              << " but the current map is: " << layer_proto.type()
-              << " check passed? "
-              << (getType().compare(layer_proto.type()) == 0) << std::endl;
+    LOG(WARNING)
+        << "Voxel size of the loaded map is: " << layer_proto.voxel_size()
+        << " but the current map is: " << voxel_size_ << " check passed? "
+        << (std::fabs(layer_proto.voxel_size() - voxel_size_) <
+            std::numeric_limits<FloatingPoint>::epsilon())
+        << "\nVPS of the loaded map is: " << layer_proto.voxels_per_side()
+        << " but the current map is: " << voxels_per_side_ << " check passed? "
+        << (layer_proto.voxels_per_side() == voxels_per_side_)
+        << "\nLayer type of the loaded map is: " << getType()
+        << " but the current map is: " << layer_proto.type()
+        << " check passed? " << (getType().compare(layer_proto.type()) == 0)
+        << "\nAre the maps using the same floating-point type? "
+        << (layer_proto.voxel_size() == voxel_size_) << std::endl;
   }
   return compatible;
 }

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -210,16 +210,32 @@ bool Layer<VoxelType>::addBlockFromProto(const BlockProto& block_proto,
 template <typename VoxelType>
 bool Layer<VoxelType>::isCompatible(const LayerProto& layer_proto) const {
   bool compatible = true;
-  compatible &= (layer_proto.voxel_size() == voxel_size_);
+  compatible &= (std::fabs(layer_proto.voxel_size() - voxel_size_) <
+                 std::numeric_limits<FloatingPoint>::epsilon());
   compatible &= (layer_proto.voxels_per_side() == voxels_per_side_);
   compatible &= (getType().compare(layer_proto.type()) == 0);
+
+  if (!compatible) {
+    LOG(INFO) << "Voxel size of the loaded map is: " << layer_proto.voxel_size()
+              << " but the current map is: " << voxel_size_ << " check passed? "
+              << (layer_proto.voxel_size() == voxel_size_)
+              << "\nVPS of the loaded map is: " << layer_proto.voxels_per_side()
+              << " but the current map is: " << voxels_per_side_
+              << " check passed? "
+              << (layer_proto.voxels_per_side() == voxels_per_side_)
+              << "\nLayer type of the loaded map is: " << getType()
+              << " but the current map is: " << layer_proto.type()
+              << " check passed? "
+              << (getType().compare(layer_proto.type()) == 0) << std::endl;
+  }
   return compatible;
 }
 
 template <typename VoxelType>
 bool Layer<VoxelType>::isCompatible(const BlockProto& block_proto) const {
   bool compatible = true;
-  compatible &= (block_proto.voxel_size() == voxel_size_);
+  compatible &= (std::fabs(block_proto.voxel_size() - voxel_size_) <
+                 std::numeric_limits<FloatingPoint>::epsilon());
   compatible &=
       (block_proto.voxels_per_side() == static_cast<int>(voxels_per_side_));
   return compatible;

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -80,7 +80,7 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
   tsdf_slice_pub_ = nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI> >(
       "tsdf_slice", 1, true);
 
-  nh_private_.param("pointcloud_queue_size_", pointcloud_queue_size_,
+  nh_private_.param("pointcloud_queue_size", pointcloud_queue_size_,
                     pointcloud_queue_size_);
   pointcloud_sub_ = nh_.subscribe("pointcloud", pointcloud_queue_size_,
                                   &TsdfServer::insertPointcloud, this);


### PR DESCRIPTION
@mfehr 
This is a bug caused by switching voxblox from double to float -- even though voxels are the same size, they fail a double-float comparison.

Let me know what you think about the extra compatibility messaging; I think it's quite useful since it took me like 20 minutes to figure out what "The layer information read from file is not compatible with the current layer!" meant, but I want to hear what you think about adding extra messaging.

@zarmomin FYI.