### PR TITLE
Add support for concatenating multiple layers when serializing.

### DIFF
--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -224,15 +224,11 @@ class Layer {
   void getProto(LayerProto* proto) const;
   bool isCompatible(const LayerProto& layer_proto) const;
   bool isCompatible(const BlockProto& layer_proto) const;
-  bool saveToFile(const std::string& file_path) const;
-  bool saveToFile(const std::string& file_path, bool clear_file) const;
+  bool saveToFile(const std::string& file_path, bool clear_file = true) const;
   // Default behavior is to clear the file.
   bool saveSubsetToFile(const std::string& file_path,
                         BlockIndexList blocks_to_include,
-                        bool include_all_blocks) const;
-  bool saveSubsetToFile(const std::string& file_path,
-                        BlockIndexList blocks_to_include,
-                        bool include_all_blocks, bool clear_file) const;
+                        bool include_all_blocks, bool clear_file = true) const;
   bool addBlockFromProto(const BlockProto& block_proto,
                          BlockMergingStrategy strategy);
 

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -127,8 +127,8 @@ class Layer {
                    voxels_per_side_, voxel_size_,
                    getOriginPointFromGridIndex(index, block_size_)));
 
-    DCHECK(insert_status.second)
-        << "Block already exists when allocating at " << index.transpose();
+    DCHECK(insert_status.second) << "Block already exists when allocating at "
+                                 << index.transpose();
 
     DCHECK(insert_status.first->second);
     DCHECK_EQ(insert_status.first->first, index);
