### PR TITLE
fixed bug that would stop layers showing

### DIFF
--- a/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
+++ b/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
@@ -193,7 +193,8 @@ inline bool visualizeDistanceIntensityTsdfVoxelsSlice(
     const TsdfVoxel& voxel, const Point& coord, unsigned int free_plane_index,
     FloatingPoint free_plane_val, FloatingPoint voxel_size, double* intensity) {
   CHECK_NOTNULL(intensity);
-  if (std::abs(coord(free_plane_index) - free_plane_val) <= voxel_size / 2.0) {
+  if (std::abs(coord(free_plane_index) - free_plane_val) <=
+      (voxel_size / 2.0 + kFloatEpsilon)) {
     if (voxel.weight > 1e-3) {
       *intensity = voxel.distance;
       return true;
@@ -218,7 +219,8 @@ inline bool visualizeDistanceIntensityEsdfVoxelsSlice(
     FloatingPoint free_plane_val, FloatingPoint voxel_size, double* intensity) {
   CHECK_NOTNULL(intensity);
 
-  if (std::abs(coord(free_plane_index) - free_plane_val) <= voxel_size / 2.0) {
+  if (std::abs(coord(free_plane_index) - free_plane_val) <=
+      (voxel_size / 2.0 + kFloatEpsilon)) {
     if (voxel.observed) {
       *intensity = voxel.distance;
       return true;

--- a/voxblox_ros/launch/cow_and_lady_dataset.launch
+++ b/voxblox_ros/launch/cow_and_lady_dataset.launch
@@ -20,7 +20,6 @@
     <param name="use_const_weight" value="false" />
     <param name="allow_clear" value="false" />
     <param name="verbose" value="true" />
-    <param name="max_integration_time_s" value="0.02"/>
     <param name="clear_checks_every_n_frames" value="1"/>
     <remap from="transform" to="/kinect/vrpn_client/estimated_transform" />
     <rosparam file="$(find voxblox_ros)/cfg/cow_and_lady.yaml"/>


### PR DESCRIPTION
If a slice is requested exactly between two blocks and the voxel_size cannot be exactly represented by a floating point no layer will be output. To fix this I added kFloatEpsilion which results in a double layer in these odd cases #144 