### PR TITLE
Simple TSDF visualization executable

### DIFF
--- a/voxblox_ros/CMakeLists.txt
+++ b/voxblox_ros/CMakeLists.txt
@@ -47,6 +47,11 @@ cs_add_executable(simulation_eval
 )
 target_link_libraries(simulation_eval ${PROJECT_NAME})
 
+cs_add_executable(visualize_tsdf
+  src/visualize_tsdf.cc
+)
+target_link_libraries(visualize_tsdf ${PROJECT_NAME})
+
 ##########
 # EXPORT #
 ##########

--- a/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
+++ b/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
@@ -171,7 +171,10 @@ inline bool visualizeNearSurfaceTsdfVoxels(const TsdfVoxel& voxel,
                                            const Point& /*coord*/,
                                            double surface_distance,
                                            Color* color) {
-  if (voxel.weight > 0 && std::abs(voxel.distance) < surface_distance) {
+  CHECK_NOTNULL(color);
+  constexpr float kMinWeight = 0;
+  if (voxel.weight > kMinWeight &&
+      std::abs(voxel.distance) < surface_distance) {
     *color = voxel.color;
     return true;
   }
@@ -180,7 +183,9 @@ inline bool visualizeNearSurfaceTsdfVoxels(const TsdfVoxel& voxel,
 
 inline bool visualizeTsdfVoxels(const TsdfVoxel& voxel, const Point& /*coord*/,
                                 Color* color) {
-  if (voxel.weight > 0) {
+  CHECK_NOTNULL(color);
+  constexpr float kMinWeight = 0;
+  if (voxel.weight > kMinWeight) {
     *color = voxel.color;
     return true;
   }
@@ -191,7 +196,8 @@ inline bool visualizeDistanceIntensityTsdfVoxels(const TsdfVoxel& voxel,
                                                  const Point& /*coord*/,
                                                  double* intensity) {
   CHECK_NOTNULL(intensity);
-  if (voxel.weight > 1e-3) {
+  constexpr float kMinWeight = 1e-3;
+  if (voxel.weight > kMinWeight) {
     *intensity = voxel.distance;
     return true;
   }
@@ -202,7 +208,9 @@ inline bool visualizeDistanceIntensityTsdfVoxelsNearSurface(
     const TsdfVoxel& voxel, const Point& /*coord*/, double surface_distance,
     double* intensity) {
   CHECK_NOTNULL(intensity);
-  if (voxel.weight > 1e-3 && std::abs(voxel.distance) < surface_distance) {
+  constexpr float kMinWeight = 1e-3;
+  if (voxel.weight > kMinWeight &&
+      std::abs(voxel.distance) < surface_distance) {
     *intensity = voxel.distance;
     return true;
   }
@@ -273,6 +281,7 @@ inline bool visualizeOccupiedOccupancyVoxels(const OccupancyVoxel& voxel,
 inline void createSurfacePointcloudFromTsdfLayer(
     const Layer<TsdfVoxel>& layer, double surface_distance,
     pcl::PointCloud<pcl::PointXYZRGB>* pointcloud) {
+  CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(
       layer,
       std::bind(&visualizeNearSurfaceTsdfVoxels, ph::_1, ph::_2,
@@ -285,6 +294,7 @@ inline void createSurfacePointcloudFromTsdfLayer(
 inline void createPointcloudFromTsdfLayer(
     const Layer<TsdfVoxel>& layer,
     pcl::PointCloud<pcl::PointXYZRGB>* pointcloud) {
+  CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(layer, &visualizeTsdfVoxels,
                                             pointcloud);
 }
@@ -294,6 +304,7 @@ inline void createPointcloudFromTsdfLayer(
 inline void createDistancePointcloudFromTsdfLayer(
     const Layer<TsdfVoxel>& layer,
     pcl::PointCloud<pcl::PointXYZI>* pointcloud) {
+  CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(
       layer, &visualizeDistanceIntensityTsdfVoxels, pointcloud);
 }
@@ -303,6 +314,7 @@ inline void createDistancePointcloudFromTsdfLayer(
 inline void createSurfaceDistancePointcloudFromTsdfLayer(
     const Layer<TsdfVoxel>& layer, double surface_distance,
     pcl::PointCloud<pcl::PointXYZI>* pointcloud) {
+  CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(
       layer,
       std::bind(&visualizeDistanceIntensityTsdfVoxelsNearSurface, ph::_1,
@@ -313,6 +325,7 @@ inline void createSurfaceDistancePointcloudFromTsdfLayer(
 inline void createDistancePointcloudFromEsdfLayer(
     const Layer<EsdfVoxel>& layer,
     pcl::PointCloud<pcl::PointXYZI>* pointcloud) {
+  CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<EsdfVoxel>(
       layer, &visualizeDistanceIntensityEsdfVoxels, pointcloud);
 }
@@ -320,6 +333,7 @@ inline void createDistancePointcloudFromEsdfLayer(
 inline void createDistancePointcloudFromTsdfLayerSlice(
     const Layer<TsdfVoxel>& layer, unsigned int free_plane_index,
     FloatingPoint free_plane_val, pcl::PointCloud<pcl::PointXYZI>* pointcloud) {
+  CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(
       layer,
       std::bind(&visualizeDistanceIntensityTsdfVoxelsSlice, ph::_1, ph::_2,
@@ -330,6 +344,7 @@ inline void createDistancePointcloudFromTsdfLayerSlice(
 inline void createDistancePointcloudFromEsdfLayerSlice(
     const Layer<EsdfVoxel>& layer, unsigned int free_plane_index,
     FloatingPoint free_plane_val, pcl::PointCloud<pcl::PointXYZI>* pointcloud) {
+  CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<EsdfVoxel>(
       layer,
       std::bind(&visualizeDistanceIntensityEsdfVoxelsSlice, ph::_1, ph::_2,
@@ -340,6 +355,7 @@ inline void createDistancePointcloudFromEsdfLayerSlice(
 inline void createOccupancyBlocksFromTsdfLayer(
     const Layer<TsdfVoxel>& layer, const std::string& frame_id,
     visualization_msgs::MarkerArray* marker_array) {
+  CHECK_NOTNULL(marker_array);
   createOccupancyBlocksFromLayer<TsdfVoxel>(layer, &visualizeOccupiedTsdfVoxels,
                                             frame_id, marker_array);
 }
@@ -347,6 +363,7 @@ inline void createOccupancyBlocksFromTsdfLayer(
 inline void createOccupancyBlocksFromOccupancyLayer(
     const Layer<OccupancyVoxel>& layer, const std::string& frame_id,
     visualization_msgs::MarkerArray* marker_array) {
+  CHECK_NOTNULL(marker_array);
   createOccupancyBlocksFromLayer<OccupancyVoxel>(
       layer, &visualizeOccupiedOccupancyVoxels, frame_id, marker_array);
 }

--- a/voxblox_ros/src/visualize_tsdf.cc
+++ b/voxblox_ros/src/visualize_tsdf.cc
@@ -1,0 +1,193 @@
+#include <pcl/conversions.h>
+#include <pcl/filters/filter.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl_msgs/PolygonMesh.h>
+#include <pcl_ros/point_cloud.h>
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <visualization_msgs/MarkerArray.h>
+
+#include <voxblox/core/tsdf_map.h>
+#include <voxblox/io/layer_io.h>
+#include <voxblox/io/mesh_ply.h>
+#include <voxblox/mesh/mesh_integrator.h>
+
+#include "voxblox_ros/mesh_pcl.h"
+#include "voxblox_ros/mesh_vis.h"
+#include "voxblox_ros/ptcloud_vis.h"
+
+DEFINE_string(tsdf_proto_path, "", "Path to the serialized TSDF grid.");
+
+DEFINE_double(tsdf_surface_distance_threshold_factor, 0.75,
+              "This factor multiplied with the voxel size determines the "
+              "maximum distance to the surface for voxels to be considered "
+              "near-surface voxels.");
+
+DEFINE_string(tsdf_world_frame, "world",
+              "Name of the world frame. This frame will be used to publish all "
+              "the pointclouds and meshes.");
+
+DEFINE_string(tsdf_mesh_color_mode, "color",
+              "Color mode for the TSDF mesh extraction, options: "
+              "[color, height, normals, lambert, gray]");
+
+namespace voxblox {
+
+class SimpleTsdfVisualizer {
+ public:
+  SimpleTsdfVisualizer(const ros::NodeHandle& nh,
+                       const ros::NodeHandle& nh_private)
+      : nh_(nh), nh_private_(nh_private) {
+    VLOG(1) << "\tSetting up ROS publishers...";
+
+    surface_pointcloud_pub_ =
+        nh_private_.advertise<pcl::PointCloud<pcl::PointXYZRGB>>(
+            "tsdf_voxels_near_surface", 1, true);
+
+    tsdf_pointcloud_pub_ =
+        nh_private_.advertise<pcl::PointCloud<pcl::PointXYZI>>(
+            "all_tsdf_voxels", 1, true);
+
+    mesh_pub_ = nh_private_.advertise<voxblox_msgs::Mesh>("mesh", 1, true);
+
+    mesh_pointcloud_pub_ =
+        nh_private_.advertise<pcl::PointCloud<pcl::PointXYZRGB>>(
+            "mesh_as_pointcloud", 1, true);
+
+    mesh_pcl_mesh_pub_ =
+        nh_private_.advertise<pcl_msgs::PolygonMesh>("mesh_pcl", 1, true);
+
+    ros::spinOnce();
+  }
+
+  void run(const Layer<TsdfVoxel>& tsdf_layer);
+
+ private:
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
+
+  ros::Publisher surface_pointcloud_pub_;
+  ros::Publisher tsdf_pointcloud_pub_;
+  ros::Publisher mesh_pub_;
+  ros::Publisher mesh_pointcloud_pub_;
+  ros::Publisher mesh_pcl_mesh_pub_;
+};
+
+void SimpleTsdfVisualizer::run(const Layer<TsdfVoxel>& tsdf_layer) {
+  LOG(INFO) << "\nTSDF Layer info:\n"
+            << "\tVoxel size:\t\t " << tsdf_layer.voxel_size() << "\n"
+            << "\t# Voxels per side:\t " << tsdf_layer.voxels_per_side() << "\n"
+            << "\tMemory size:\t\t " << tsdf_layer.getMemorySize() * 1e-6
+            << "MB\n"
+            << "\t# Allocated blocks:\t "
+            << tsdf_layer.getNumberOfAllocatedBlocks() << "\n";
+
+  VLOG(1) << "\tVisualize voxels near surface...";
+  {
+    pcl::PointCloud<pcl::PointXYZRGB> pointcloud;
+    const float surface_distance_thresh_m =
+        tsdf_layer.voxel_size() * FLAGS_tsdf_surface_distance_threshold_factor;
+    voxblox::createSurfacePointcloudFromTsdfLayer(
+        tsdf_layer, surface_distance_thresh_m, &pointcloud);
+
+    pointcloud.header.frame_id = FLAGS_tsdf_world_frame;
+    surface_pointcloud_pub_.publish(pointcloud);
+  }
+
+  VLOG(1) << "\tVisualize all voxels...";
+  {
+    pcl::PointCloud<pcl::PointXYZI> pointcloud;
+    voxblox::createDistancePointcloudFromTsdfLayer(tsdf_layer, &pointcloud);
+
+    pointcloud.header.frame_id = FLAGS_tsdf_world_frame;
+    tsdf_pointcloud_pub_.publish(pointcloud);
+  }
+
+  VLOG(1) << "\tVisualize mesh...";
+  {
+    std::shared_ptr<MeshLayer> mesh_layer;
+    mesh_layer.reset(new MeshLayer(tsdf_layer.block_size()));
+    MeshIntegrator<TsdfVoxel>::Config mesh_config;
+    std::shared_ptr<MeshIntegrator<TsdfVoxel>> mesh_integrator;
+    mesh_integrator.reset(new MeshIntegrator<TsdfVoxel>(mesh_config, tsdf_layer,
+                                                        mesh_layer.get()));
+
+    constexpr bool kOnlyMeshUpdatedBlocks = false;
+    constexpr bool kClearUpdatedFlag = false;
+    mesh_integrator->generateMesh(kOnlyMeshUpdatedBlocks, kClearUpdatedFlag);
+
+    const std::string color_mode_string = FLAGS_tsdf_mesh_color_mode;
+    ColorMode color_mode;
+    if (color_mode_string == "color") {
+      color_mode = ColorMode::kColor;
+    } else if (color_mode_string == "height") {
+      color_mode = ColorMode::kHeight;
+    } else if (color_mode_string == "normals") {
+      color_mode = ColorMode::kNormals;
+    } else if (color_mode_string == "lambert") {
+      color_mode = ColorMode::kLambert;
+    } else if (color_mode_string == "gray") {
+      color_mode = ColorMode::kGray;
+    } else {
+      LOG(FATAL) << "Undefined mesh coloring mode: "
+                 << FLAGS_tsdf_mesh_color_mode;
+    }
+
+    // Output as native voxblox mesh.
+    voxblox_msgs::Mesh mesh_msg;
+    generateVoxbloxMeshMsg(mesh_layer, color_mode, &mesh_msg);
+    mesh_msg.header.frame_id = FLAGS_tsdf_world_frame;
+    mesh_pub_.publish(mesh_msg);
+
+    // Output as point cloud.
+    pcl::PointCloud<pcl::PointXYZRGB> pointcloud;
+    fillPointcloudWithMesh(mesh_layer, color_mode, &pointcloud);
+    pointcloud.header.frame_id = FLAGS_tsdf_world_frame;
+    mesh_pointcloud_pub_.publish(pointcloud);
+
+    // Output as pcl mesh.
+    pcl::PolygonMesh polygon_mesh;
+    toPCLPolygonMesh(*mesh_layer, FLAGS_tsdf_world_frame, &polygon_mesh);
+    pcl_msgs::PolygonMesh pcl_mesh_msg;
+    pcl_conversions::fromPCL(polygon_mesh, pcl_mesh_msg);
+    mesh_msg.header.stamp = ros::Time::now();
+    mesh_pcl_mesh_pub_.publish(mesh_msg);
+  }
+}
+
+}  // namespace voxblox
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "visualize_tsdf_node");
+  google::InitGoogleLogging(argv[0]);
+  google::ParseCommandLineFlags(&argc, &argv, false);
+  google::InstallFailureSignalHandler();
+  ros::NodeHandle nh;
+  ros::NodeHandle nh_private("~");
+
+  if (FLAGS_tsdf_proto_path.empty()) {
+    LOG(FATAL) << "Please provide a TSDF proto file to visualize using "
+               << "--tsdf_proto_path";
+  }
+
+  LOG(INFO) << "Visualize TSDF grid from " << FLAGS_tsdf_proto_path;
+
+  VLOG(1) << "Loading...";
+  voxblox::Layer<voxblox::TsdfVoxel>::Ptr tsdf_layer;
+  if (!voxblox::io::LoadLayer<voxblox::TsdfVoxel>(FLAGS_tsdf_proto_path,
+                                                  &tsdf_layer)) {
+    LOG(FATAL) << "Unable to load a TSDF grid from: " << FLAGS_tsdf_proto_path;
+  }
+  CHECK(tsdf_layer);
+  VLOG(1) << "Done.";
+
+  VLOG(1) << "Visualizing...";
+  voxblox::SimpleTsdfVisualizer visualizer(nh, nh_private);
+  visualizer.run(*tsdf_layer);
+  VLOG(1) << "Done.";
+
+  ros::spin();
+
+  return 0;
+}

--- a/voxblox_ros/src/visualize_tsdf.cc
+++ b/voxblox_ros/src/visualize_tsdf.cc
@@ -1,12 +1,14 @@
+#include <string>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
 #include <pcl/conversions.h>
-#include <pcl/filters/filter.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl_msgs/PolygonMesh.h>
 #include <pcl_ros/point_cloud.h>
 #include <ros/ros.h>
 #include <sensor_msgs/PointCloud2.h>
-#include <visualization_msgs/MarkerArray.h>
 
 #include <voxblox/core/tsdf_map.h>
 #include <voxblox/io/layer_io.h>


### PR DESCRIPTION
We needed a simple tool like that for the object DB, it helps analyzing the serialized TSDF objects.

The implementation was mostly taken from the `VoxbloxNode`.

```
rosrun voxblox_ros visualize_tsdf _tsdf_proto_path:=voxel_layer.proto
```

For larger TSDF grids, export the point cloud to a ply file and open it with meshlab or cloud compare, because RVIZ won't be able to handle it.
```
rosrun voxblox_ros visualize_tsdf _tsdf_proto_path:=voxel_layer.proto _tsdf_voxel_ply_output_path:=output.ply
```

  
  