@@ -225,9 +225,14 @@ class Layer {
   bool isCompatible(const LayerProto& layer_proto) const;
   bool isCompatible(const BlockProto& layer_proto) const;
   bool saveToFile(const std::string& file_path) const;
+  bool saveToFile(const std::string& file_path, bool clear_file) const;
+  // Default behavior is to clear the file.
   bool saveSubsetToFile(const std::string& file_path,
                         BlockIndexList blocks_to_include,
                         bool include_all_blocks) const;
+  bool saveSubsetToFile(const std::string& file_path,
+                        BlockIndexList blocks_to_include,
+                        bool include_all_blocks, bool clear_file) const;
   bool addBlockFromProto(const BlockProto& block_proto,
                          BlockMergingStrategy strategy);
 

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -109,7 +109,9 @@ bool Layer<VoxelType>::saveSubsetToFile(const std::string& file_path,
   // same file, depending on the flag.
   char file_flags = std::fstream::out | std::fstream::binary;
   if (!clear_file) {
-    file_flags |= std::fstream::ate;
+    file_flags |= std::fstream::app | std::fstream::ate;
+  } else {
+    file_flags |= std::fstream::trunc;
   }
   outfile.open(file_path, file_flags);
   if (!outfile.is_open()) {

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -74,23 +74,44 @@ Layer<VoxelType>::Layer(const Layer& other) {
 
 template <typename VoxelType>
 bool Layer<VoxelType>::saveToFile(const std::string& file_path) const {
+  constexpr bool clear_file = true;
+  return saveToFile(file_path, clear_file);
+}
+
+template <typename VoxelType>
+bool Layer<VoxelType>::saveToFile(const std::string& file_path,
+                                  bool clear_file) const {
   constexpr bool kIncludeAllBlocks = true;
-  return saveSubsetToFile(file_path, BlockIndexList(), kIncludeAllBlocks);
+  return saveSubsetToFile(file_path, BlockIndexList(), kIncludeAllBlocks,
+                          clear_file);
 }
 
 template <typename VoxelType>
 bool Layer<VoxelType>::saveSubsetToFile(const std::string& file_path,
                                         BlockIndexList blocks_to_include,
                                         bool include_all_blocks) const {
+  constexpr bool clear_file = true;
+  return saveSubsetToFile(file_path, blocks_to_include, include_all_blocks,
+                          clear_file);
+}
+
+template <typename VoxelType>
+bool Layer<VoxelType>::saveSubsetToFile(const std::string& file_path,
+                                        BlockIndexList blocks_to_include,
+                                        bool include_all_blocks,
+                                        bool clear_file) const {
   CHECK_NE(getType().compare(voxel_types::kNotSerializable), 0)
       << "The voxel type of this layer is not serializable!";
 
   CHECK(!file_path.empty());
   std::fstream outfile;
   // Will APPEND to the current file in case outputting multiple layers on the
-  // same file.
-  outfile.open(file_path,
-               std::fstream::out | std::fstream::binary | std::fstream::ate);
+  // same file, depending on the flag.
+  char file_flags = std::fstream::out | std::fstream::binary;
+  if (!clear_file) {
+    file_flags |= std::fstream::ate;
+  }
+  outfile.open(file_path, file_flags);
   if (!outfile.is_open()) {
     LOG(ERROR) << "Could not open file for writing: " << file_path;
     return false;

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -107,7 +107,7 @@ bool Layer<VoxelType>::saveSubsetToFile(const std::string& file_path,
   std::fstream outfile;
   // Will APPEND to the current file in case outputting multiple layers on the
   // same file, depending on the flag.
-  char file_flags = std::fstream::out | std::fstream::binary;
+  std::ios_base::openmode file_flags = std::fstream::out | std::fstream::binary;
   if (!clear_file) {
     file_flags |= std::fstream::app | std::fstream::ate;
   } else {

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -87,7 +87,10 @@ bool Layer<VoxelType>::saveSubsetToFile(const std::string& file_path,
 
   CHECK(!file_path.empty());
   std::fstream outfile;
-  outfile.open(file_path, std::fstream::out | std::fstream::binary);
+  // Will APPEND to the current file in case outputting multiple layers on the
+  // same file.
+  outfile.open(file_path,
+               std::fstream::out | std::fstream::binary | std::fstream::ate);
   if (!outfile.is_open()) {
     LOG(ERROR) << "Could not open file for writing: " << file_path;
     return false;

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -73,25 +73,10 @@ Layer<VoxelType>::Layer(const Layer& other) {
 }
 
 template <typename VoxelType>
-bool Layer<VoxelType>::saveToFile(const std::string& file_path) const {
-  constexpr bool clear_file = true;
-  return saveToFile(file_path, clear_file);
-}
-
-template <typename VoxelType>
 bool Layer<VoxelType>::saveToFile(const std::string& file_path,
                                   bool clear_file) const {
   constexpr bool kIncludeAllBlocks = true;
   return saveSubsetToFile(file_path, BlockIndexList(), kIncludeAllBlocks,
-                          clear_file);
-}
-
-template <typename VoxelType>
-bool Layer<VoxelType>::saveSubsetToFile(const std::string& file_path,
-                                        BlockIndexList blocks_to_include,
-                                        bool include_all_blocks) const {
-  constexpr bool clear_file = true;
-  return saveSubsetToFile(file_path, blocks_to_include, include_all_blocks,
                           clear_file);
 }
 

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -26,13 +26,14 @@ bool LoadBlocksFromFile(
     typename Layer<VoxelType>::BlockMergingStrategy strategy,
     bool multiple_layer_support, Layer<VoxelType>* layer_ptr);
 
+// Unlike LoadBlocks above, this actually allocates the layer as well.
 // By default loads without multiple layer support (i.e., only checks the first
 // layer in the file).
 template <typename VoxelType>
 bool LoadLayer(const std::string& file_path,
                typename Layer<VoxelType>::Ptr* layer_ptr);
 template <typename VoxelType>
-bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
+bool LoadLayer(const std::string& file_path, const bool multiple_layer_support,
                typename Layer<VoxelType>::Ptr* layer_ptr);
 
 // By default, clears (truncates) the output file. Set clear_file to false in
@@ -45,7 +46,8 @@ bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path,
 template <typename VoxelType>
 bool SaveLayerSubset(const Layer<VoxelType>& layer,
                      const std::string& file_path,
-                     BlockIndexList blocks_to_include, bool include_all_blocks);
+                     const BlockIndexList& blocks_to_include,
+                     bool include_all_blocks);
 
 }  // namespace io
 }  // namespace voxblox

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -5,248 +5,51 @@
 
 #include <glog/logging.h>
 
-#include "./Block.pb.h"
-#include "./Layer.pb.h"
 #include "voxblox/core/common.h"
 #include "voxblox/core/layer.h"
-#include "voxblox/utils/protobuf_utils.h"
 
 namespace voxblox {
 namespace io {
 
+// By default, loads blocks without multiple layer support.
+// Loading blocks assumes that the layer is already setup and allocated, while
+// loading the full layer (below) allocates a layer of the correct size instead.
 template <typename VoxelType>
 bool LoadBlocksFromFile(
     const std::string& file_path,
     typename Layer<VoxelType>::BlockMergingStrategy strategy,
-    bool multiple_layer_support, Layer<VoxelType>* layer_ptr) {
-  CHECK_NOTNULL(layer_ptr);
-  CHECK(!file_path.empty());
-
-  // Open and check the file
-  std::fstream proto_file;
-  proto_file.open(file_path, std::fstream::in);
-  if (!proto_file.is_open()) {
-    LOG(ERROR) << "Could not open protobuf file to load layer: " << file_path;
-    return false;
-  }
-
-  // Byte offset result, used to keep track where we are in the file if
-  // necessary.
-  uint32_t tmp_byte_offset = 0;
-
-  bool layer_found = false;
-
-  do {
-    // Get number of messages
-    uint32_t num_protos;
-    if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
-                                          &tmp_byte_offset)) {
-      LOG(ERROR) << "Could not read number of messages.";
-      return false;
-    }
-
-    if (num_protos == 0u) {
-      LOG(WARNING) << "Empty protobuf file!";
-      return false;
-    }
-
-    // Get header and check if it is compatible with existing layer.
-    LayerProto layer_proto;
-    if (!utils::readProtoMsgFromStream(&proto_file, &layer_proto,
-                                       &tmp_byte_offset)) {
-      LOG(ERROR) << "Could not read layer protobuf message.";
-      return false;
-    }
-
-    if (layer_ptr->isCompatible(layer_proto)) {
-      layer_found = true;
-    } else if (!multiple_layer_support) {
-      LOG(ERROR)
-          << "The layer information read from file is not compatible with "
-             "the current layer!";
-      return false;
-    } else {
-      // Figure out how much offset to jump forward by. This is the number of
-      // blocks * the block size... Actually maybe we just read them in? This
-      // is probably easiest. Then if there's corrupted blocks, we abort.
-      // We just don't add these to the layer.
-      const size_t num_blocks = num_protos - 1;
-      for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
-        BlockProto block_proto;
-        if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
-                                           &tmp_byte_offset)) {
-          LOG(ERROR) << "Could not read block protobuf message number "
-                     << block_idx;
-          return false;
-        }
-      }
-      continue;
-    }
-
-    // Read all blocks and add them to the layer.
-    const size_t num_blocks = num_protos - 1;
-    for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
-      BlockProto block_proto;
-      if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
-                                         &tmp_byte_offset)) {
-        LOG(ERROR) << "Could not read block protobuf message number "
-                   << block_idx;
-        return false;
-      }
-
-      if (!layer_ptr->addBlockFromProto(block_proto, strategy)) {
-        LOG(ERROR) << "Could not add the block protobuf message to the layer!";
-        return false;
-      }
-    }
-  } while (multiple_layer_support && !layer_found && !proto_file.eof());
-  return layer_found;
-}
+    Layer<VoxelType>* layer_ptr);
 
 template <typename VoxelType>
 bool LoadBlocksFromFile(
     const std::string& file_path,
     typename Layer<VoxelType>::BlockMergingStrategy strategy,
-    Layer<VoxelType>* layer_ptr) {
-  bool multiple_layer_support = false;
-  return LoadBlocksFromFile(file_path, strategy, multiple_layer_support,
-                            layer_ptr);
-}
-
-template <typename VoxelType>
-bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
-               typename Layer<VoxelType>::Ptr* layer_ptr) {
-  CHECK_NOTNULL(layer_ptr);
-  CHECK(!file_path.empty());
-
-  // Open and check the file
-  std::fstream proto_file;
-  proto_file.open(file_path, std::fstream::in);
-  if (!proto_file.is_open()) {
-    LOG(ERROR) << "Could not open protobuf file to load layer: " << file_path;
-    return false;
-  }
-
-  // Byte offset result, used to keep track where we are in the file if
-  // necessary.
-  uint32_t tmp_byte_offset = 0;
-
-  bool layer_found = false;
-
-  do {
-    // Get number of messages
-    uint32_t num_protos;
-    if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
-                                          &tmp_byte_offset)) {
-      LOG(ERROR) << "Could not read number of messages.";
-      return false;
-    }
-
-    if (num_protos == 0u) {
-      LOG(WARNING) << "Empty protobuf file!";
-      return false;
-    }
-
-    // Get header and check if it is compatible with existing layer.
-    LayerProto layer_proto;
-    if (!utils::readProtoMsgFromStream(&proto_file, &layer_proto,
-                                       &tmp_byte_offset)) {
-      LOG(ERROR) << "Could not read layer protobuf message.";
-      return false;
-    }
-
-    if ((layer_proto.voxel_size() <= 0.0f) ||
-        (layer_proto.voxels_per_side() == 0u)) {
-      LOG(ERROR)
-          << "Invalid parameter in layer protobuf message. Check the format.";
-      return false;
-    }
-
-    if (getVoxelType<VoxelType>().compare(layer_proto.type()) == 0) {
-      layer_found = true;
-    } else if (!multiple_layer_support) {
-      LOG(ERROR)
-          << "The layer information read from file is not compatible with "
-             "the current layer!";
-      return false;
-    } else {
-      // Figure out how much offset to jump forward by. This is the number of
-      // blocks * the block size... Actually maybe we just read them in? This
-      // is probably easiest. Then if there's corrupted blocks, we abort.
-      // We just don't add these to the layer.
-      const size_t num_blocks = num_protos - 1;
-      for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
-        BlockProto block_proto;
-        if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
-                                           &tmp_byte_offset)) {
-          LOG(ERROR) << "Could not read block protobuf message number "
-                     << block_idx;
-          return false;
-        }
-      }
-      continue;
-    }
-
-    *layer_ptr = aligned_shared<Layer<VoxelType> >(layer_proto);
-    CHECK(*layer_ptr);
-
-    // Read all blocks and add them to the layer.
-    const size_t num_blocks = num_protos - 1;
-    for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
-      BlockProto block_proto;
-      if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
-                                         &tmp_byte_offset)) {
-        LOG(ERROR) << "Could not read block protobuf message number "
-                   << block_idx;
-        return false;
-      }
-
-      if (!(*layer_ptr)
-               ->addBlockFromProto(
-                   block_proto,
-                   Layer<VoxelType>::BlockMergingStrategy::kProhibit)) {
-        LOG(ERROR) << "Could not add the block protobuf message to the layer!";
-        return false;
-      }
-    }
-  } while (multiple_layer_support && !layer_found && !proto_file.eof());
-  return layer_found;
-}
+    bool multiple_layer_support, Layer<VoxelType>* layer_ptr);
 
 // By default loads without multiple layer support (i.e., only checks the first
 // layer in the file).
 template <typename VoxelType>
 bool LoadLayer(const std::string& file_path,
-               typename Layer<VoxelType>::Ptr* layer_ptr) {
-  constexpr bool multiple_layer_support = false;
-  return LoadLayer<VoxelType>(file_path, multiple_layer_support, layer_ptr);
-}
+               typename Layer<VoxelType>::Ptr* layer_ptr);
+template <typename VoxelType>
+bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
+               typename Layer<VoxelType>::Ptr* layer_ptr);
 
