### PR TITLE
Fix/compiler warnings

### DIFF
--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin_simple REQUIRED)
 catkin_simple()
 
 set(CMAKE_MACOSX_RPATH 0)
-add_definitions(-std=c++11 -Wno-sign-compare -Wno-unused-value)
+add_definitions(-std=c++11 -Wall)
 
 if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/../tools/pybind11/CMakeLists.txt")
   set(HAVE_PYBIND11 TRUE)

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -125,13 +125,16 @@ class Block {
   }
 
   inline bool isValidVoxelIndex(const VoxelIndex& index) const {
-    if (index.x() < 0 || index.x() >= (IndexElement)voxels_per_side_) {
+    if (index.x() < 0 ||
+        index.x() >= static_cast<IndexElement>(voxels_per_side_)) {
       return false;
     }
-    if (index.y() < 0 || index.y() >= (IndexElement)voxels_per_side_) {
+    if (index.y() < 0 ||
+        index.y() >= static_cast<IndexElement>(voxels_per_side_)) {
       return false;
     }
-    if (index.z() < 0 || index.z() >= (IndexElement)voxels_per_side_) {
+    if (index.z() < 0 ||
+        index.z() >= static_cast<IndexElement>(voxels_per_side_)) {
       return false;
     }
     return true;

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -125,13 +125,13 @@ class Block {
   }
 
   inline bool isValidVoxelIndex(const VoxelIndex& index) const {
-    if (index.x() < 0 || index.x() >= voxels_per_side_) {
+    if (index.x() < 0 || index.x() >= (IndexElement)voxels_per_side_) {
       return false;
     }
-    if (index.y() < 0 || index.y() >= voxels_per_side_) {
+    if (index.y() < 0 || index.y() >= (IndexElement)voxels_per_side_) {
       return false;
     }
-    if (index.z() < 0 || index.z() >= voxels_per_side_) {
+    if (index.z() < 0 || index.z() >= (IndexElement)voxels_per_side_) {
       return false;
     }
     return true;

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -35,9 +35,9 @@ class ThreadSafeIndex {
  private:
   size_t getMixedIndex(size_t base_idx);
 
+  std::atomic<size_t> atomic_idx_;
   const size_t number_of_points_;
   const size_t number_of_groups_;
-  std::atomic<size_t> atomic_idx_;
 
   static constexpr size_t num_bits = 10;  // 1024 bins
   static constexpr size_t step_size_ = 1 << num_bits;

--- a/voxblox/include/voxblox/integrator/merge_integrator.h
+++ b/voxblox/include/voxblox/integrator/merge_integrator.h
@@ -40,7 +40,8 @@ class MergeIntegrator {
       block_B->has_data() = true;
       block_B->updated() = true;
 
-      for (IndexElement voxel_idx = 0; voxel_idx < (IndexElement)block_B->num_voxels();
+      for (IndexElement voxel_idx = 0;
+           voxel_idx < static_cast<IndexElement>(block_B->num_voxels());
            ++voxel_idx) {
         mergeVoxelAIntoVoxelB<VoxelType>(
             block_A.getVoxelByLinearIndex(voxel_idx),
@@ -221,7 +222,8 @@ class MergeIntegrator {
       typename Block<VoxelType>::Ptr block =
           layer_out->allocateBlockPtrByIndex(block_idx);
 
-      for (IndexElement voxel_idx = 0; voxel_idx < (IndexElement)block->num_voxels();
+      for (IndexElement voxel_idx = 0;
+           voxel_idx < static_cast<IndexElement>(block->num_voxels());
            ++voxel_idx) {
         VoxelType& voxel = block->getVoxelByLinearIndex(voxel_idx);
 

--- a/voxblox/include/voxblox/integrator/merge_integrator.h
+++ b/voxblox/include/voxblox/integrator/merge_integrator.h
@@ -40,7 +40,7 @@ class MergeIntegrator {
       block_B->has_data() = true;
       block_B->updated() = true;
 
-      for (IndexElement voxel_idx = 0; voxel_idx < block_B->num_voxels();
+      for (IndexElement voxel_idx = 0; voxel_idx < (IndexElement)block_B->num_voxels();
            ++voxel_idx) {
         mergeVoxelAIntoVoxelB<VoxelType>(
             block_A.getVoxelByLinearIndex(voxel_idx),
@@ -221,7 +221,7 @@ class MergeIntegrator {
       typename Block<VoxelType>::Ptr block =
           layer_out->allocateBlockPtrByIndex(block_idx);
 
-      for (IndexElement voxel_idx = 0; voxel_idx < block->num_voxels();
+      for (IndexElement voxel_idx = 0; voxel_idx < (IndexElement)block->num_voxels();
            ++voxel_idx) {
         VoxelType& voxel = block->getVoxelByLinearIndex(voxel_idx);
 

--- a/voxblox/include/voxblox/integrator/occupancy_integrator.h
+++ b/voxblox/include/voxblox/integrator/occupancy_integrator.h
@@ -33,10 +33,10 @@ class OccupancyIntegrator {
 
   OccupancyIntegrator(const Config& config, Layer<OccupancyVoxel>* layer)
       : config_(config), layer_(layer) {
-    DCHECK_NOTNULL(layer_);
+    DCHECK(layer_ != NULL);
     DCHECK_GT(layer_->voxel_size(), 0.0);
     DCHECK_GT(layer_->block_size(), 0.0);
-    DCHECK_GT(layer_->voxels_per_side(), 0);
+    DCHECK_GT(layer_->voxels_per_side(), 0u);
 
     voxel_size_ = layer_->voxel_size();
     block_size_ = layer_->block_size();
@@ -55,7 +55,7 @@ class OccupancyIntegrator {
   }
 
   inline void updateOccupancyVoxel(bool occupied, OccupancyVoxel* occ_voxel) {
-    DCHECK_NOTNULL(occ_voxel);
+    DCHECK(occ_voxel != NULL);
     // Set voxel to observed.
     occ_voxel->observed = true;
     // Skip update if necessary.

--- a/voxblox/include/voxblox/interpolator/interpolator_inl.h
+++ b/voxblox/include/voxblox/interpolator/interpolator_inl.h
@@ -156,7 +156,7 @@ bool Interpolator<VoxelType>::setIndexes(const Point& pos,
   // shift index to bottom left corner voxel (makes math easier)
   Point center_offset =
       pos - block_ptr->computeCoordinatesFromVoxelIndex(voxel_index);
-  for (size_t i = 0; i < center_offset.rows(); ++i) {
+  for (size_t i = 0; i < (size_t)center_offset.rows(); ++i) {
     // ensure that the point we are interpolating to is always larger than the
     // center of the voxel_index in all dimensions
     if (center_offset(i) < 0) {
@@ -204,7 +204,7 @@ bool Interpolator<VoxelType>::getVoxelsAndQVector(
   CHECK_NOTNULL(q_vector);
 
   // for each voxel index
-  for (size_t i = 0; i < voxel_indexes.cols(); ++i) {
+  for (size_t i = 0; i < (size_t)voxel_indexes.cols(); ++i) {
     typename Layer<VoxelType>::BlockType::ConstPtr block_ptr =
         layer_->getBlockPtrByIndex(block_index);
     if (block_ptr == nullptr) {
@@ -215,8 +215,8 @@ bool Interpolator<VoxelType>::getVoxelsAndQVector(
     // if voxel index is too large get neighboring block and update index
     if ((voxel_index.array() >= block_ptr->voxels_per_side()).any()) {
       BlockIndex new_block_index = block_index;
-      for (size_t j = 0; j < block_index.rows(); ++j) {
-        if (voxel_index(j) >= block_ptr->voxels_per_side()) {
+      for (size_t j = 0; j < (size_t)block_index.rows(); ++j) {
+        if (voxel_index(j) >= (IndexElement)block_ptr->voxels_per_side()) {
           new_block_index(j)++;
           voxel_index(j) -= block_ptr->voxels_per_side();
         }

--- a/voxblox/include/voxblox/interpolator/interpolator_inl.h
+++ b/voxblox/include/voxblox/interpolator/interpolator_inl.h
@@ -156,7 +156,7 @@ bool Interpolator<VoxelType>::setIndexes(const Point& pos,
   // shift index to bottom left corner voxel (makes math easier)
   Point center_offset =
       pos - block_ptr->computeCoordinatesFromVoxelIndex(voxel_index);
-  for (size_t i = 0; i < (size_t)center_offset.rows(); ++i) {
+  for (size_t i = 0; i < static_cast<size_t>(center_offset.rows()); ++i) {
     // ensure that the point we are interpolating to is always larger than the
     // center of the voxel_index in all dimensions
     if (center_offset(i) < 0) {
@@ -204,7 +204,7 @@ bool Interpolator<VoxelType>::getVoxelsAndQVector(
   CHECK_NOTNULL(q_vector);
 
   // for each voxel index
-  for (size_t i = 0; i < (size_t)voxel_indexes.cols(); ++i) {
+  for (size_t i = 0; i < static_cast<size_t>(voxel_indexes.cols()); ++i) {
     typename Layer<VoxelType>::BlockType::ConstPtr block_ptr =
         layer_->getBlockPtrByIndex(block_index);
     if (block_ptr == nullptr) {
@@ -215,8 +215,9 @@ bool Interpolator<VoxelType>::getVoxelsAndQVector(
     // if voxel index is too large get neighboring block and update index
     if ((voxel_index.array() >= block_ptr->voxels_per_side()).any()) {
       BlockIndex new_block_index = block_index;
-      for (size_t j = 0; j < (size_t)block_index.rows(); ++j) {
-        if (voxel_index(j) >= (IndexElement)block_ptr->voxels_per_side()) {
+      for (size_t j = 0; j < static_cast<size_t>(block_index.rows()); ++j) {
+        if (voxel_index(j) >=
+            static_cast<IndexElement>(block_ptr->voxels_per_side())) {
           new_block_index(j)++;
           voxel_index(j) -= block_ptr->voxels_per_side();
         }

--- a/voxblox/include/voxblox/mesh/marching_cubes.h
+++ b/voxblox/include/voxblox/mesh/marching_cubes.h
@@ -41,7 +41,7 @@ class MarchingCubes {
       const Eigen::Matrix<FloatingPoint, 3, 8>& vertex_coordinates,
       const Eigen::Matrix<FloatingPoint, 8, 1>& vertex_sdf,
       TriangleVector* triangles) {
-    DCHECK_NOTNULL(triangles);
+    DCHECK(triangles != NULL);
 
     const int index = calculateVertexConfiguration(vertex_sdf);
 
@@ -67,8 +67,8 @@ class MarchingCubes {
   static void meshCube(const Eigen::Matrix<FloatingPoint, 3, 8>& vertex_coords,
                        const Eigen::Matrix<FloatingPoint, 8, 1>& vertex_sdf,
                        VertexIndex* next_index, Mesh* mesh) {
-    DCHECK_NOTNULL(next_index);
-    DCHECK_NOTNULL(mesh);
+    DCHECK(next_index != NULL);
+    DCHECK(mesh != NULL);
     const int index = calculateVertexConfiguration(vertex_sdf);
 
     // No edges in this cube.
@@ -123,7 +123,7 @@ class MarchingCubes {
       const Eigen::Matrix<FloatingPoint, 3, 8>& vertex_coords,
       const Eigen::Matrix<FloatingPoint, 8, 1>& vertex_sdf,
       Eigen::Matrix<FloatingPoint, 3, 12>* edge_coords) {
-    DCHECK_NOTNULL(edge_coords);
+    DCHECK(edge_coords != NULL);
     for (std::size_t i = 0; i < 12; ++i) {
       const int* pairs = kEdgeIndexPairs[i];
       const int edge0 = pairs[0];

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -258,7 +258,7 @@ class MeshIntegrator {
           if (corner_index(j) < 0) {
             block_offset(j) = -1;
             corner_index(j) = corner_index(j) + voxels_per_side_;
-          } else if (corner_index(j) >= voxels_per_side_) {
+          } else if (corner_index(j) >= (IndexElement)voxels_per_side_) {
             block_offset(j) = 1;
             corner_index(j) = corner_index(j) - voxels_per_side_;
           }

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -127,7 +127,7 @@ class MeshIntegrator {
     DCHECK(block != nullptr);
     DCHECK(mesh != nullptr);
 
-    size_t vps = block->voxels_per_side();
+    IndexElement vps = block->voxels_per_side();
     VertexIndex next_mesh_index = 0;
 
     VoxelIndex voxel_index;

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -258,7 +258,7 @@ class MeshIntegrator {
           if (corner_index(j) < 0) {
             block_offset(j) = -1;
             corner_index(j) = corner_index(j) + voxels_per_side_;
-          } else if (corner_index(j) >= (IndexElement)voxels_per_side_) {
+          } else if (corner_index(j) >= static_cast<IndexElement>(voxels_per_side_)) {
             block_offset(j) = 1;
             corner_index(j) = corner_index(j) - voxels_per_side_;
           }

--- a/voxblox/src/core/esdf_map.cc
+++ b/voxblox/src/core/esdf_map.cc
@@ -17,7 +17,7 @@ bool EsdfMap::getDistanceAtPosition(const Eigen::Vector3d& position,
 bool EsdfMap::getDistanceAndGradientAtPosition(
     const Eigen::Vector3d& position, double* distance,
     Eigen::Vector3d* gradient) const {
-  FloatingPoint distance_fp;
+  FloatingPoint distance_fp = 0;
   Point gradient_fp = Point::Zero();
   bool interpolate = true;
   bool use_adaptive = false;

--- a/voxblox/src/core/esdf_map.cc
+++ b/voxblox/src/core/esdf_map.cc
@@ -17,7 +17,7 @@ bool EsdfMap::getDistanceAtPosition(const Eigen::Vector3d& position,
 bool EsdfMap::getDistanceAndGradientAtPosition(
     const Eigen::Vector3d& position, double* distance,
     Eigen::Vector3d* gradient) const {
-  FloatingPoint distance_fp = 0;
+  FloatingPoint distance_fp = 0.0;
   Point gradient_fp = Point::Zero();
   bool interpolate = true;
   bool use_adaptive = false;

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -882,7 +882,7 @@ void EsdfIntegrator::getNeighbor(const BlockIndex& block_index,
     if ((*neighbor_voxel_index)(i) < 0) {
       (*neighbor_block_index)(i)--;
       (*neighbor_voxel_index)(i) += esdf_voxels_per_side_;
-    } else if ((*neighbor_voxel_index)(i) >= esdf_voxels_per_side_) {
+    } else if ((*neighbor_voxel_index)(i) >= (IndexElement)esdf_voxels_per_side_) {
       (*neighbor_block_index)(i)++;
       (*neighbor_voxel_index)(i) -= esdf_voxels_per_side_;
     }

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -882,7 +882,8 @@ void EsdfIntegrator::getNeighbor(const BlockIndex& block_index,
     if ((*neighbor_voxel_index)(i) < 0) {
       (*neighbor_block_index)(i)--;
       (*neighbor_voxel_index)(i) += esdf_voxels_per_side_;
-    } else if ((*neighbor_voxel_index)(i) >= (IndexElement)esdf_voxels_per_side_) {
+    } else if ((*neighbor_voxel_index)(i) >=
+               static_cast<IndexElement>(esdf_voxels_per_side_)) {
       (*neighbor_block_index)(i)++;
       (*neighbor_voxel_index)(i) -= esdf_voxels_per_side_;
     }

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -872,8 +872,8 @@ void EsdfIntegrator::getNeighbor(const BlockIndex& block_index,
                                  const Eigen::Vector3i& direction,
                                  BlockIndex* neighbor_block_index,
                                  VoxelIndex* neighbor_voxel_index) const {
-  DCHECK_NOTNULL(neighbor_block_index);
-  DCHECK_NOTNULL(neighbor_voxel_index);
+  DCHECK(neighbor_block_index != NULL);
+  DCHECK(neighbor_voxel_index != NULL);
 
   *neighbor_block_index = block_index;
   *neighbor_voxel_index = voxel_index + direction;

--- a/voxblox/src/integrator/esdf_occ_integrator.cc
+++ b/voxblox/src/integrator/esdf_occ_integrator.cc
@@ -283,7 +283,7 @@ void EsdfOccIntegrator::getNeighbor(const BlockIndex& block_index,
     if ((*neighbor_voxel_index)(i) < 0) {
       (*neighbor_block_index)(i)--;
       (*neighbor_voxel_index)(i) += esdf_voxels_per_side_;
-    } else if ((*neighbor_voxel_index)(i) >= esdf_voxels_per_side_) {
+    } else if ((*neighbor_voxel_index)(i) >= (IndexElement)esdf_voxels_per_side_) {
       (*neighbor_block_index)(i)++;
       (*neighbor_voxel_index)(i) -= esdf_voxels_per_side_;
     }

--- a/voxblox/src/integrator/esdf_occ_integrator.cc
+++ b/voxblox/src/integrator/esdf_occ_integrator.cc
@@ -283,7 +283,8 @@ void EsdfOccIntegrator::getNeighbor(const BlockIndex& block_index,
     if ((*neighbor_voxel_index)(i) < 0) {
       (*neighbor_block_index)(i)--;
       (*neighbor_voxel_index)(i) += esdf_voxels_per_side_;
-    } else if ((*neighbor_voxel_index)(i) >= (IndexElement)esdf_voxels_per_side_) {
+    } else if ((*neighbor_voxel_index)(i) >=
+               static_cast<IndexElement>(esdf_voxels_per_side_)) {
       (*neighbor_block_index)(i)++;
       (*neighbor_voxel_index)(i) -= esdf_voxels_per_side_;
     }

--- a/voxblox/src/integrator/esdf_occ_integrator.cc
+++ b/voxblox/src/integrator/esdf_occ_integrator.cc
@@ -273,8 +273,8 @@ void EsdfOccIntegrator::getNeighbor(const BlockIndex& block_index,
                                     const Eigen::Vector3i& direction,
                                     BlockIndex* neighbor_block_index,
                                     VoxelIndex* neighbor_voxel_index) const {
-  DCHECK_NOTNULL(neighbor_block_index);
-  DCHECK_NOTNULL(neighbor_voxel_index);
+  DCHECK(neighbor_block_index != NULL);
+  DCHECK(neighbor_voxel_index != NULL);
 
   *neighbor_block_index = block_index;
   *neighbor_voxel_index = voxel_index + direction;

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -424,7 +424,6 @@ void MergedTsdfIntegrator::integrateRays(
     const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
     const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
     const AnyIndexHashMapType<AlignedVector<size_t>>::type& clear_map) {
-  const Point& origin = T_G_C.getPosition();
 
   // if only 1 thread just do function call, otherwise spawn threads
   if (config_.integrator_threads == 1) {

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -486,7 +486,7 @@ void FastTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
                          config_.max_ray_length_m, voxel_size_inv_,
                          config_.default_truncation_distance, cast_from_origin);
 
-    size_t consecutive_ray_collisions = 0;
+    long int consecutive_ray_collisions = 0;
 
     Block<TsdfVoxel>::Ptr block = nullptr;
     BlockIndex block_idx;
@@ -522,7 +522,7 @@ void FastTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
 
   integration_start_time_ = std::chrono::steady_clock::now();
 
-  static size_t reset_counter = 0;
+  static long int reset_counter = 0;
   if ((++reset_counter) >= config_.clear_checks_every_n_frames) {
     reset_counter = 0;
     start_voxel_approx_set_.resetApproxSet();

--- a/voxblox/src/utils/camera_model.cc
+++ b/voxblox/src/utils/camera_model.cc
@@ -105,7 +105,7 @@ void CameraModel::calculateBoundingPlanes() {
     return;
   }
 
-  CHECK_EQ(corners_C_.size(), 8);
+  CHECK_EQ(corners_C_.size(), 8u);
   if (bounding_planes_.empty()) {
     bounding_planes_.resize(6);
   }

--- a/voxblox/test/test_tsdf_interpolator.cc
+++ b/voxblox/test/test_tsdf_interpolator.cc
@@ -25,9 +25,9 @@ class TsdfMergeIntegratorTest : public ::testing::Test {
   void setBlockSameValues(const float distance,
                           Block<TsdfVoxel>::Ptr block_ptr) {
     // Looping and setting all voxels
-    for (int x_idx = 0; x_idx < tsdf_voxels_per_side_; x_idx++) {
-      for (int y_idx = 0; y_idx < tsdf_voxels_per_side_; y_idx++) {
-        for (int z_idx = 0; z_idx < tsdf_voxels_per_side_; z_idx++) {
+    for (size_t x_idx = 0; x_idx < tsdf_voxels_per_side_; x_idx++) {
+      for (size_t y_idx = 0; y_idx < tsdf_voxels_per_side_; y_idx++) {
+        for (size_t z_idx = 0; z_idx < tsdf_voxels_per_side_; z_idx++) {
           // Creating the point
           VoxelIndex index(x_idx, y_idx, z_idx);
           TsdfVoxel& voxel_ref = block_ptr->getVoxelByVoxelIndex(index);

--- a/voxblox_ros/CMakeLists.txt
+++ b/voxblox_ros/CMakeLists.txt
@@ -4,7 +4,7 @@ project(voxblox_ros)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
-add_definitions(-std=c++11 -Wno-sign-compare -Wno-unused-value)
+add_definitions(-std=c++11 -Wall)
 
 #############
 # LIBRARIES #

--- a/voxblox_ros/launch/euroc_dataset_bag.launch
+++ b/voxblox_ros/launch/euroc_dataset_bag.launch
@@ -39,7 +39,7 @@
     <rosparam file="$(find stereo_dense_reconstruction_nodes)/cfg/ParamsHalfRes.yaml"/>
 
     <!-- Load stereo camera calibration from yaml file (only used if visensor_msgs not found)-->
-    <rosparam file="$(find mav_startup)/parameters/mavs/ijrr_euroc_datasets/camchain_equidistant_new.yaml"/>
+    <rosparam file="$(find mav_startup)/parameters/mavs/ijrr_euroc_datasets/camchain.yaml"/>
   </node>
 
   <node name="voxblox_node" pkg="voxblox_ros" type="voxblox_node" output="screen" args="-alsologtostderr" clear_params="true">
@@ -53,11 +53,11 @@
     <!--
     <remap from="transform" to="vicon/firefly_sbx/firefly_sbx" /> -->
     <remap from="transform" to="/groundtruth_transform" />
-    <param name="update_mesh_every_n_sec" value="0.0" />
+    <param name="update_mesh_every_n_sec" value="1.0" />
     <param name="generate_esdf" value="$(arg generate_esdf)" />
     <param name="slice_level" value="1.0" />
     <param name="method" value="merged" />
-    <param name="anti_grazing" value="false">
+    <param name="anti_grazing" value="false" />
     <param name="use_const_weight" value="false" />
 
     <rosparam file="$(find voxblox_ros)/cfg/euroc_dataset.yaml"/>

--- a/voxblox_ros/launch/kitti_dataset.launch
+++ b/voxblox_ros/launch/kitti_dataset.launch
@@ -35,7 +35,7 @@
     <param name="min_time_between_msgs_sec" value="0.2" />
     <param name="slice_level" value="1.0" />
     <param name="method" value="merged" />
-    <param name="anti_grazing" value="true">
+    <param name="anti_grazing" value="true"/>
     <param name="use_const_weight" value="true" />
     <param name="mesh_filename" value="$(find voxblox_ros)/mesh_results/$(anon kitti).ply" />
   </node>

--- a/voxblox_ros/src/simulation_server.cc
+++ b/voxblox_ros/src/simulation_server.cc
@@ -165,7 +165,7 @@ bool SimulationServer::generatePlausibleViewpoint(FloatingPoint min_distance,
   Point position = Point::Zero();
   bool success = false;
   // Generate a position, and check if it's ok.
-  for (int i = 0; i < max_attempts_to_generate_viewpoint_; ++i) {
+  for (size_t i = 0; i < max_attempts_to_generate_viewpoint_; ++i) {
     position.setRandom();
     // Make this span the whole space.
     position =

--- a/voxblox_ros/src/simulation_server.cc
+++ b/voxblox_ros/src/simulation_server.cc
@@ -86,8 +86,8 @@ SimulationServer::SimulationServer(
       num_viewpoints_(50) {
   CHECK_EQ(voxel_size_, tsdf_config.tsdf_voxel_size);
   CHECK_EQ(voxel_size_, esdf_config.esdf_voxel_size);
-  CHECK_EQ(voxels_per_side_, tsdf_config.tsdf_voxels_per_side);
-  CHECK_EQ(voxels_per_side_, esdf_config.esdf_voxels_per_side);
+  CHECK_EQ((size_t)voxels_per_side_, tsdf_config.tsdf_voxels_per_side);
+  CHECK_EQ((size_t)voxels_per_side_, esdf_config.esdf_voxels_per_side);
 
   getServerConfigFromRosParam(nh_private);
 

--- a/voxblox_ros/src/simulation_server.cc
+++ b/voxblox_ros/src/simulation_server.cc
@@ -86,8 +86,10 @@ SimulationServer::SimulationServer(
       num_viewpoints_(50) {
   CHECK_EQ(voxel_size_, tsdf_config.tsdf_voxel_size);
   CHECK_EQ(voxel_size_, esdf_config.esdf_voxel_size);
-  CHECK_EQ((size_t)voxels_per_side_, tsdf_config.tsdf_voxels_per_side);
-  CHECK_EQ((size_t)voxels_per_side_, esdf_config.esdf_voxels_per_side);
+  CHECK_EQ(static_cast<size_t>(voxels_per_side_),
+           tsdf_config.tsdf_voxels_per_side);
+  CHECK_EQ(static_cast<size_t>(voxels_per_side_),
+           esdf_config.esdf_voxels_per_side);
 
   getServerConfigFromRosParam(nh_private);
 

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -56,7 +56,6 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
                        const TsdfIntegratorBase::Config& integrator_config)
     : nh_(nh),
       nh_private_(nh_private),
-      pointcloud_queue_size_(1),
       verbose_(true),
       world_frame_("world"),
       slice_level_(0.5),
@@ -64,6 +63,7 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
       publish_tsdf_info_(false),
       publish_slices_(false),
       publish_tsdf_map_(false),
+      pointcloud_queue_size_(1),
       transformer_(nh, nh_private) {
   getServerConfigFromRosParam(nh_private);
 

--- a/voxblox_rviz_plugin/CMakeLists.txt
+++ b/voxblox_rviz_plugin/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
 set(CMAKE_MACOSX_RPATH 0)
-add_definitions(-std=c++11 -Wno-sign-compare -Wno-unused-value)
+add_definitions(-std=c++11 -Wall)
 
 ## This setting causes Qt's "MOC" generation to happen automatically.
 set(CMAKE_AUTOMOC ON)

--- a/voxblox_tango_interface/CMakeLists.txt
+++ b/voxblox_tango_interface/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin_simple REQUIRED)
 catkin_simple()
 
 set(CMAKE_MACOSX_RPATH 0)
-add_definitions(-std=c++11 -Wno-sign-compare -Wno-unused-value)
+add_definitions(-std=c++11 -Wall)
 
 if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/../tools/pybind11/CMakeLists.txt")
   set(HAVE_PYBIND11 TRUE)


### PR DESCRIPTION
@helenol @mfehr So voxblox compiles without warnings using -Wall (only some weird catkin warning). However all these cast are probably only symptom handling and not the right way to do it. 
But the other fixes should be legit.