### PR TITLE
Add a service call to publish pointclouds on demand.

### DIFF
--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -30,6 +30,7 @@ class EsdfServer : public TsdfServer {
                             std_srvs::Empty::Response& response);  // NOLINT
 
   virtual void updateMesh();
+  virtual void publishPointclouds();
   virtual void newPoseCallback(const Transformation& T_G_C);
 
   // Call updateMesh if you want everything updated; call this specifically

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -60,6 +60,7 @@ class TsdfServer {
   virtual void publishSlices();
   virtual void updateMesh();    // Incremental update.
   virtual bool generateMesh();  // Batch update.
+  virtual void publishPointclouds();  // Publishes all available pointclouds.
 
   bool saveMapCallback(voxblox_msgs::FilePath::Request& request,     // NOLINT
                        voxblox_msgs::FilePath::Response& response);  // NOLINT
@@ -67,6 +68,9 @@ class TsdfServer {
                        voxblox_msgs::FilePath::Response& response);  // NOLINT
   bool generateMeshCallback(std_srvs::Empty::Request& request,       // NOLINT
                             std_srvs::Empty::Response& response);    // NOLINT
+  bool publishPointcloudsCallback(
+      std_srvs::Empty::Request& request,     // NOLINT
+      std_srvs::Empty::Response& response);  // NOLINT
 
   void updateMeshEvent(const ros::TimerEvent& event);
 
@@ -126,6 +130,7 @@ class TsdfServer {
   ros::ServiceServer generate_mesh_srv_;
   ros::ServiceServer save_map_srv_;
   ros::ServiceServer load_map_srv_;
+  ros::ServiceServer publish_pointclouds_srv_;
 
   // Timers.
   ros::Timer update_mesh_timer_;

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -129,6 +129,12 @@ void EsdfServer::updateMesh() {
   TsdfServer::updateMesh();
 }
 
+void EsdfServer::publishPointclouds() {
+  publishAllUpdatedEsdfVoxels();
+
+  TsdfServer::publishPointclouds();
+}
+
 void EsdfServer::updateEsdf() {
   if (tsdf_map_->getTsdfLayer().getNumberOfAllocatedBlocks() > 0) {
     const bool clear_updated_flag_esdf = true;

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -128,6 +128,8 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
       "save_map", &TsdfServer::saveMapCallback, this);
   load_map_srv_ = nh_private_.advertiseService(
       "load_map", &TsdfServer::loadMapCallback, this);
+  publish_pointclouds_srv_ = nh_private_.advertiseService(
+      "publish_pointclouds", &TsdfServer::publishPointcloudsCallback, this);
 
   // If set, use a timer to progressively integrate the mesh.
   double update_mesh_every_n_sec = 0.0;
@@ -291,6 +293,13 @@ void TsdfServer::publishSlices() {
   tsdf_slice_pub_.publish(pointcloud);
 }
 
+void TsdfServer::publishPointclouds() {
+  // Combined function to publish everything we got.
+  publishAllUpdatedTsdfVoxels();
+  publishTsdfSurfacePoints();
+  publishTsdfOccupiedNodes();
+}
+
 void TsdfServer::updateMesh() {
   if (verbose_) {
     ROS_INFO("Updating mesh.");
@@ -368,6 +377,13 @@ bool TsdfServer::loadMapCallback(
   return io::LoadBlocksFromFile(
       request.file_path, Layer<TsdfVoxel>::BlockMergingStrategy::kReplace,
       tsdf_map_->getTsdfLayerPtr());
+}
+
+bool TsdfServer::publishPointcloudsCallback(
+    std_srvs::Empty::Request& request,
+    std_srvs::Empty::Response& response) {  // NOLINT
+  publishPointclouds();
+  return true;
 }
 
 void TsdfServer::updateMeshEvent(const ros::TimerEvent& event) { updateMesh(); }

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -294,7 +294,8 @@ void TsdfServer::publishSlices() {
 }
 
 void TsdfServer::publishPointclouds() {
-  // Combined function to publish everything we got.
+  // Combined function to publish all possible pointcloud messages -- surface
+  // pointclouds, updated points, and occupied points.
   publishAllUpdatedTsdfVoxels();
   publishTsdfSurfacePoints();
   publishTsdfOccupiedNodes();


### PR DESCRIPTION
Now you can load maps from file and then still get pointclouds of them, by calling `/voxblox/publish_pointclouds`.

Example surface pointcloud from a pre-recorded map, colored by z-axis:

![image](https://user-images.githubusercontent.com/5616392/32848769-92fb2ab6-ca2d-11e7-94fe-2c81e37f353e.png)