+// By default, clears (truncates) the output file. Set clear_file to false in
+// case writing the second (or subsequent) layer into the same file.
 template <typename VoxelType>
 bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path,
-               bool clear_file) {
-  CHECK(!file_path.empty());
-  return layer.saveToFile(file_path, clear_file);
-}
+               bool clear_file);
 
-template <typename VoxelType>
-bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path) {
-  constexpr bool clear_file = true;
-  return SaveLayer(layer, file_path, clear_file);
-}
-
+// Saves only some parts of the layer to the file. Clears the file by default.
 template <typename VoxelType>
 bool SaveLayerSubset(const Layer<VoxelType>& layer,
                      const std::string& file_path,
-                     BlockIndexList blocks_to_include,
-                     bool include_all_blocks) {
-  CHECK(!file_path.empty());
-  return layer.saveSubsetToFile(file_path, blocks_to_include,
-                                include_all_blocks);
-}
+                     BlockIndexList blocks_to_include, bool include_all_blocks);
 
 }  // namespace io
-
 }  // namespace voxblox
+
+#include "voxblox/io/layer_io_inl.h"
 
 #endif  // VOXBLOX_CORE_IO_LAYER_IO_H_

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -99,7 +99,7 @@ bool LoadBlocksFromFile(
         return false;
       }
     }
-  } while (multiple_layer_support && !layer_found);
+  } while (multiple_layer_support && !layer_found && !proto_file.eof());
   return layer_found;
 }
 
@@ -162,7 +162,7 @@ bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
       return false;
     }
 
-    if (getVoxelType<VoxelType>().compare(layer_proto.type())) {
+    if (getVoxelType<VoxelType>().compare(layer_proto.type()) == 0) {
       layer_found = true;
     } else if (!multiple_layer_support) {
       LOG(ERROR)
@@ -201,13 +201,15 @@ bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
         return false;
       }
 
-      if (!(*layer_ptr)->addBlockFromProto(
-              block_proto, Layer<VoxelType>::BlockMergingStrategy::kProhibit)) {
+      if (!(*layer_ptr)
+               ->addBlockFromProto(
+                   block_proto,
+                   Layer<VoxelType>::BlockMergingStrategy::kProhibit)) {
         LOG(ERROR) << "Could not add the block protobuf message to the layer!";
         return false;
       }
     }
-  } while (multiple_layer_support && !layer_found);
+  } while (multiple_layer_support && !layer_found && !proto_file.eof());
   return layer_found;
 }
 

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -39,7 +39,7 @@ bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
 // case writing the second (or subsequent) layer into the same file.
 template <typename VoxelType>
 bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path,
-               bool clear_file);
+               bool clear_file = true);
 
 // Saves only some parts of the layer to the file. Clears the file by default.
 template <typename VoxelType>

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -15,7 +15,106 @@ namespace voxblox {
 namespace io {
 
 template <typename VoxelType>
-bool LoadLayer(const std::string& file_path,
+bool LoadBlocksFromFile(
+    const std::string& file_path,
+    typename Layer<VoxelType>::BlockMergingStrategy strategy,
+    bool multiple_layer_support, Layer<VoxelType>* layer_ptr) {
+  CHECK_NOTNULL(layer_ptr);
+  CHECK(!file_path.empty());
+
+  // Open and check the file
+  std::fstream proto_file;
+  proto_file.open(file_path, std::fstream::in);
+  if (!proto_file.is_open()) {
+    LOG(ERROR) << "Could not open protobuf file to load layer: " << file_path;
+    return false;
+  }
+
+  // Byte offset result, used to keep track where we are in the file if
+  // necessary.
+  uint32_t tmp_byte_offset = 0;
+
+  bool layer_found = false;
+
+  do {
+    // Get number of messages
+    uint32_t num_protos;
+    if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
+                                          &tmp_byte_offset)) {
+      LOG(ERROR) << "Could not read number of messages.";
+      return false;
+    }
+
+    if (num_protos == 0u) {
+      LOG(WARNING) << "Empty protobuf file!";
+      return false;
+    }
+
+    // Get header and check if it is compatible with existing layer.
+    LayerProto layer_proto;
+    if (!utils::readProtoMsgFromStream(&proto_file, &layer_proto,
+                                       &tmp_byte_offset)) {
+      LOG(ERROR) << "Could not read layer protobuf message.";
+      return false;
+    }
+
+    if (layer_ptr->isCompatible(layer_proto)) {
+      layer_found = true;
+    } else if (!multiple_layer_support) {
+      LOG(ERROR)
+          << "The layer information read from file is not compatible with "
+             "the current layer!";
+      return false;
+    } else {
+      // Figure out how much offset to jump forward by. This is the number of
+      // blocks * the block size... Actually maybe we just read them in? This
+      // is probably easiest. Then if there's corrupted blocks, we abort.
+      // We just don't add these to the layer.
+      const size_t num_blocks = num_protos - 1;
+      for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+        BlockProto block_proto;
+        if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+                                           &tmp_byte_offset)) {
+          LOG(ERROR) << "Could not read block protobuf message number "
+                     << block_idx;
+          return false;
+        }
+      }
+      continue;
+    }
+
+    // Read all blocks and add them to the layer.
+    const size_t num_blocks = num_protos - 1;
+    for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+      BlockProto block_proto;
+      if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+                                         &tmp_byte_offset)) {
+        LOG(ERROR) << "Could not read block protobuf message number "
+                   << block_idx;
+        return false;
+      }
+
+      if (!layer_ptr->addBlockFromProto(block_proto, strategy)) {
+        LOG(ERROR) << "Could not add the block protobuf message to the layer!";
+        return false;
+      }
+    }
+  } while (multiple_layer_support && !layer_found);
+  return layer_found;
+}
+
+template <typename VoxelType>
+bool LoadBlocksFromFile(
+    const std::string& file_path,
+    typename Layer<VoxelType>::BlockMergingStrategy strategy,
+    Layer<VoxelType>* layer_ptr) {
+  bool multiple_layer_support = false;
+  return LoadBlocksFromFile(file_path, strategy, multiple_layer_support,
+                            layer_ptr);
+}
+
+template <typename VoxelType>
+bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
                typename Layer<VoxelType>::Ptr* layer_ptr) {
   CHECK_NOTNULL(layer_ptr);
   CHECK(!file_path.empty());
@@ -28,132 +127,110 @@ bool LoadLayer(const std::string& file_path,
     return false;
   }
 
-  // Unused byte offset result.
-  uint32_t tmp_byte_offset;
+  // Byte offset result, used to keep track where we are in the file if
+  // necessary.
+  uint32_t tmp_byte_offset = 0;
 
-  // Get number of messages
-  uint32_t num_protos;
-  if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
-                                        &tmp_byte_offset)) {
-    LOG(ERROR) << "Could not read number of messages.";
-    return false;
-  }
+  bool layer_found = false;
 
-  if (num_protos == 0u) {
-    LOG(WARNING) << "Empty protobuf file!";
-    return false;
-  }
+  do {
+    // Get number of messages
+    uint32_t num_protos;
+    if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
+                                          &tmp_byte_offset)) {
+      LOG(ERROR) << "Could not read number of messages.";
+      return false;
+    }
 
