### PR TITLE
Template argument vs less than comparison 

### DIFF
--- a/voxblox/include/voxblox/utils/evaluation_utils.h
+++ b/voxblox/include/voxblox/utils/evaluation_utils.h
@@ -185,8 +185,8 @@ VoxelEvaluationResult computeVoxelError(
       (evaluation_mode == VoxelEvaluationMode::kIgnoreErrorBehindGtSurface) ||
       (evaluation_mode == VoxelEvaluationMode::kIgnoreErrorBehindAllSurfaces);
 
-  if ((ignore_behind_test_surface && voxel_test.distance < 0.0) ||
-      (ignore_behind_gt_surface && voxel_gt.distance < 0.0)) {
+  if ((ignore_behind_test_surface && (voxel_test.distance) < 0.0) ||
+      (ignore_behind_gt_surface && (voxel_gt.distance) < 0.0)) {
     return VoxelEvaluationResult::kIgnored;
   }
 


### PR DESCRIPTION
On my machine code including evaluation_utils.h will not compile because gcc interprets the comparison `voxel_gt.distance < 0.0` as intending to instantiate a member template. Compilation then fails as 0.0 is not a typename.

To me this interpretation seems incorrect wrt the standard. < should be interpreted as less than unless the keyword `template` is used. It is also strange that you do not have the same issue in your tests using this function...

The redundant brackets are not an ideal solution but are the only one I found that worked.