### PR TITLE
Rename Plane to PlaneObject

### DIFF
--- a/voxblox/include/voxblox/simulation/objects.h
+++ b/voxblox/include/voxblox/simulation/objects.h
@@ -199,13 +199,13 @@ class Cube : public Object {
 };
 
 // Requires normal being passed in to ALREADY BE NORMALIZED!!!!
-class Plane : public Object {
+class PlaneObject : public Object {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  Plane(const Point& center, const Point& normal)
+  PlaneObject(const Point& center, const Point& normal)
       : Object(center, Type::kPlane), normal_(normal) {}
-  Plane(const Point& center, const Point& normal, const Color& color)
+  PlaneObject(const Point& center, const Point& normal, const Color& color)
       : Object(center, Type::kPlane, color), normal_(normal) {
     CHECK_NEAR(normal.norm(), 1.0, 1e-3);
   }

--- a/voxblox/src/simulation/simulation_world.cc
+++ b/voxblox/src/simulation/simulation_world.cc
@@ -11,7 +11,7 @@ void SimulationWorld::addObject(std::unique_ptr<Object> object) {
 
 void SimulationWorld::addGroundLevel(FloatingPoint height) {
   objects_.emplace_back(
-      new Plane(Point(0.0, 0.0, height), Point(0.0, 0.0, 1.0)));
+      new PlaneObject(Point(0.0, 0.0, height), Point(0.0, 0.0, 1.0)));
 }
 
 void SimulationWorld::addPlaneBoundaries(FloatingPoint x_min,
@@ -20,15 +20,15 @@ void SimulationWorld::addPlaneBoundaries(FloatingPoint x_min,
                                          FloatingPoint y_max) {
   // X planes:
   objects_.emplace_back(
-      new Plane(Point(x_min, 0.0, 0.0), Point(1.0, 0.0, 0.0)));
+      new PlaneObject(Point(x_min, 0.0, 0.0), Point(1.0, 0.0, 0.0)));
   objects_.emplace_back(
-      new Plane(Point(x_max, 0.0, 0.0), Point(-1.0, 0.0, 0.0)));
+      new PlaneObject(Point(x_max, 0.0, 0.0), Point(-1.0, 0.0, 0.0)));
 
   // Y planes:
   objects_.emplace_back(
-      new Plane(Point(0.0, y_min, 0.0), Point(0.0, 1.0, 0.0)));
+      new PlaneObject(Point(0.0, y_min, 0.0), Point(0.0, 1.0, 0.0)));
   objects_.emplace_back(
-      new Plane(Point(0.0, y_max, 0.0), Point(0.0, -1.0, 0.0)));
+      new PlaneObject(Point(0.0, y_max, 0.0), Point(0.0, -1.0, 0.0)));
 }
 
 void SimulationWorld::clear() { objects_.clear(); }

--- a/voxblox_ros/src/simulation_eval.cc
+++ b/voxblox_ros/src/simulation_eval.cc
@@ -16,10 +16,10 @@ class SimulationServerImpl : public voxblox::SimulationServer {
         new Sphere(Point(0.0, 0.0, 2.0), 2.0, Color::Red())));
 
     world_.addObject(std::unique_ptr<Object>(
-        new Plane(Point(-2.0, -4.0, 2.0), Point(0, 1, 0), Color::White())));
+        new PlaneObject(Point(-2.0, -4.0, 2.0), Point(0, 1, 0), Color::White())));
 
     world_.addObject(std::unique_ptr<Object>(
-        new Plane(Point(4.0, 0.0, 0.0), Point(-1, 0, 0), Color::Pink())));
+        new PlaneObject(Point(4.0, 0.0, 0.0), Point(-1, 0, 0), Color::Pink())));
 
     world_.addObject(std::unique_ptr<Object>(
         new Cube(Point(-4.0, 4.0, 2.0), Point(4, 4, 4), Color::Green())));


### PR DESCRIPTION
There are two classes called voxblox::Plane, this didn't compile on gcc-4.8, not sure why this wasn't a problem earlier...