-  // Get header and create the layer if compatible
-  LayerProto layer_proto;
-  if (!utils::readProtoMsgFromStream(&proto_file, &layer_proto,
-                                     &tmp_byte_offset)) {
-    LOG(ERROR) << "Could not read layer protobuf message.";
-    return false;
-  }
+    if (num_protos == 0u) {
+      LOG(WARNING) << "Empty protobuf file!";
+      return false;
+    }
 
-  if ((layer_proto.voxel_size() <= 0.0f)    ||
-      (layer_proto.voxels_per_side() == 0u) ||
-      (getVoxelType<VoxelType>().compare(layer_proto.type()))) {
-    LOG(ERROR)
-        << "Invalid parameter in layer protobuf message. Check the format.";
-    return false;
-  }
-
-  *layer_ptr = aligned_shared<Layer<VoxelType> >(layer_proto);
-  CHECK(*layer_ptr);
-
-  // Read all blocks and add them to the layer.
-  const size_t num_blocks = num_protos - 1;
-  for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
-    BlockProto block_proto;
-    if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+    // Get header and check if it is compatible with existing layer.
+    LayerProto layer_proto;
+    if (!utils::readProtoMsgFromStream(&proto_file, &layer_proto,
                                        &tmp_byte_offset)) {
-      LOG(ERROR) << "Could not read block protobuf message number "
-                 << block_idx;
+      LOG(ERROR) << "Could not read layer protobuf message.";
       return false;
     }
 
-    if (!(*layer_ptr)
-             ->addBlockFromProto(
-                 block_proto,
-                 Layer<VoxelType>::BlockMergingStrategy::kProhibit)) {
-      LOG(ERROR) << "Could not add the block protobuf message to the layer!";
+    if ((layer_proto.voxel_size() <= 0.0f) ||
+        (layer_proto.voxels_per_side() == 0u)) {
+      LOG(ERROR)
+          << "Invalid parameter in layer protobuf message. Check the format.";
       return false;
     }
-  }
 
-  return true;
+    if (getVoxelType<VoxelType>().compare(layer_proto.type())) {
+      layer_found = true;
+    } else if (!multiple_layer_support) {
+      LOG(ERROR)
+          << "The layer information read from file is not compatible with "
+             "the current layer!";
+      return false;
+    } else {
+      // Figure out how much offset to jump forward by. This is the number of
+      // blocks * the block size... Actually maybe we just read them in? This
+      // is probably easiest. Then if there's corrupted blocks, we abort.
+      // We just don't add these to the layer.
+      const size_t num_blocks = num_protos - 1;
+      for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+        BlockProto block_proto;
+        if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+                                           &tmp_byte_offset)) {
+          LOG(ERROR) << "Could not read block protobuf message number "
+                     << block_idx;
+          return false;
+        }
+      }
+      continue;
+    }
+
+    *layer_ptr = aligned_shared<Layer<VoxelType> >(layer_proto);
+    CHECK(*layer_ptr);
+
+    // Read all blocks and add them to the layer.
+    const size_t num_blocks = num_protos - 1;
+    for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+      BlockProto block_proto;
+      if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+                                         &tmp_byte_offset)) {
+        LOG(ERROR) << "Could not read block protobuf message number "
+                   << block_idx;
+        return false;
+      }
+
+      if (!(*layer_ptr)->addBlockFromProto(
+              block_proto, Layer<VoxelType>::BlockMergingStrategy::kProhibit)) {
+        LOG(ERROR) << "Could not add the block protobuf message to the layer!";
+        return false;
+      }
+    }
+  } while (multiple_layer_support && !layer_found);
+  return layer_found;
+}
+
+// By default loads without multiple layer support (i.e., only checks the first
+// layer in the file).
+template <typename VoxelType>
+bool LoadLayer(const std::string& file_path,
+               typename Layer<VoxelType>::Ptr* layer_ptr) {
+  constexpr bool multiple_layer_support = false;
+  return LoadLayer<VoxelType>(file_path, multiple_layer_support, layer_ptr);
 }
 
 template <typename VoxelType>
-bool LoadBlocksFromFile(
-    const std::string& file_path,
-    typename Layer<VoxelType>::BlockMergingStrategy strategy,
-    Layer<VoxelType>* layer_ptr) {
-  CHECK_NOTNULL(layer_ptr);
+bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path,
+               bool clear_file) {
   CHECK(!file_path.empty());
-
-  // Open and check the file
-  std::fstream proto_file;
-  proto_file.open(file_path, std::fstream::in);
-  if (!proto_file.is_open()) {
-    LOG(ERROR) << "Could not open protobuf file to load layer: " << file_path;
-    return false;
-  }
-
-  // Unused byte offset result.
-  uint32_t tmp_byte_offset;
-
-  // Get number of messages
-  uint32_t num_protos;
-  if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
-                                        &tmp_byte_offset)) {
-    LOG(ERROR) << "Could not read number of messages.";
-    return false;
-  }
-
-  if (num_protos == 0u) {
-    LOG(WARNING) << "Empty protobuf file!";
-    return false;
-  }
-
-  // Get header and check if it is compatible with existing layer.
-  LayerProto layer_proto;
-  if (!utils::readProtoMsgFromStream(&proto_file, &layer_proto,
-                                     &tmp_byte_offset)) {
-    LOG(ERROR) << "Could not read layer protobuf message.";
-    return false;
-  }
-  if (!layer_ptr->isCompatible(layer_proto)) {
-    LOG(ERROR) << "The layer information read from file is not compatible with "
-                  "the current layer!";
-    return false;
-  }
-
-  // Read all blocks and add them to the layer.
-  const size_t num_blocks = num_protos - 1;
-  for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
-    BlockProto block_proto;
-    if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
-                                       &tmp_byte_offset)) {
-      LOG(ERROR) << "Could not read block protobuf message number "
-                 << block_idx;
-      return false;
-    }
-
-    if (!layer_ptr->addBlockFromProto(block_proto, strategy)) {
-      LOG(ERROR) << "Could not add the block protobuf message to the layer!";
-      return false;
-    }
-  }
-  return true;
+  return layer.saveToFile(file_path, clear_file);
 }
 
 template <typename VoxelType>
 bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path) {
-  CHECK(!file_path.empty());
-  return layer.saveToFile(file_path);
+  constexpr bool clear_file = true;
+  return SaveLayer(layer, file_path, clear_file);
 }
 
 template <typename VoxelType>

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -105,13 +105,13 @@ bool LoadBlocksFromFile(
     const std::string& file_path,
     typename Layer<VoxelType>::BlockMergingStrategy strategy,
     Layer<VoxelType>* layer_ptr) {
-  bool multiple_layer_support = false;
+  constexpr bool multiple_layer_support = false;
   return LoadBlocksFromFile(file_path, strategy, multiple_layer_support,
                             layer_ptr);
 }
 
 template <typename VoxelType>
-bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
+bool LoadLayer(const std::string& file_path, const bool multiple_layer_support,
                typename Layer<VoxelType>::Ptr* layer_ptr) {
   CHECK_NOTNULL(layer_ptr);
   CHECK(!file_path.empty());
@@ -229,7 +229,7 @@ bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path,
 template <typename VoxelType>
 bool SaveLayerSubset(const Layer<VoxelType>& layer,
                      const std::string& file_path,
-                     BlockIndexList blocks_to_include,
+                     const BlockIndexList& blocks_to_include,
                      bool include_all_blocks) {
   CHECK(!file_path.empty());
   return layer.saveSubsetToFile(file_path, blocks_to_include,

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -1,6 +1,8 @@
 #ifndef VOXBLOX_CORE_IO_LAYER_IO_INL_H_
 #define VOXBLOX_CORE_IO_LAYER_IO_INL_H_
 
+#include <fstream>
+
 #include "./Block.pb.h"
 #include "./Layer.pb.h"
 

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -227,12 +227,6 @@ bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path,
 }
 
 template <typename VoxelType>
-bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path) {
-  constexpr bool clear_file = true;
-  return SaveLayer(layer, file_path, clear_file);
-}
-
-template <typename VoxelType>
 bool SaveLayerSubset(const Layer<VoxelType>& layer,
                      const std::string& file_path,
                      BlockIndexList blocks_to_include,

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -1,0 +1,246 @@
+#ifndef VOXBLOX_CORE_IO_LAYER_IO_INL_H_
+#define VOXBLOX_CORE_IO_LAYER_IO_INL_H_
+
+#include "./Block.pb.h"
+#include "./Layer.pb.h"
+
+#include "voxblox/utils/protobuf_utils.h"
+
+namespace voxblox {
+namespace io {
+
+template <typename VoxelType>
+bool LoadBlocksFromFile(
+    const std::string& file_path,
+    typename Layer<VoxelType>::BlockMergingStrategy strategy,
+    bool multiple_layer_support, Layer<VoxelType>* layer_ptr) {
+  CHECK_NOTNULL(layer_ptr);
+  CHECK(!file_path.empty());
+
+  // Open and check the file
+  std::fstream proto_file;
+  proto_file.open(file_path, std::fstream::in);
+  if (!proto_file.is_open()) {
+    LOG(ERROR) << "Could not open protobuf file to load layer: " << file_path;
+    return false;
+  }
+
+  // Byte offset result, used to keep track where we are in the file if
+  // necessary.
+  uint32_t tmp_byte_offset = 0;
+
+  bool layer_found = false;
+
+  do {
+    // Get number of messages
+    uint32_t num_protos;
+    if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
+                                          &tmp_byte_offset)) {
+      LOG(ERROR) << "Could not read number of messages.";
+      return false;
+    }
+
+    if (num_protos == 0u) {
+      LOG(WARNING) << "Empty protobuf file!";
+      return false;
+    }
+
+    // Get header and check if it is compatible with existing layer.
+    LayerProto layer_proto;
+    if (!utils::readProtoMsgFromStream(&proto_file, &layer_proto,
+                                       &tmp_byte_offset)) {
+      LOG(ERROR) << "Could not read layer protobuf message.";
+      return false;
+    }
+
+    if (layer_ptr->isCompatible(layer_proto)) {
+      layer_found = true;
+    } else if (!multiple_layer_support) {
+      LOG(ERROR)
+          << "The layer information read from file is not compatible with "
+             "the current layer!";
+      return false;
+    } else {
+      // Figure out how much offset to jump forward by. This is the number of
+      // blocks * the block size... Actually maybe we just read them in? This
+      // is probably easiest. Then if there's corrupted blocks, we abort.
+      // We just don't add these to the layer.
+      const size_t num_blocks = num_protos - 1;
+      for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+        BlockProto block_proto;
+        if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+                                           &tmp_byte_offset)) {
+          LOG(ERROR) << "Could not read block protobuf message number "
+                     << block_idx;
+          return false;
+        }
+      }
+      continue;
+    }
+
+    // Read all blocks and add them to the layer.
+    const size_t num_blocks = num_protos - 1;
+    for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+      BlockProto block_proto;
+      if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+                                         &tmp_byte_offset)) {
+        LOG(ERROR) << "Could not read block protobuf message number "
+                   << block_idx;
+        return false;
+      }
+
+      if (!layer_ptr->addBlockFromProto(block_proto, strategy)) {
+        LOG(ERROR) << "Could not add the block protobuf message to the layer!";
+        return false;
+      }
+    }
+  } while (multiple_layer_support && !layer_found && !proto_file.eof());
+  return layer_found;
+}
+
+template <typename VoxelType>
+bool LoadBlocksFromFile(
+    const std::string& file_path,
+    typename Layer<VoxelType>::BlockMergingStrategy strategy,
+    Layer<VoxelType>* layer_ptr) {
+  bool multiple_layer_support = false;
+  return LoadBlocksFromFile(file_path, strategy, multiple_layer_support,
+                            layer_ptr);
+}
+
+template <typename VoxelType>
+bool LoadLayer(const std::string& file_path, bool multiple_layer_support,
+               typename Layer<VoxelType>::Ptr* layer_ptr) {
+  CHECK_NOTNULL(layer_ptr);
+  CHECK(!file_path.empty());
+
+  // Open and check the file
+  std::fstream proto_file;
+  proto_file.open(file_path, std::fstream::in);
+  if (!proto_file.is_open()) {
+    LOG(ERROR) << "Could not open protobuf file to load layer: " << file_path;
+    return false;
+  }
+
+  // Byte offset result, used to keep track where we are in the file if
+  // necessary.
+  uint32_t tmp_byte_offset = 0;
+
+  bool layer_found = false;
+
+  do {
+    // Get number of messages
+    uint32_t num_protos;
+    if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
+                                          &tmp_byte_offset)) {
+      LOG(ERROR) << "Could not read number of messages.";
+      return false;
+    }
+
+    if (num_protos == 0u) {
+      LOG(WARNING) << "Empty protobuf file!";
+      return false;
+    }
+
+    // Get header and check if it is compatible with existing layer.
+    LayerProto layer_proto;
+    if (!utils::readProtoMsgFromStream(&proto_file, &layer_proto,
+                                       &tmp_byte_offset)) {
+      LOG(ERROR) << "Could not read layer protobuf message.";
+      return false;
+    }
+
+    if ((layer_proto.voxel_size() <= 0.0f) ||
+        (layer_proto.voxels_per_side() == 0u)) {
+      LOG(ERROR)
+          << "Invalid parameter in layer protobuf message. Check the format.";
+      return false;
+    }
+
+    if (getVoxelType<VoxelType>().compare(layer_proto.type()) == 0) {
+      layer_found = true;
+    } else if (!multiple_layer_support) {
+      LOG(ERROR)
+          << "The layer information read from file is not compatible with "
+             "the current layer!";
+      return false;
+    } else {
+      // Figure out how much offset to jump forward by. This is the number of
+      // blocks * the block size... Actually maybe we just read them in? This
+      // is probably easiest. Then if there's corrupted blocks, we abort.
+      // We just don't add these to the layer.
+      const size_t num_blocks = num_protos - 1;
+      for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+        BlockProto block_proto;
+        if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+                                           &tmp_byte_offset)) {
+          LOG(ERROR) << "Could not read block protobuf message number "
+                     << block_idx;
+          return false;
+        }
+      }
+      continue;
+    }
+
+    *layer_ptr = aligned_shared<Layer<VoxelType> >(layer_proto);
+    CHECK(*layer_ptr);
+
+    // Read all blocks and add them to the layer.
+    const size_t num_blocks = num_protos - 1;
+    for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+      BlockProto block_proto;
+      if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
+                                         &tmp_byte_offset)) {
+        LOG(ERROR) << "Could not read block protobuf message number "
+                   << block_idx;
+        return false;
+      }
+
+      if (!(*layer_ptr)
+               ->addBlockFromProto(
+                   block_proto,
+                   Layer<VoxelType>::BlockMergingStrategy::kProhibit)) {
+        LOG(ERROR) << "Could not add the block protobuf message to the layer!";
+        return false;
+      }
+    }
+  } while (multiple_layer_support && !layer_found && !proto_file.eof());
+  return layer_found;
+}
+
+// By default loads without multiple layer support (i.e., only checks the first
+// layer in the file).
+template <typename VoxelType>
+bool LoadLayer(const std::string& file_path,
+               typename Layer<VoxelType>::Ptr* layer_ptr) {
+  constexpr bool multiple_layer_support = false;
+  return LoadLayer<VoxelType>(file_path, multiple_layer_support, layer_ptr);
+}
+
+template <typename VoxelType>
+bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path,
+               bool clear_file) {
+  CHECK(!file_path.empty());
+  return layer.saveToFile(file_path, clear_file);
+}
+
+template <typename VoxelType>
+bool SaveLayer(const Layer<VoxelType>& layer, const std::string& file_path) {
+  constexpr bool clear_file = true;
+  return SaveLayer(layer, file_path, clear_file);
+}
+
+template <typename VoxelType>
+bool SaveLayerSubset(const Layer<VoxelType>& layer,
+                     const std::string& file_path,
+                     BlockIndexList blocks_to_include,
+                     bool include_all_blocks) {
+  CHECK(!file_path.empty());
+  return layer.saveSubsetToFile(file_path, blocks_to_include,
+                                include_all_blocks);
+}
+
+}  // namespace io
+}  // namespace voxblox
+
+#endif  // VOXBLOX_CORE_IO_LAYER_IO_INL_H_

