### PR TITLE
removed unneeded catkin lib

### DIFF
--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -106,8 +106,7 @@ if(HAVE_PYBIND11)
     src/pybind11/bind.cc)
   set_target_properties(voxbloxpy PROPERTIES LINKER_LANGUAGE CXX)
   target_link_libraries(voxbloxpy PUBLIC ${PROJECT_NAME}_proto
-                                         ${PROTOBUF_LIBRARIES}
-                                         ${catkin_LIBRARIES})
+                                         ${PROTOBUF_LIBRARIES})
 
   set_target_properties(voxbloxpy
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY
@@ -121,12 +120,12 @@ endif()
 add_executable(tsdf_to_esdf
   test/tsdf_to_esdf.cc
 )
-target_link_libraries(tsdf_to_esdf ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(tsdf_to_esdf ${PROJECT_NAME})
 
 add_executable(test_load_esdf
   test/test_load_esdf.cc
 )
-target_link_libraries(test_load_esdf ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(test_load_esdf ${PROJECT_NAME})
 
 #########
 # TESTS #
@@ -148,27 +147,27 @@ target_link_libraries(test_approx_hash_array ${PROJECT_NAME})
 catkin_add_gtest(test_tsdf_map
   test/test_tsdf_map.cc
 )
-target_link_libraries(test_tsdf_map ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(test_tsdf_map ${PROJECT_NAME})
 
 catkin_add_gtest(test_protobuf
   test/test_protobuf.cc
 )
-target_link_libraries(test_protobuf ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(test_protobuf ${PROJECT_NAME})
 
 catkin_add_gtest(test_tsdf_interpolator
   test/test_tsdf_interpolator.cc
 )
-target_link_libraries(test_tsdf_interpolator ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(test_tsdf_interpolator ${PROJECT_NAME})
 
 catkin_add_gtest(test_layer
   test/test_layer.cc
 )
-target_link_libraries(test_layer ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(test_layer ${PROJECT_NAME})
 
 catkin_add_gtest(test_layer_utils
   test/test_layer_utils.cc
 )
-target_link_libraries(test_layer_utils ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(test_layer_utils ${PROJECT_NAME})
 
 ##########
 # EXPORT #

--- a/voxblox_rviz_plugin/CMakeLists.txt
+++ b/voxblox_rviz_plugin/CMakeLists.txt
@@ -37,7 +37,7 @@ set(HEADER_FILES include/voxblox_rviz_plugin/voxblox_mesh_display.h include/voxb
 
 set(SRC_FILES src/voxblox_mesh_display.cc src/voxblox_mesh_visual.cc )
 
-add_library(${PROJECT_NAME}
+cs_add_library(${PROJECT_NAME}
   ${SRC_FILES} 
   ${HEADER_FILES}
   ${MOC_FILES}

--- a/voxblox_rviz_plugin/CMakeLists.txt
+++ b/voxblox_rviz_plugin/CMakeLists.txt
@@ -45,7 +45,6 @@ add_library(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  ${catkin_LIBRARIES}
 )
 
 ##########

--- a/voxblox_tango_interface/CMakeLists.txt
+++ b/voxblox_tango_interface/CMakeLists.txt
@@ -87,8 +87,7 @@ if(HAVE_PYBIND11)
     src/pybind11/tango_layer_io_bind.cc)
   set_target_properties(voxblox_tango_interfacepy PROPERTIES LINKER_LANGUAGE CXX)
   target_link_libraries(voxblox_tango_interfacepy PUBLIC ${PROJECT_NAME}_proto
-                                                         ${PROTOBUF_LIBRARIES}
-                                                         ${catkin_LIBRARIES})
+                                                         ${PROTOBUF_LIBRARIES})
 
   set_target_properties(voxblox_tango_interfacepy
     PROPERTIES LIBRARY_OUTPUT_DIRECTORY
@@ -103,17 +102,17 @@ endif()
 add_executable(mesh_tango_tsdf
   test/mesh_tango_tsdf.cc
 )
-target_link_libraries(mesh_tango_tsdf ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(mesh_tango_tsdf ${PROJECT_NAME})
 
 add_executable(tango_tsdf_resize_to_tsdf
   test/tango_tsdf_resize_to_tsdf.cc
 )
-target_link_libraries(tango_tsdf_resize_to_tsdf ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(tango_tsdf_resize_to_tsdf ${PROJECT_NAME})
 
 add_executable(tango_tsdf_to_esdf
   test/tango_tsdf_to_esdf.cc
 )
-target_link_libraries(tango_tsdf_to_esdf ${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(tango_tsdf_to_esdf ${PROJECT_NAME})
 
 ##########
 # EXPORT #


### PR DESCRIPTION
Turns out ${catkin_LIBRARIES} is unneeded for catkin simple, I probably have this unnecessarily in whole bunch of other repos as well. 