### PR TITLE
made methods protected not private and un-inlined methods implemented…

### DIFF
--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -56,6 +56,7 @@ typedef IndexVector VoxelIndexList;
 
 struct Color;
 typedef uint32_t Label;
+typedef uint32_t LabelConfidence;
 
 // Pointcloud types for external interface.
 typedef AlignedVector<Point> Pointcloud;

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -83,15 +83,15 @@ class TsdfIntegratorBase {
   // mutex allowing it to grow during integration.
   // These temporary blocks can be merged into the layer later by calling
   // updateLayerWithStoredBlocks()
-  inline TsdfVoxel* allocateStorageAndGetVoxelPtr(
+  TsdfVoxel* allocateStorageAndGetVoxelPtr(
       const VoxelIndex& global_voxel_idx, Block<TsdfVoxel>::Ptr* last_block,
       BlockIndex* last_block_idx);
 
   // NOT thread safe
-  inline void updateLayerWithStoredBlocks();
+  void updateLayerWithStoredBlocks();
 
   // Updates tsdf_voxel. Thread safe.
-  inline void updateTsdfVoxel(const Point& origin, const Point& point_G,
+  void updateTsdfVoxel(const Point& origin, const Point& point_G,
                               const VoxelIndex& global_voxel_index,
                               const Color& color, const float weight,
                               TsdfVoxel* tsdf_voxel);
@@ -101,7 +101,7 @@ class TsdfIntegratorBase {
                                const Point& voxel_center) const;
 
   // Thread safe.
-  inline float getVoxelWeight(const Point& point_C) const;
+  float getVoxelWeight(const Point& point_C) const;
 
   Config config_;
 
@@ -162,8 +162,8 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
                            const Pointcloud& points_C, const Colors& colors,
                            const bool freespace_points = false);
 
- private:
-  inline void bundleRays(
+ protected:
+  void bundleRays(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, const bool freespace_points,
       ThreadSafeIndex* index_getter,

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -58,7 +58,7 @@ inline bool TsdfIntegratorBase::isPointValid(const Point& point_C,
 // mutex allowing it to grow during integration.
 // These temporary blocks can be merged into the layer later by calling
 // updateLayerWithStoredBlocks()
-inline TsdfVoxel* TsdfIntegratorBase::allocateStorageAndGetVoxelPtr(
+TsdfVoxel* TsdfIntegratorBase::allocateStorageAndGetVoxelPtr(
     const VoxelIndex& global_voxel_idx, Block<TsdfVoxel>::Ptr* last_block,
     BlockIndex* last_block_idx) {
   DCHECK(last_block != nullptr);
@@ -104,7 +104,7 @@ inline TsdfVoxel* TsdfIntegratorBase::allocateStorageAndGetVoxelPtr(
 }
 
 // NOT thread safe
-inline void TsdfIntegratorBase::updateLayerWithStoredBlocks() {
+void TsdfIntegratorBase::updateLayerWithStoredBlocks() {
   BlockIndex last_block_idx;
   Block<TsdfVoxel>::Ptr block = nullptr;
 
@@ -117,7 +117,7 @@ inline void TsdfIntegratorBase::updateLayerWithStoredBlocks() {
 }
 
 // Updates tsdf_voxel. Thread safe.
-inline void TsdfIntegratorBase::updateTsdfVoxel(
+void TsdfIntegratorBase::updateTsdfVoxel(
     const Point& origin, const Point& point_G,
     const VoxelIndex& global_voxel_idx, const Color& color, const float weight,
     TsdfVoxel* tsdf_voxel) {
@@ -198,7 +198,7 @@ inline float TsdfIntegratorBase::computeDistance(
 }
 
 // Thread safe.
-inline float TsdfIntegratorBase::getVoxelWeight(const Point& point_C) const {
+float TsdfIntegratorBase::getVoxelWeight(const Point& point_C) const {
   if (config_.use_const_weight) {
     return 1.0f;
   }
@@ -303,7 +303,7 @@ void MergedTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
   integrate_timer.Stop();
 }
 
-inline void MergedTsdfIntegrator::bundleRays(
+void MergedTsdfIntegrator::bundleRays(
     const Transformation& T_G_C, const Pointcloud& points_C,
     const Colors& colors, const bool freespace_points,
     ThreadSafeIndex* index_getter,


### PR DESCRIPTION
… in cc files

The inlined functions could also be placed in the header files, but like it was before, linking to the inlined methods failed in different packages.

So, if this would drastically decrease speed we can move the inlined methods implementations to the headers.