--- a/voxblox/src/pybind11/layer_bind.cc
+++ b/voxblox/src/pybind11/layer_bind.cc
@@ -22,7 +22,7 @@ void layer_bind(py::module &m) {
       .def_property_readonly("voxel_size", &TsdfLayer::voxel_size)
       .def_property_readonly("voxels_per_side", &TsdfLayer::voxels_per_side)
 
-      .def("saveToFile", &TsdfLayer::saveToFile)
+      .def("saveToFile", (bool (TsdfLayer::*)(const std::string&)) &TsdfLayer::saveToFile)
 
       .def("allocateBlockPtrByCoordinates",
            &TsdfLayer::allocateBlockPtrByCoordinates)

--- a/voxblox/src/pybind11/layer_bind.cc
+++ b/voxblox/src/pybind11/layer_bind.cc
@@ -22,7 +22,8 @@ void layer_bind(py::module &m) {
       .def_property_readonly("voxel_size", &TsdfLayer::voxel_size)
       .def_property_readonly("voxels_per_side", &TsdfLayer::voxels_per_side)
 
-      .def("saveToFile", (bool (TsdfLayer::*)(const std::string&)) &TsdfLayer::saveToFile)
+      .def("saveToFile", (bool (TsdfLayer::*)(const std::string &) const) &
+                             TsdfLayer::saveToFile)
 
       .def("allocateBlockPtrByCoordinates",
            &TsdfLayer::allocateBlockPtrByCoordinates)
@@ -35,8 +36,8 @@ void layer_bind(py::module &m) {
       .def_property_readonly("voxel_size", &EsdfLayer::voxel_size)
       .def_property_readonly("voxels_per_side", &EsdfLayer::voxels_per_side)
 
-      .def("saveToFile", &EsdfLayer::saveToFile)
-
+      .def("saveToFile", (bool (EsdfLayer::*)(const std::string &) const) &
+                             EsdfLayer::saveToFile)
       .def("allocateBlockPtrByCoordinates",
            &EsdfLayer::allocateBlockPtrByCoordinates)
       .def("removeBlockByCoordinates", &EsdfLayer::removeBlockByCoordinates);

--- a/voxblox/src/utils/protobuf_utils.cc
+++ b/voxblox/src/utils/protobuf_utils.cc
@@ -31,7 +31,6 @@ bool writeProtoMsgCountToStream(uint32_t message_count,
   CHECK_NOTNULL(stream_out);
   CHECK(stream_out->is_open());
   stream_out->clear();
-  // stream_out->seekg(0, std::ios::beg);
   google::protobuf::io::OstreamOutputStream raw_out(stream_out);
   google::protobuf::io::CodedOutputStream coded_out(&raw_out);
   coded_out.WriteVarint32(message_count);

--- a/voxblox/src/utils/protobuf_utils.cc
+++ b/voxblox/src/utils/protobuf_utils.cc
@@ -14,7 +14,7 @@ bool readProtoMsgCountToStream(std::fstream* stream_in, uint32_t* message_count,
   CHECK_NOTNULL(byte_offset);
   CHECK(stream_in->is_open());
   stream_in->clear();
-  stream_in->seekg(0, std::ios::beg);
+  stream_in->seekg(*byte_offset, std::ios::beg);
   google::protobuf::io::IstreamInputStream raw_in(stream_in);
   google::protobuf::io::CodedInputStream coded_in(&raw_in);
   const int prev_position = coded_in.CurrentPosition();
@@ -22,7 +22,7 @@ bool readProtoMsgCountToStream(std::fstream* stream_in, uint32_t* message_count,
     LOG(ERROR) << "Could not read message size.";
     return false;
   }
-  *byte_offset = coded_in.CurrentPosition() - prev_position;
+  *byte_offset += coded_in.CurrentPosition() - prev_position;
   return true;
 }
 
@@ -31,7 +31,7 @@ bool writeProtoMsgCountToStream(uint32_t message_count,
   CHECK_NOTNULL(stream_out);
   CHECK(stream_out->is_open());
   stream_out->clear();
-  stream_out->seekg(0, std::ios::beg);
+  // stream_out->seekg(0, std::ios::beg);
   google::protobuf::io::OstreamOutputStream raw_out(stream_out);
   google::protobuf::io::CodedOutputStream coded_out(&raw_out);
   coded_out.WriteVarint32(message_count);

--- a/voxblox/test/test_protobuf.cc
+++ b/voxblox/test/test_protobuf.cc
@@ -9,6 +9,8 @@
 #include "voxblox/core/voxel.h"
 #include "voxblox/io/layer_io.h"
 #include "voxblox/test/layer_test_utils.h"
+#include "voxblox/core/esdf_map.h"
+#include "voxblox/integrator/esdf_integrator.h"
 
 using namespace voxblox;  // NOLINT
 
@@ -211,7 +213,7 @@ TEST_F(ProtobufTsdfTest, LayerSubsetSerializationFromFile) {
   CompareLayers(*layer_, layer_with_blocks_from_file);
 }
 
-TEST_F(ProtobufTsdfTest, MultipleLayerSerialization) {
+TEST_F(ProtobufTsdfTest, DISABLE_MultipleLayerSerialization) {
   // First, generate an ESDF out of the test TSDF layer.
   // ESDF maps.
   EsdfMap::Config esdf_config;
@@ -225,10 +227,11 @@ TEST_F(ProtobufTsdfTest, MultipleLayerSerialization) {
   EsdfIntegrator::Config esdf_integrator_config;
 
   EsdfMap esdf_map(esdf_config);
-  EsdfIntegrator esdf_integrator(esdf_integrator_config, layer_->get(),
+  EsdfIntegrator esdf_integrator(esdf_integrator_config, layer_.get(),
                                  esdf_map.getEsdfLayerPtr());
 
   esdf_integrator.updateFromTsdfLayerBatchFullEuclidean();
+  voxblox::test::LayerTest<EsdfVoxel> esdf_test;
 
   const std::string file = "multi_layer_test.voxblox";
   bool clear_file = true;
@@ -236,14 +239,15 @@ TEST_F(ProtobufTsdfTest, MultipleLayerSerialization) {
   clear_file = false;
   io::SaveLayer(*esdf_map.getEsdfLayerPtr(), file, clear_file);
 
+  bool multiple_layer_support = true;
   Layer<TsdfVoxel>::Ptr tsdf_layer_from_file;
-  io::LoadLayer<TsdfVoxel>(file, &tsdf_layer_from_file);
+  io::LoadLayer<TsdfVoxel>(file, multiple_layer_support, &tsdf_layer_from_file);
 
   Layer<EsdfVoxel>::Ptr esdf_layer_from_file;
-  io::LoadLayer<EsdfVoxel>(file, esdf_layer_from_file);
+  io::LoadLayer<EsdfVoxel>(file, multiple_layer_support, &esdf_layer_from_file);
 
   CompareLayers(*layer_, *tsdf_layer_from_file);
-  CompareLayers(*esdf_map.getEsdfLayerPtr(), *esdf_layer_from_file);
+  esdf_test.CompareLayers(*esdf_map.getEsdfLayerPtr(), *esdf_layer_from_file);
 }
 
 int main(int argc, char** argv) {

--- a/voxblox/test/test_protobuf.cc
+++ b/voxblox/test/test_protobuf.cc
@@ -9,8 +9,6 @@
 #include "voxblox/core/voxel.h"
 #include "voxblox/io/layer_io.h"
 #include "voxblox/test/layer_test_utils.h"
-#include "voxblox/core/esdf_map.h"
-#include "voxblox/integrator/esdf_integrator.h"
 
 using namespace voxblox;  // NOLINT
 
@@ -214,30 +212,18 @@ TEST_F(ProtobufTsdfTest, LayerSubsetSerializationFromFile) {
 }
 
 TEST_F(ProtobufTsdfTest, MultipleLayerSerialization) {
-  // First, generate an ESDF out of the test TSDF layer.
-  // ESDF maps.
-  EsdfMap::Config esdf_config;
-  // Same number of voxels per side for ESDF as with TSDF
-  esdf_config.esdf_voxels_per_side = layer_->voxels_per_side();
-  // Same voxel size for ESDF as with TSDF
-  esdf_config.esdf_voxel_size = layer_->voxel_size();
+  Layer<EsdfVoxel>::Ptr esdf_layer;
+  // Match TSDF settings.
+  esdf_layer.reset(new Layer<EsdfVoxel>(voxel_size_, voxels_per_side_));
+  voxblox::test::SetUpTestLayer(kBlockVolumeDiameter, esdf_layer.get());
 
-  // Default settings are fine, actual content of the ESDF doesn't matter
-  // much.
-  EsdfIntegrator::Config esdf_integrator_config;
-
-  EsdfMap esdf_map(esdf_config);
-  EsdfIntegrator esdf_integrator(esdf_integrator_config, layer_.get(),
-                                 esdf_map.getEsdfLayerPtr());
-
-  esdf_integrator.updateFromTsdfLayerBatchFullEuclidean();
   voxblox::test::LayerTest<EsdfVoxel> esdf_test;
 
   const std::string file = "multi_layer_test.voxblox";
   bool clear_file = true;
   io::SaveLayer(*layer_, file, clear_file);
   clear_file = false;
-  io::SaveLayer(*esdf_map.getEsdfLayerPtr(), file, clear_file);
+  io::SaveLayer(*esdf_layer, file, clear_file);
 
   bool multiple_layer_support = true;
   Layer<TsdfVoxel>::Ptr tsdf_layer_from_file;
@@ -249,7 +235,7 @@ TEST_F(ProtobufTsdfTest, MultipleLayerSerialization) {
                                        &esdf_layer_from_file));
 
   CompareLayers(*layer_, *tsdf_layer_from_file);
-  esdf_test.CompareLayers(*esdf_map.getEsdfLayerPtr(), *esdf_layer_from_file);
+  esdf_test.CompareLayers(*esdf_layer, *esdf_layer_from_file);
 }
 
 int main(int argc, char** argv) {

--- a/voxblox/test/test_protobuf.cc
+++ b/voxblox/test/test_protobuf.cc
@@ -225,7 +225,7 @@ TEST_F(ProtobufTsdfTest, MultipleLayerSerialization) {
   clear_file = false;
   io::SaveLayer(*esdf_layer, file, clear_file);
 
-  bool multiple_layer_support = true;
+  constexpr bool multiple_layer_support = true;
   Layer<TsdfVoxel>::Ptr tsdf_layer_from_file;
   ASSERT_TRUE(io::LoadLayer<TsdfVoxel>(file, multiple_layer_support,
                                        &tsdf_layer_from_file));
@@ -241,7 +241,7 @@ TEST_F(ProtobufTsdfTest, MultipleLayerSerialization) {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   google::InitGoogleLogging(argv[0]);
-  FLAGS_alsologtostderr = 1;
+  FLAGS_alsologtostderr = true;
 
   int result = RUN_ALL_TESTS();
 

--- a/voxblox/test/test_protobuf.cc
+++ b/voxblox/test/test_protobuf.cc
@@ -160,7 +160,7 @@ TEST_F(ProtobufTsdfTest, LayerSubsetSerializationToFile) {
   io::SaveLayerSubset(*layer_, file, block_index_list, kIncludeAllBlocks);
 
   Layer<TsdfVoxel>::Ptr layer_from_file;
-  io::LoadLayer<TsdfVoxel>(file, &layer_from_file);
+  ASSERT_TRUE(io::LoadLayer<TsdfVoxel>(file, &layer_from_file));
 
   // Remove all other blocks for comparison.
   BlockIndexList all_block_indices;
@@ -200,9 +200,9 @@ TEST_F(ProtobufTsdfTest, LayerSubsetSerializationFromFile) {
   layer_with_blocks_from_file.allocateNewBlock(block_index_4);
 
   // Now load the blocks from the file layer and add it.
-  io::LoadBlocksFromFile<TsdfVoxel>(
+  ASSERT_TRUE(io::LoadBlocksFromFile<TsdfVoxel>(
       file, Layer<TsdfVoxel>::BlockMergingStrategy::kProhibit,
-      &layer_with_blocks_from_file);
+      &layer_with_blocks_from_file));
 
   // Add those blocks to the layer for comparison.
   layer_->allocateNewBlock(block_index_1);
@@ -213,7 +213,7 @@ TEST_F(ProtobufTsdfTest, LayerSubsetSerializationFromFile) {
   CompareLayers(*layer_, layer_with_blocks_from_file);
 }
 
-TEST_F(ProtobufTsdfTest, DISABLE_MultipleLayerSerialization) {
+TEST_F(ProtobufTsdfTest, MultipleLayerSerialization) {
   // First, generate an ESDF out of the test TSDF layer.
   // ESDF maps.
   EsdfMap::Config esdf_config;
@@ -241,10 +241,12 @@ TEST_F(ProtobufTsdfTest, DISABLE_MultipleLayerSerialization) {
 
   bool multiple_layer_support = true;
   Layer<TsdfVoxel>::Ptr tsdf_layer_from_file;
-  io::LoadLayer<TsdfVoxel>(file, multiple_layer_support, &tsdf_layer_from_file);
+  ASSERT_TRUE(io::LoadLayer<TsdfVoxel>(file, multiple_layer_support,
+                                       &tsdf_layer_from_file));
 
   Layer<EsdfVoxel>::Ptr esdf_layer_from_file;
-  io::LoadLayer<EsdfVoxel>(file, multiple_layer_support, &esdf_layer_from_file);
+  ASSERT_TRUE(io::LoadLayer<EsdfVoxel>(file, multiple_layer_support,
+                                       &esdf_layer_from_file));
 
   CompareLayers(*layer_, *tsdf_layer_from_file);
   esdf_test.CompareLayers(*esdf_map.getEsdfLayerPtr(), *esdf_layer_from_file);
@@ -253,6 +255,7 @@ TEST_F(ProtobufTsdfTest, DISABLE_MultipleLayerSerialization) {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   google::InitGoogleLogging(argv[0]);
+  FLAGS_alsologtostderr = 1;
 
   int result = RUN_ALL_TESTS();
 

--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -32,6 +32,9 @@ class EsdfServer : public TsdfServer {
   virtual void updateMesh();
   virtual void publishPointclouds();
   virtual void newPoseCallback(const Transformation& T_G_C);
+  virtual void publishMap();
+  virtual bool saveMap(const std::string& file_path);
+  virtual bool loadMap(const std::string& file_path);
 
   // Call updateMesh if you want everything updated; call this specifically
   // if you don't want the mesh or visualization.

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -64,6 +64,8 @@ class TsdfServer {
   virtual bool generateMesh();  // Batch update.
   virtual void publishPointclouds();  // Publishes all available pointclouds.
   virtual void publishMap(); // Publishes the complete map
+  virtual bool saveMap(const std::string& file_path);
+  virtual bool loadMap(const std::string& file_path);
 
   bool saveMapCallback(voxblox_msgs::FilePath::Request& request,     // NOLINT
                        voxblox_msgs::FilePath::Response& response);  // NOLINT

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -157,17 +157,20 @@ bool EsdfServer::saveMap(const std::string& file_path) {
   // Output TSDF map first, then ESDF.
   bool success = TsdfServer::saveMap(file_path);
 
-  return success && io::SaveLayer(esdf_map_->getEsdfLayer(), file_path);
+  constexpr bool clear_file = false;
+  return success &&
+         io::SaveLayer(esdf_map_->getEsdfLayer(), file_path, clear_file);
 }
 
 bool EsdfServer::loadMap(const std::string& file_path) {
   // Load in the same order: TSDF first, then ESDF.
   bool success = TsdfServer::loadMap(file_path);
 
+  constexpr bool multiple_layer_support = true;
   return success &&
          io::LoadBlocksFromFile(
              file_path, Layer<EsdfVoxel>::BlockMergingStrategy::kReplace,
-             esdf_map_->getEsdfLayerPtr());
+             multiple_layer_support, esdf_map_->getEsdfLayerPtr());
 }
 
 void EsdfServer::updateEsdf() {

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -155,22 +155,22 @@ void EsdfServer::publishMap() {
 
 bool EsdfServer::saveMap(const std::string& file_path) {
   // Output TSDF map first, then ESDF.
-  bool success = TsdfServer::saveMap(file_path);
+  const bool success = TsdfServer::saveMap(file_path);
 
-  constexpr bool clear_file = false;
+  constexpr bool kClearFile = false;
   return success &&
-         io::SaveLayer(esdf_map_->getEsdfLayer(), file_path, clear_file);
+         io::SaveLayer(esdf_map_->getEsdfLayer(), file_path, kClearFile);
 }
 
 bool EsdfServer::loadMap(const std::string& file_path) {
   // Load in the same order: TSDF first, then ESDF.
   bool success = TsdfServer::loadMap(file_path);
 
-  constexpr bool multiple_layer_support = true;
+  constexpr bool kMulitpleLayerSupport = true;
   return success &&
          io::LoadBlocksFromFile(
              file_path, Layer<EsdfVoxel>::BlockMergingStrategy::kReplace,
-             multiple_layer_support, esdf_map_->getEsdfLayerPtr());
+             kMulitpleLayerSupport, esdf_map_->getEsdfLayerPtr());
 }
 
 void EsdfServer::updateEsdf() {

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -139,6 +139,37 @@ void EsdfServer::publishPointclouds() {
   TsdfServer::publishPointclouds();
 }
 
+void EsdfServer::publishMap() {
+  if (this->esdf_map_pub_.getNumSubscribers() > 0) {
+    const bool only_updated = false;
+    timing::Timer publish_map_timer("map/publish_esdf");
+    voxblox_msgs::Layer layer_msg;
+    serializeLayerAsMsg<EsdfVoxel>(this->esdf_map_->getEsdfLayer(),
+                                   only_updated, &layer_msg);
+    this->esdf_map_pub_.publish(layer_msg);
+    publish_map_timer.Stop();
+  }
+
+  TsdfServer::publishMap();
+}
+
+bool EsdfServer::saveMap(const std::string& file_path) {
+  // Output TSDF map first, then ESDF.
+  bool success = TsdfServer::saveMap(file_path);
+
+  return success && io::SaveLayer(esdf_map_->getEsdfLayer(), file_path);
+}
+
+bool EsdfServer::loadMap(const std::string& file_path) {
+  // Load in the same order: TSDF first, then ESDF.
+  bool success = TsdfServer::loadMap(file_path);
+
+  return success &&
+         io::LoadBlocksFromFile(
+             file_path, Layer<EsdfVoxel>::BlockMergingStrategy::kReplace,
+             esdf_map_->getEsdfLayerPtr());
+}
+
 void EsdfServer::updateEsdf() {
   if (tsdf_map_->getTsdfLayer().getNumberOfAllocatedBlocks() > 0) {
     const bool clear_updated_flag_esdf = true;

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -398,8 +398,10 @@ bool TsdfServer::saveMap(const std::string& file_path) {
 bool TsdfServer::loadMap(const std::string& file_path) {
   // Will only load TSDF layer for now. Inherited classes should add other
   // layers.
+  constexpr bool multiple_layer_support = true;
   return io::LoadBlocksFromFile(
       file_path, Layer<TsdfVoxel>::BlockMergingStrategy::kReplace,
+      multiple_layer_support,
       tsdf_map_->getTsdfLayerPtr());
 }
 

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -390,19 +390,17 @@ bool TsdfServer::generateMesh() {
 }
 
 bool TsdfServer::saveMap(const std::string& file_path) {
-  // Will only save TSDF layer for now. Inheriting classes should add other
-  // layers.
+  // Inheriting classes should add saving other layers to this function.
   return io::SaveLayer(tsdf_map_->getTsdfLayer(), file_path);
 }
 
 bool TsdfServer::loadMap(const std::string& file_path) {
-  // Will only load TSDF layer for now. Inherited classes should add other
-  // layers.
-  constexpr bool multiple_layer_support = true;
+  // Inheriting classes should add other layers to load, as this will only load
+  // the TSDF layer.
+  constexpr bool kMulitpleLayerSupport = true;
   return io::LoadBlocksFromFile(
       file_path, Layer<TsdfVoxel>::BlockMergingStrategy::kReplace,
-      multiple_layer_support,
-      tsdf_map_->getTsdfLayerPtr());
+      kMulitpleLayerSupport, tsdf_map_->getTsdfLayerPtr());
 }
 
 bool TsdfServer::generateMeshCallback(

--- a/voxblox_tango_interface/src/pybind11/tango_layer_interface_bind.cc
+++ b/voxblox_tango_interface/src/pybind11/tango_layer_interface_bind.cc
@@ -23,5 +23,7 @@ void tango_layer_interface_bind(py::module& m) {
       .def_property_readonly("voxels_per_side",
                              &TangoLayerInterface::voxels_per_side)
 
-      .def("saveToFile", &TangoLayerInterface::saveToFile);
+      .def("saveToFile",
+           (bool (TangoLayerInterface::*)(const std::string&) const) &
+               TangoLayerInterface::saveToFile);
 }


### PR DESCRIPTION
Now you can serialize multiple layers on the same file, if you turn multiple layer support on when reading back. Default behavior remains the same.
Also split up the io functionality a bit and added comments about what the different functions do, since it took me ages to figure out...