### PR TITLE
don't do clearing without carving

### DIFF
--- a/voxblox/src/integrator/integrator_utils.cc
+++ b/voxblox/src/integrator/integrator_utils.cc
@@ -143,19 +143,20 @@ RayCaster::RayCaster(const Point& origin, const Point& point_G,
                      const bool cast_from_origin) {
   const Ray unit_ray = (point_G - origin).normalized();
 
-  Point ray_end;
+  Point ray_start, ray_end;
   if (is_clearing_ray) {
     FloatingPoint ray_length = (point_G - origin).norm();
     ray_length = std::min(std::max(ray_length - truncation_distance,
                                    static_cast<FloatingPoint>(0.0)),
                           max_ray_length_m);
     ray_end = origin + unit_ray * ray_length;
+    ray_start = voxel_carving_enabled ? origin : ray_end;
   } else {
     ray_end = point_G + unit_ray * truncation_distance;
+    ray_start = voxel_carving_enabled
+                    ? origin
+                    : (point_G - unit_ray * truncation_distance);
   }
-  const Point ray_start = voxel_carving_enabled
-                              ? origin
-                              : (point_G - unit_ray * truncation_distance);
 
   const Point start_scaled = ray_start * voxel_size_inv;
   const Point end_scaled = ray_end * voxel_size_inv;

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -26,6 +26,10 @@ TsdfIntegratorBase::TsdfIntegratorBase(const Config& config,
     LOG(WARNING) << "Automatic core count failed, defaulting to 1 threads";
     config_.integrator_threads = 1;
   }
+  // clearing rays have no utility is voxel_carving is disabled
+  if (config_.allow_clear && !config_.voxel_carving_enabled) {
+    config_.allow_clear = false;
+  }
 }
 
 // Thread safe.

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -26,7 +26,7 @@ TsdfIntegratorBase::TsdfIntegratorBase(const Config& config,
     LOG(WARNING) << "Automatic core count failed, defaulting to 1 threads";
     config_.integrator_threads = 1;
   }
-  // clearing rays have no utility is voxel_carving is disabled
+  // clearing rays have no utility if voxel_carving is disabled
   if (config_.allow_clear && !config_.voxel_carving_enabled) {
     config_.allow_clear = false;
   }


### PR DESCRIPTION
Previously if clearing was enabled and carving was disabled the system would begin clearing backwards beyond the max ray distance. This fix will just gives a clearing ray of length 0 instead.
@mfehr @margaritaG 
https://github.com/ethz-asl/voxblox_gsm/issues/12