### PR TITLE
Fix warnings raised by -Wall

### DIFF
--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin_simple REQUIRED)
 catkin_simple()
 
 set(CMAKE_MACOSX_RPATH 0)
-add_definitions(-std=c++11 -Wall)
+add_definitions(-std=c++11 -Wall -Wextra)
 
 if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/../tools/pybind11/CMakeLists.txt")
   set(HAVE_PYBIND11 TRUE)

--- a/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
@@ -38,8 +38,7 @@ class EsdfOccIntegrator {
   // Fixed is overloaded as occupied in this case.
   // Only batch operations are currently supported for the occupancy map.
   void updateFromOccLayerBatch();
-  void updateFromOccBlocks(const BlockIndexList& occ_blocks,
-                           bool push_neighbors);
+  void updateFromOccBlocks(const BlockIndexList& occ_blocks);
 
   void processOpenSet();
 

--- a/voxblox/include/voxblox/integrator/merge_integration.h
+++ b/voxblox/include/voxblox/integrator/merge_integration.h
@@ -39,7 +39,8 @@ void mergeBlockAIntoBlockB(const Block<VoxelType>& block_A,
     block_B->has_data() = true;
     block_B->updated() = true;
 
-    for (IndexElement voxel_idx = 0; voxel_idx < block_B->num_voxels();
+    for (IndexElement voxel_idx = 0;
+         voxel_idx < static_cast<IndexElement>(block_B->num_voxels());
          ++voxel_idx) {
       mergeVoxelAIntoVoxelB<VoxelType>(
           block_A.getVoxelByLinearIndex(voxel_idx),
@@ -221,7 +222,7 @@ void transformLayer(const Layer<VoxelType>& layer_in,
         layer_out->allocateBlockPtrByIndex(block_idx);
 
     for (IndexElement voxel_idx = 0;
-          voxel_idx < static_cast<IndexElement>(block->num_voxels());
+         voxel_idx < static_cast<IndexElement>(block->num_voxels());
          ++voxel_idx) {
       VoxelType& voxel = block->getVoxelByLinearIndex(voxel_idx);
 

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -83,18 +83,17 @@ class TsdfIntegratorBase {
   // mutex allowing it to grow during integration.
   // These temporary blocks can be merged into the layer later by calling
   // updateLayerWithStoredBlocks()
-  TsdfVoxel* allocateStorageAndGetVoxelPtr(
-      const VoxelIndex& global_voxel_idx, Block<TsdfVoxel>::Ptr* last_block,
-      BlockIndex* last_block_idx);
+  TsdfVoxel* allocateStorageAndGetVoxelPtr(const VoxelIndex& global_voxel_idx,
+                                           Block<TsdfVoxel>::Ptr* last_block,
+                                           BlockIndex* last_block_idx);
 
   // NOT thread safe
   void updateLayerWithStoredBlocks();
 
   // Updates tsdf_voxel. Thread safe.
   void updateTsdfVoxel(const Point& origin, const Point& point_G,
-                              const VoxelIndex& global_voxel_index,
-                              const Color& color, const float weight,
-                              TsdfVoxel* tsdf_voxel);
+                       const VoxelIndex& global_voxel_index, const Color& color,
+                       const float weight, TsdfVoxel* tsdf_voxel);
 
   // Thread safe.
   inline float computeDistance(const Point& origin, const Point& point_G,
@@ -163,12 +162,10 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
                            const bool freespace_points = false);
 
  protected:
-  void bundleRays(
-      const Transformation& T_G_C, const Pointcloud& points_C,
-      const Colors& colors, const bool freespace_points,
-      ThreadSafeIndex* index_getter,
-      AnyIndexHashMapType<AlignedVector<size_t>>::type* voxel_map,
-      AnyIndexHashMapType<AlignedVector<size_t>>::type* clear_map);
+  void bundleRays(const Transformation& T_G_C, const Pointcloud& points_C,
+                  const bool freespace_points, ThreadSafeIndex* index_getter,
+                  AnyIndexHashMapType<AlignedVector<size_t>>::type* voxel_map,
+                  AnyIndexHashMapType<AlignedVector<size_t>>::type* clear_map);
 
   void integrateVoxel(
       const Transformation& T_G_C, const Pointcloud& points_C,

--- a/voxblox/include/voxblox/simulation/objects.h
+++ b/voxblox/include/voxblox/simulation/objects.h
@@ -27,9 +27,8 @@ class Object {
   virtual ~Object() {}
 
   // Map-building accessors.
-  virtual FloatingPoint getDistanceToPoint(const Point& point) const {
-    return 0.0;
-  }
+  virtual FloatingPoint getDistanceToPoint(const Point& point) const = 0;
+
   Color getColor() const { return color_; }
 
   // Raycasting accessors.
@@ -37,9 +36,7 @@ class Object {
                                   const Point& ray_direction,
                                   FloatingPoint max_dist,
                                   Point* intersect_point,
-                                  FloatingPoint* intersect_dist) const {
-    return false;
-  }
+                                  FloatingPoint* intersect_dist) const = 0;
 
  protected:
   Point center_;
@@ -142,7 +139,7 @@ class Cube : public Object {
 
   virtual bool getRayIntersection(const Point& ray_origin,
                                   const Point& ray_direction,
-                                  FloatingPoint max_dist,
+                                  FloatingPoint /*max_dist*/,
                                   Point* intersect_point,
                                   FloatingPoint* intersect_dist) const {
     // Adapted from https://www.scratchapixel.com/lessons/3d-basic-rendering/

--- a/voxblox/include/voxblox/simulation/objects.h
+++ b/voxblox/include/voxblox/simulation/objects.h
@@ -139,7 +139,7 @@ class Cube : public Object {
 
   virtual bool getRayIntersection(const Point& ray_origin,
                                   const Point& ray_direction,
-                                  FloatingPoint /*max_dist*/,
+                                  FloatingPoint max_dist,
                                   Point* intersect_point,
                                   FloatingPoint* intersect_dist) const {
     // Adapted from https://www.scratchapixel.com/lessons/3d-basic-rendering/
@@ -185,6 +185,11 @@ class Cube : public Object {
         return false;
       }
     }
+
+    if (t > max_dist) {
+      return false;
+    }
+
     *intersect_dist = t;
     *intersect_point = ray_origin + ray_direction * t;
 

--- a/voxblox/include/voxblox/simulation/simulation_world_inl.h
+++ b/voxblox/include/voxblox/simulation/simulation_world_inl.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <memory>
 
 #include "voxblox/core/block.h"
 
@@ -72,7 +73,7 @@ void SimulationWorld::setVoxel(FloatingPoint dist, const Color& color,
 
 // Color ignored.
 template <>
-void SimulationWorld::setVoxel(FloatingPoint dist, const Color& color,
+void SimulationWorld::setVoxel(FloatingPoint dist, const Color& /*color*/,
                                EsdfVoxel* voxel) const {
   voxel->distance = static_cast<float>(dist);
   voxel->observed = true;

--- a/voxblox/include/voxblox/utils/evaluation_utils.h
+++ b/voxblox/include/voxblox/utils/evaluation_utils.h
@@ -30,7 +30,7 @@ struct VoxelEvaluationDetails {
 };
 
 template <typename VoxelType>
-const VoxelEvaluationResult computeVoxelError(
+VoxelEvaluationResult computeVoxelError(
     const VoxelType& voxel_gt, const VoxelType& voxel_test,
     const VoxelEvaluationMode evaluation_mode, FloatingPoint* error);
 
@@ -166,7 +166,7 @@ FloatingPoint evaluateLayersRmse(const Layer<VoxelType>& layer_gt,
 }
 
 template <typename VoxelType>
-const VoxelEvaluationResult computeVoxelError(
+VoxelEvaluationResult computeVoxelError(
     const VoxelType& voxel_gt, const VoxelType& voxel_test,
     const VoxelEvaluationMode evaluation_mode, FloatingPoint* error) {
   CHECK_NOTNULL(error);

--- a/voxblox/src/integrator/esdf_occ_integrator.cc
+++ b/voxblox/src/integrator/esdf_occ_integrator.cc
@@ -20,12 +20,10 @@ void EsdfOccIntegrator::updateFromOccLayerBatch() {
   esdf_layer_->removeAllBlocks();
   BlockIndexList occ_blocks;
   occ_layer_->getAllAllocatedBlocks(&occ_blocks);
-  constexpr bool push_neighbors = false;
-  updateFromOccBlocks(occ_blocks, push_neighbors);
+  updateFromOccBlocks(occ_blocks);
 }
 
-void EsdfOccIntegrator::updateFromOccBlocks(const BlockIndexList& occ_blocks,
-                                            bool push_neighbors) {
+void EsdfOccIntegrator::updateFromOccBlocks(const BlockIndexList& occ_blocks) {
   DCHECK_EQ(occ_layer_->voxels_per_side(), esdf_layer_->voxels_per_side());
   timing::Timer esdf_timer("esdf_occ");
 

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -287,8 +287,8 @@ void MergedTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
 
   ThreadSafeIndex index_getter(points_C.size());
 
-  bundleRays(T_G_C, points_C, colors, freespace_points, &index_getter,
-             &voxel_map, &clear_map);
+  bundleRays(T_G_C, points_C, freespace_points, &index_getter, &voxel_map,
+             &clear_map);
 
   integrateRays(T_G_C, points_C, colors, config_.enable_anti_grazing, false,
                 voxel_map, clear_map);
@@ -305,8 +305,7 @@ void MergedTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
 
 void MergedTsdfIntegrator::bundleRays(
     const Transformation& T_G_C, const Pointcloud& points_C,
-    const Colors& colors, const bool freespace_points,
-    ThreadSafeIndex* index_getter,
+    const bool freespace_points, ThreadSafeIndex* index_getter,
     AnyIndexHashMapType<AlignedVector<size_t>>::type* voxel_map,
     AnyIndexHashMapType<AlignedVector<size_t>>::type* clear_map) {
   DCHECK(voxel_map != nullptr);
@@ -424,16 +423,16 @@ void MergedTsdfIntegrator::integrateRays(
     const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
     const AnyIndexHashMapType<AlignedVector<size_t>>::type& voxel_map,
     const AnyIndexHashMapType<AlignedVector<size_t>>::type& clear_map) {
-
   // if only 1 thread just do function call, otherwise spawn threads
   if (config_.integrator_threads == 1) {
     constexpr size_t thread_idx = 0;
     integrateVoxels(T_G_C, points_C, colors, enable_anti_grazing, clearing_ray,
                     voxel_map, clear_map, thread_idx);
   } else {
-      std::list<std::thread> integration_threads;
+    std::list<std::thread> integration_threads;
     for (size_t i = 0; i < config_.integrator_threads; ++i) {
-      integration_threads.emplace_back(&MergedTsdfIntegrator::integrateVoxels, this, T_G_C, points_C, colors,
+      integration_threads.emplace_back(
+          &MergedTsdfIntegrator::integrateVoxels, this, T_G_C, points_C, colors,
           enable_anti_grazing, clearing_ray, voxel_map, clear_map, i);
     }
 
@@ -486,7 +485,7 @@ void FastTsdfIntegrator::integrateFunction(const Transformation& T_G_C,
                          config_.max_ray_length_m, voxel_size_inv_,
                          config_.default_truncation_distance, cast_from_origin);
 
-    long int consecutive_ray_collisions = 0;
+    int64_t consecutive_ray_collisions = 0;
 
     Block<TsdfVoxel>::Ptr block = nullptr;
     BlockIndex block_idx;
@@ -522,7 +521,7 @@ void FastTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
 
   integration_start_time_ = std::chrono::steady_clock::now();
 
-  static long int reset_counter = 0;
+  static int64_t reset_counter = 0;
   if ((++reset_counter) >= config_.clear_checks_every_n_frames) {
     reset_counter = 0;
     start_voxel_approx_set_.resetApproxSet();

--- a/voxblox/src/utils/evaluation_utils.cc
+++ b/voxblox/src/utils/evaluation_utils.cc
@@ -7,7 +7,7 @@ namespace voxblox {
 namespace utils {
 
 template <>
-const VoxelEvaluationResult computeVoxelError(
+VoxelEvaluationResult computeVoxelError(
     const TsdfVoxel& voxel_gt, const TsdfVoxel& voxel_test,
     const VoxelEvaluationMode evaluation_mode, FloatingPoint* error) {
   CHECK_NOTNULL(error);
@@ -37,7 +37,7 @@ const VoxelEvaluationResult computeVoxelError(
 }
 
 template <>
-const VoxelEvaluationResult computeVoxelError(
+VoxelEvaluationResult computeVoxelError(
     const EsdfVoxel& voxel_gt, const EsdfVoxel& voxel_test,
     const VoxelEvaluationMode evaluation_mode, FloatingPoint* error) {
   CHECK_NOTNULL(error);

--- a/voxblox_ros/CMakeLists.txt
+++ b/voxblox_ros/CMakeLists.txt
@@ -4,7 +4,7 @@ project(voxblox_ros)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
-add_definitions(-std=c++11 -Wall)
+add_definitions(-std=c++11 -Wall -Wextra)
 
 #############
 # LIBRARIES #

--- a/voxblox_ros/include/voxblox_ros/transformer.h
+++ b/voxblox_ros/include/voxblox_ros/transformer.h
@@ -28,9 +28,7 @@ class Transformer {
                          const std::string& to_frame,
                          const ros::Time& timestamp, Transformation* transform);
 
-  bool lookupTransformQueue(const std::string& from_frame,
-                            const std::string& to_frame,
-                            const ros::Time& timestamp,
+  bool lookupTransformQueue(const ros::Time& timestamp,
                             Transformation* transform);
 
   ros::NodeHandle nh_;

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -51,7 +51,9 @@ class TsdfServer {
   void integratePointcloud(const Transformation& T_G_C,
                            const Pointcloud& ptcloud_C, const Colors& colors,
                            const bool is_freespace_pointcloud = false);
-  virtual void newPoseCallback(const Transformation& new_pose) {}
+  virtual void newPoseCallback(const Transformation& /*new_pose*/) {
+    // Do nothing.
+  }
 
   void publishAllUpdatedTsdfVoxels();
   void publishTsdfSurfacePoints();

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -100,8 +100,8 @@ void EsdfServer::publishSlices() {
 }
 
 bool EsdfServer::generateEsdfCallback(
-    std_srvs::Empty::Request& request,      // NOLINT
-    std_srvs::Empty::Response& response) {  // NOLINT
+    std_srvs::Empty::Request& /*request*/,      // NOLINT
+    std_srvs::Empty::Response& /*response*/) {  // NOLINT
   const bool clear_esdf = true;
   if (clear_esdf) {
     esdf_integrator_->updateFromTsdfLayerBatch();

--- a/voxblox_ros/src/transformer.cc
+++ b/voxblox_ros/src/transformer.cc
@@ -71,7 +71,7 @@ bool Transformer::lookupTransform(const std::string& from_frame,
   if (use_tf_transforms_) {
     return lookupTransformTf(from_frame, to_frame, timestamp, transform);
   } else {
-    return lookupTransformQueue(from_frame, to_frame, timestamp, transform);
+    return lookupTransformQueue(timestamp, transform);
   }
 }
 
@@ -112,9 +112,7 @@ bool Transformer::lookupTransformTf(const std::string& from_frame,
   return true;
 }
 
-bool Transformer::lookupTransformQueue(const std::string& from_frame,
-                                       const std::string& to_frame,
-                                       const ros::Time& timestamp,
+bool Transformer::lookupTransformQueue(const ros::Time& timestamp,
                                        Transformation* transform) {
   CHECK_NOTNULL(transform);
   // Try to match the transforms in the queue.

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -376,21 +376,21 @@ bool TsdfServer::generateMesh() {
 }
 
 bool TsdfServer::generateMeshCallback(
-    std_srvs::Empty::Request& request,
-    std_srvs::Empty::Response& response) {  // NOLINT
+    std_srvs::Empty::Request& /*request*/,
+    std_srvs::Empty::Response& /*response*/) {  // NOLINT
   return generateMesh();
 }
 
 bool TsdfServer::saveMapCallback(
     voxblox_msgs::FilePath::Request& request,
-    voxblox_msgs::FilePath::Response& response) {  // NOLINT
+    voxblox_msgs::FilePath::Response& /*response*/) {  // NOLINT
   // Will only save TSDF layer for now.
   return io::SaveLayer(tsdf_map_->getTsdfLayer(), request.file_path);
 }
 
 bool TsdfServer::loadMapCallback(
     voxblox_msgs::FilePath::Request& request,
-    voxblox_msgs::FilePath::Response& response) {  // NOLINT
+    voxblox_msgs::FilePath::Response& /*response*/) {  // NOLINT
   // Will only load TSDF layer for now.
   return io::LoadBlocksFromFile(
       request.file_path, Layer<TsdfVoxel>::BlockMergingStrategy::kReplace,
@@ -398,13 +398,15 @@ bool TsdfServer::loadMapCallback(
 }
 
 bool TsdfServer::publishPointcloudsCallback(
-    std_srvs::Empty::Request& request,
-    std_srvs::Empty::Response& response) {  // NOLINT
+    std_srvs::Empty::Request& /*request*/,
+    std_srvs::Empty::Response& /*response*/) {  // NOLINT
   publishPointclouds();
   return true;
 }
 
-void TsdfServer::updateMeshEvent(const ros::TimerEvent& event) { updateMesh(); }
+void TsdfServer::updateMeshEvent(const ros::TimerEvent& /*event*/) {
+  updateMesh();
+}
 
 void TsdfServer::clear() {
   tsdf_map_->getTsdfLayerPtr()->removeAllBlocks();

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -49,9 +49,7 @@ class VoxbloxNode {
   bool lookupTransformTf(const std::string& from_frame,
                          const std::string& to_frame,
                          const ros::Time& timestamp, Transformation* transform);
-  bool lookupTransformQueue(const std::string& from_frame,
-                            const std::string& to_frame,
-                            const ros::Time& timestamp,
+  bool lookupTransformQueue(const ros::Time& timestamp,
                             Transformation* transform);
 
   void publishAllUpdatedTsdfVoxels();
@@ -694,7 +692,7 @@ bool VoxbloxNode::lookupTransform(const std::string& from_frame,
   if (use_tf_transforms_) {
     return lookupTransformTf(from_frame, to_frame, timestamp, transform);
   } else {
-    return lookupTransformQueue(from_frame, to_frame, timestamp, transform);
+    return lookupTransformQueue(timestamp, transform);
   }
 }
 
@@ -734,9 +732,7 @@ bool VoxbloxNode::lookupTransformTf(const std::string& from_frame,
   return true;
 }
 
-bool VoxbloxNode::lookupTransformQueue(const std::string& from_frame,
-                                       const std::string& to_frame,
-                                       const ros::Time& timestamp,
+bool VoxbloxNode::lookupTransformQueue(const ros::Time& timestamp,
                                        Transformation* transform) {
   // Try to match the transforms in the queue.
   bool match_found = false;
@@ -784,8 +780,8 @@ bool VoxbloxNode::lookupTransformQueue(const std::string& from_frame,
 }
 
 bool VoxbloxNode::generateMeshCallback(
-    std_srvs::Empty::Request& request,
-    std_srvs::Empty::Response& response) {  // NOLINT
+    std_srvs::Empty::Request& /*request*/,
+    std_srvs::Empty::Response& /*response*/) {  // NOLINT
   timing::Timer generate_mesh_timer("mesh/generate");
   const bool clear_mesh = true;
   if (clear_mesh) {
@@ -840,8 +836,8 @@ bool VoxbloxNode::generateMeshCallback(
 }
 
 bool VoxbloxNode::generateEsdfCallback(
-    std_srvs::Empty::Request& request,
-    std_srvs::Empty::Response& response) {  // NOLINT
+    std_srvs::Empty::Request& /*request*/,
+    std_srvs::Empty::Response& /*response*/) {  // NOLINT
   if (!generate_esdf_) {
     return false;
   }
@@ -859,21 +855,21 @@ bool VoxbloxNode::generateEsdfCallback(
 
 bool VoxbloxNode::saveMapCallback(
     voxblox_msgs::FilePath::Request& request,
-    voxblox_msgs::FilePath::Response& response) {  // NOLINT
+    voxblox_msgs::FilePath::Response& /*response*/) {  // NOLINT
   // Will only save TSDF layer for now.
   return io::SaveLayer(tsdf_map_->getTsdfLayer(), request.file_path);
 }
 
 bool VoxbloxNode::loadMapCallback(
     voxblox_msgs::FilePath::Request& request,
-    voxblox_msgs::FilePath::Response& response) {  // NOLINT
+    voxblox_msgs::FilePath::Response& /*response*/) {  // NOLINT
   // Will only load TSDF layer for now.
   return io::LoadBlocksFromFile(
       request.file_path, Layer<TsdfVoxel>::BlockMergingStrategy::kReplace,
       tsdf_map_->getTsdfLayerPtr());
 }
 
-void VoxbloxNode::updateMeshEvent(const ros::TimerEvent& e) {
+void VoxbloxNode::updateMeshEvent(const ros::TimerEvent& /*event*/) {
   if (verbose_) {
     ROS_INFO("Updating mesh.");
   }

--- a/voxblox_tango_interface/CMakeLists.txt
+++ b/voxblox_tango_interface/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(catkin_simple REQUIRED)
 catkin_simple()
 
 set(CMAKE_MACOSX_RPATH 0)
-add_definitions(-std=c++11 -Wall)
+add_definitions(-std=c++11 -Wall -Wextra)
 
 if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/../tools/pybind11/CMakeLists.txt")
   set(HAVE_PYBIND11 TRUE)


### PR DESCRIPTION
We use -Wextra in maplab, therefore voxblox was still raising warnings.
This should fix all of them.