### PR TITLE
Merge bugfixes and features from GSM compatability branch

### DIFF
--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -54,6 +54,7 @@ set("${PROJECT_NAME}_SRCS"
   src/integrator/merge_integration.cc
   src/integrator/tsdf_integrator.cc
   src/io/mesh_ply.cc
+  src/io/sdf_ply.cc
   src/mesh/marching_cubes.cc
   src/simulation/objects.cc
   src/simulation/simulation_world.cc

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -53,6 +53,10 @@ class Block {
     return linear_index;
   }
 
+  // NOTE: This function is dangerous, it will truncate the voxel index to an
+  // index that is within this block if you pass a coordinate outside the range
+  // of this block. Try not to use this function if there is an alternative to
+  // directly address the voxels via precise integer indexing math.
   inline VoxelIndex computeVoxelIndexFromCoordinates(
       const Point& coords) const {
     const IndexElement max_value = voxels_per_side_ - 1;
@@ -65,6 +69,10 @@ class Block {
                       std::max(std::min(voxel_index.z(), max_value), 0));
   }
 
+  // NOTE: This function is dangerous, it will truncate the voxel index to an
+  // index that is within this block if you pass a coordinate outside the range
+  // of this block. Try not to use this function if there is an alternative to
+  // directly address the voxels via precise integer indexing math.
   inline size_t computeLinearIndexFromCoordinates(const Point& coords) const {
     return computeLinearIndexFromVoxelIndex(
         computeVoxelIndexFromCoordinates(coords));
@@ -103,6 +111,10 @@ class Block {
     return voxels_[computeLinearIndexFromVoxelIndex(index)];
   }
 
+  // NOTE: This function is dangerous, it will truncate the voxel index to an
+  // index that is within this block if you pass a coordinate outside the range
+  // of this block. Try not to use this function if there is an alternative to
+  // directly address the voxels via precise integer indexing math.
   inline const VoxelType& getVoxelByCoordinates(const Point& coords) const {
     return voxels_[computeLinearIndexFromCoordinates(coords)];
   }
@@ -157,6 +169,7 @@ class Block {
   FloatingPoint voxel_size_inv() const { return voxel_size_inv_; }
   size_t num_voxels() const { return num_voxels_; }
   Point origin() const { return origin_; }
+  void setOrigin(const Point& new_origin) { origin_ = new_origin; }
   FloatingPoint block_size() const { return block_size_; }
 
   bool has_data() const { return has_data_; }
@@ -193,7 +206,7 @@ class Block {
   // Base parameters.
   const size_t voxels_per_side_;
   const FloatingPoint voxel_size_;
-  const Point origin_;
+  Point origin_;
 
   // Derived, cached parameters.
   FloatingPoint voxel_size_inv_;

--- a/voxblox/include/voxblox/core/block_hash.h
+++ b/voxblox/include/voxblox/core/block_hash.h
@@ -1,8 +1,9 @@
-#ifndef VOXBLOX_BLOCK_HASH_H_
-#define VOXBLOX_BLOCK_HASH_H_
+#ifndef VOXBLOX_CORE_BLOCK_HASH_H_
+#define VOXBLOX_CORE_BLOCK_HASH_H_
 
 #include <functional>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include <Eigen/Core>
@@ -70,4 +71,4 @@ struct LongIndexHashMapType {
 
 }  // namespace voxblox
 
-#endif  // VOXBLOX_BLOCK_HASH_H_
+#endif  // VOXBLOX_CORE_BLOCK_HASH_H_

--- a/voxblox/include/voxblox/core/block_hash.h
+++ b/voxblox/include/voxblox/core/block_hash.h
@@ -29,8 +29,8 @@ struct AnyIndexHashMapType {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   typedef std::unordered_map<
-      BlockIndex, ValueType, AnyIndexHash, std::equal_to<BlockIndex>,
-      Eigen::aligned_allocator<std::pair<const BlockIndex, ValueType> > >
+      AnyIndex, ValueType, AnyIndexHash, std::equal_to<AnyIndex>,
+      Eigen::aligned_allocator<std::pair<const AnyIndex, ValueType> > >
       type;
 };
 
@@ -43,6 +43,30 @@ typedef typename AnyIndexHashMapType<IndexVector>::type HierarchicalIndexMap;
 typedef typename AnyIndexHashMapType<IndexSet>::type HierarchicalIndexSet;
 
 typedef typename HierarchicalIndexMap::value_type HierarchicalIndex;
+
+// Hash map for large index values.
+struct LongIndexHash {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  static constexpr size_t prime1 = 73856093;
+  static constexpr size_t prime2 = 19349663;
+  static constexpr size_t prime3 = 83492791;
+
+  std::size_t operator()(const LongIndex& index) const {
+    return (static_cast<unsigned int>(index.x()) * prime1 ^ index.y() * prime2 ^
+            index.z() * prime3);
+  }
+};
+
+template <typename ValueType>
+struct LongIndexHashMapType {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  typedef std::unordered_map<
+      LongIndex, ValueType, LongIndexHash, std::equal_to<LongIndex>,
+      Eigen::aligned_allocator<std::pair<const LongIndex, ValueType> > >
+      type;
+};
 
 }  // namespace voxblox
 

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -40,6 +40,7 @@ inline std::shared_ptr<Type> aligned_shared(Arguments&&... arguments) {
 // Types.
 typedef float FloatingPoint;
 typedef int IndexElement;
+typedef long long LongIndexElement;
 
 typedef Eigen::Matrix<FloatingPoint, 3, 1> Point;
 typedef Eigen::Matrix<FloatingPoint, 3, 1> Ray;
@@ -47,6 +48,8 @@ typedef Eigen::Matrix<FloatingPoint, 3, 1> Ray;
 typedef Eigen::Matrix<IndexElement, 3, 1> AnyIndex;
 typedef AnyIndex VoxelIndex;
 typedef AnyIndex BlockIndex;
+
+typedef Eigen::Matrix<LongIndexElement, 3, 1> LongIndex;
 
 typedef std::pair<BlockIndex, VoxelIndex> VoxelKey;
 

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -137,9 +137,10 @@ constexpr float kFloatEpsilon = 1e-6;     // Used for weights.
 
 // Grid <-> point conversion functions.
 
-// IMPORTANT NOTE: Due the limited accuracy of the FloatingPoint type, this
+// NOTE: Due the limited accuracy of the FloatingPoint type, this
 // function doesn't always compute the correct grid index for coordinates
-// near the grid cell boundaries.
+// near the grid cell boundaries. Use the safer `getGridIndexFromOriginPoint` if
+// the origin point is available.
 inline AnyIndex getGridIndexFromPoint(const Point& point,
                                       const FloatingPoint grid_size_inv) {
   return AnyIndex(std::floor(point.x() * grid_size_inv + kEpsilon),
@@ -147,7 +148,7 @@ inline AnyIndex getGridIndexFromPoint(const Point& point,
                   std::floor(point.z() * grid_size_inv + kEpsilon));
 }
 
-// IMPORTANT NOTE: Due the limited accuracy of the FloatingPoint type, this
+// NOTE: Due the limited accuracy of the FloatingPoint type, this
 // function doesn't always compute the correct grid index for coordinates
 // near the grid cell boundaries.
 inline AnyIndex getGridIndexFromPoint(const Point& scaled_point) {
@@ -156,11 +157,15 @@ inline AnyIndex getGridIndexFromPoint(const Point& scaled_point) {
                   std::floor(scaled_point.z() + kEpsilon));
 }
 
+// NOTE: This function is safer than `getGridIndexFromPoint`, because it assumes
+// we pass in not an arbitrary point in the grid cell, but the ORIGIN. This way
+// we can avoid the floating point precision issue that arrises for calls to
+// `getGridIndexFromPoint`for arbitrary points near the border of the grid cell.
 inline AnyIndex getGridIndexFromOriginPoint(const Point& point,
                                             const FloatingPoint grid_size_inv) {
-  return AnyIndex(std::round(point.x() * grid_size_inv),
-                  std::round(point.y() * grid_size_inv),
-                  std::round(point.z() * grid_size_inv));
+  return AnyIndex(std::floor(point.x() * grid_size_inv + 0.5),
+                  std::floor(point.y() * grid_size_inv + 0.5),
+                  std::floor(point.z() * grid_size_inv + 0.5));
 }
 
 inline Point getCenterPointFromGridIndex(const AnyIndex& idx,

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -40,7 +40,7 @@ inline std::shared_ptr<Type> aligned_shared(Arguments&&... arguments) {
 // Types.
 typedef float FloatingPoint;
 typedef int IndexElement;
-typedef long long LongIndexElement;
+typedef int64_t LongIndexElement;
 
 typedef Eigen::Matrix<FloatingPoint, 3, 1> Point;
 typedef Eigen::Matrix<FloatingPoint, 3, 1> Ray;

--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -166,9 +166,9 @@ inline AnyIndex getGridIndexFromPoint(const Point& scaled_point) {
 // `getGridIndexFromPoint`for arbitrary points near the border of the grid cell.
 inline AnyIndex getGridIndexFromOriginPoint(const Point& point,
                                             const FloatingPoint grid_size_inv) {
-  return AnyIndex(std::floor(point.x() * grid_size_inv + 0.5),
-                  std::floor(point.y() * grid_size_inv + 0.5),
-                  std::floor(point.z() * grid_size_inv + 0.5));
+  return AnyIndex(std::round(point.x() * grid_size_inv),
+                  std::round(point.y() * grid_size_inv),
+                  std::round(point.z() * grid_size_inv));
 }
 
 inline Point getCenterPointFromGridIndex(const AnyIndex& idx,

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -50,20 +50,18 @@ class Layer {
 
   inline const BlockType& getBlockByIndex(const BlockIndex& index) const {
     typename BlockHashMap::const_iterator it = block_map_.find(index);
-    if (it != block_map_.end()) {
-      return *(it->second);
-    } else {
+    if (it == block_map_.end()) {
       LOG(FATAL) << "Accessed unallocated block at " << index.transpose();
     }
+    return *(it->second);
   }
 
   inline BlockType& getBlockByIndex(const BlockIndex& index) {
     typename BlockHashMap::iterator it = block_map_.find(index);
-    if (it != block_map_.end()) {
-      return *(it->second);
-    } else {
+    if (it == block_map_.end()) {
       LOG(FATAL) << "Accessed unallocated block at " << index.transpose();
     }
+    return *(it->second);
   }
 
   inline typename BlockType::ConstPtr getBlockPtrByIndex(

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -2,6 +2,7 @@
 #define VOXBLOX_CORE_LAYER_INL_H_
 
 #include <fstream>  // NOLINT
+#include <limits>
 #include <string>
 #include <utility>
 
@@ -60,8 +61,10 @@ Layer<VoxelType>::Layer(const Layer& other) {
        other.block_map_) {
     const BlockIndex& block_idx = key_value_pair.first;
     const typename BlockType::Ptr& block_ptr = key_value_pair.second;
+    CHECK(block_ptr);
 
     typename BlockType::Ptr new_block = allocateBlockPtrByIndex(block_idx);
+    CHECK(new_block);
 
     for (size_t linear_idx = 0u; linear_idx < block_ptr->num_voxels();
          ++linear_idx) {

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -96,8 +96,8 @@ class TsdfIntegratorBase {
                        const float weight, TsdfVoxel* tsdf_voxel);
 
   // Thread safe.
-  inline float computeDistance(const Point& origin, const Point& point_G,
-                               const Point& voxel_center) const;
+  float computeDistance(const Point& origin, const Point& point_G,
+                        const Point& voxel_center) const;
 
   // Thread safe.
   float getVoxelWeight(const Point& point_C) const;

--- a/voxblox/include/voxblox/io/mesh_ply.h
+++ b/voxblox/include/voxblox/io/mesh_ply.h
@@ -20,22 +20,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#ifndef VOXBLOX_MESH_MESH_PLY_H_
-#define VOXBLOX_MESH_MESH_PLY_H_
+#ifndef VOXBLOX_IO_MESH_PLY_H_
+#define VOXBLOX_IO_MESH_PLY_H_
 
 #include "voxblox/mesh/mesh_layer.h"
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 
 namespace voxblox {
 
+bool convertMeshLayerToMesh(
+    const MeshLayer& mesh_layer, Mesh* mesh, const bool connected_mesh = true,
+    const FloatingPoint vertex_proximity_threshold = 1e-10);
+
+// Default behaviour is to simplify the mesh.
 bool outputMeshLayerAsPly(const std::string& filename,
+                          const MeshLayer& mesh_layer);
+
+bool outputMeshLayerAsPly(const std::string& filename,
+                          const bool connected_mesh,
                           const MeshLayer& mesh_layer);
 
 bool outputMeshAsPly(const std::string& filename, const Mesh& mesh);
 
 }  // namespace voxblox
 
-#endif  // VOXBLOX_MESH_MESH_PLY_H_
+#endif  // VOXBLOX_IO_MESH_PLY_H_

--- a/voxblox/include/voxblox/io/sdf_ply.h
+++ b/voxblox/include/voxblox/io/sdf_ply.h
@@ -6,7 +6,6 @@
 
 #include "voxblox/core/layer.h"
 #include "voxblox/io/mesh_ply.h"
-#include "voxblox/io/ply_writer.h"
 #include "voxblox/mesh/mesh.h"
 #include "voxblox/mesh/mesh_integrator.h"
 #include "voxblox/mesh/mesh_layer.h"
@@ -19,7 +18,10 @@ enum PlyOutputTypes {
   // The full SDF colorized by the distance in each voxel.
   kSdfColoredDistanceField,
   // Output isosurface, i.e. the mesh for sdf voxel types.
-  kSdfIsosurface
+  kSdfIsosurface,
+  // Output isosurface, i.e. the mesh for sdf voxel types.
+  // Close vertices are connected and zero surface faces are removed.
+  kSdfIsosurfaceConnected
 };
 
 template <typename VoxelType>
@@ -28,117 +30,131 @@ bool getColorFromVoxel(const VoxelType& voxel, const FloatingPoint max_distance,
 
 template <>
 bool getColorFromVoxel(const TsdfVoxel& voxel, const FloatingPoint max_distance,
-                       Color* color) {
-  CHECK_NOTNULL(color);
-
-  static constexpr float kTolerance = 1e-6;
-  if (voxel.weight <= kTolerance) {
-    return false;
-  }
-
-  // Decide how to color this.
-  // Distance > 0 = blue, distance < 0 = red.
-  Color distance_color = Color::blendTwoColors(
-      Color(255, 0, 0, 0),
-      std::max<float>(1 - voxel.distance / max_distance, 0.0),
-      Color(0, 0, 255, 0),
-      std::max<float>(1 + voxel.distance / max_distance, 0.0));
-
-  *color = distance_color;
-  return true;
-}
+                       Color* color);
 
 template <>
 bool getColorFromVoxel(const EsdfVoxel& voxel, const FloatingPoint max_distance,
-                       Color* color) {
-  CHECK_NOTNULL(color);
-  if (!voxel.observed) {
-    return false;
-  }
+                       Color* color);
 
-  // Decide how to color this.
-  // Distance > 0 = blue, distance < 0 = red.
-  Color distance_color = Color::blendTwoColors(
-      Color(255, 0, 0, 0),
-      std::max<float>(1 - voxel.distance / max_distance, 0.0),
-      Color(0, 0, 255, 0),
-      std::max<float>(1 + voxel.distance / max_distance, 0.0));
-
-  *color = distance_color;
-  return true;
-}
-
+// This function converts all voxels with positive weight/observed into points
+// colored by a color map based on the SDF value. The parameter sdf_range_max is
+// used to determine the range of the rainbow color map which is used to
+// visualize the SDF values. If an SDF value is outside this range, it will be
+// truncated to the limits of the range.
 template <typename VoxelType>
-bool outputLayerAsPly(const Layer<VoxelType>& layer,
-                      const std::string& filename, PlyOutputTypes type) {
-  // Create a PlyWriter.
-  PlyWriter writer(filename);
+bool convertVoxelGridToPointCloud(const Layer<VoxelType>& layer,
+                                  const FloatingPoint sdf_range_max,
+                                  voxblox::Mesh* point_cloud) {
+  CHECK_NOTNULL(point_cloud);
+  CHECK_GT(sdf_range_max, 0.0);
 
-  switch (type) {
-    case PlyOutputTypes::kSdfColoredDistanceField: {
-      // In this case, we get all the allocated voxels and color them based on
-      // distance value.
-      size_t num_blocks = layer.getNumberOfAllocatedBlocks();
-      // This function is block-specific:
-      size_t vps = layer.voxels_per_side();
-      size_t num_voxels_per_block = vps * vps * vps;
+  BlockIndexList blocks;
+  layer.getAllAllocatedBlocks(&blocks);
 
-      // Maybe this isn't strictly true, since actually we may have stuff with 0
-      // weight...
-      size_t total_voxels = num_blocks * num_voxels_per_block;
-      const bool has_color = true;
-      writer.addVerticesWithProperties(total_voxels, has_color);
-      if (!writer.writeHeader()) {
-        return false;
-      }
+  // Iterate over all blocks.
+  for (const BlockIndex& index : blocks) {
+    // Iterate over all voxels in said blocks.
+    const Block<VoxelType>& block = layer.getBlockByIndex(index);
 
-      BlockIndexList blocks;
-      layer.getAllAllocatedBlocks(&blocks);
+    const int vps = block.voxels_per_side();
 
-      int observed_voxels = 0;
+    VoxelIndex voxel_index = VoxelIndex::Zero();
+    for (voxel_index.x() = 0; voxel_index.x() < vps; ++voxel_index.x()) {
+      for (voxel_index.y() = 0; voxel_index.y() < vps; ++voxel_index.y()) {
+        for (voxel_index.z() = 0; voxel_index.z() < vps; ++voxel_index.z()) {
+          const VoxelType& voxel = block.getVoxelByVoxelIndex(voxel_index);
 
-      // Iterate over all blocks.
-      const float max_distance = 20;
-      for (const BlockIndex& index : blocks) {
-        // Iterate over all voxels in said blocks.
-        const Block<VoxelType>& block = layer.getBlockByIndex(index);
+          // Get back the original coordinate of this voxel.
+          const Point coord =
+              block.computeCoordinatesFromVoxelIndex(voxel_index);
 
-        VoxelIndex voxel_index = VoxelIndex::Zero();
-        for (voxel_index.x() = 0; voxel_index.x() < vps; ++voxel_index.x()) {
-          for (voxel_index.y() = 0; voxel_index.y() < vps; ++voxel_index.y()) {
-            for (voxel_index.z() = 0; voxel_index.z() < vps;
-                 ++voxel_index.z()) {
-              const VoxelType& voxel = block.getVoxelByVoxelIndex(voxel_index);
-
-              // Get back the original coordinate of this voxel.
-              Point coord = block.computeCoordinatesFromVoxelIndex(voxel_index);
-
-              Color color;
-              if (getColorFromVoxel(voxel, max_distance, &color)) {
-                ++observed_voxels;
-              }
-
-              writer.writeVertex(coord, color);
-            }
+          Color color;
+          if (getColorFromVoxel(voxel, sdf_range_max, &color)) {
+            point_cloud->vertices.push_back(coord);
+            point_cloud->colors.push_back(color);
           }
         }
       }
-      LOG(INFO) << "Number of observed voxels: " << observed_voxels;
-      writer.closeFile();
-      return true;
+    }
+  }
+  return point_cloud->size() > 0u;
+}
+
+// Converts the layer to a mesh by extracting its ISO surface using marching
+// cubes. This function returns false if the mesh is empty. The mesh can either
+// be extracted as a set of distinct triangles, or the function can try to
+// connect all identical vertices to create a connected mesh.
+template <typename VoxelType>
+bool convertLayerToMesh(
+    const Layer<VoxelType>& layer, const MeshIntegratorConfig& mesh_config,
+    voxblox::Mesh* mesh, const bool connected_mesh = true,
+    const FloatingPoint vertex_proximity_threshold = 1e-10) {
+  CHECK_NOTNULL(mesh);
+
+  MeshLayer mesh_layer(layer.block_size());
+  MeshIntegrator<VoxelType> mesh_integrator(mesh_config, layer, &mesh_layer);
+
+  // Generate mesh layer.
+  constexpr bool only_mesh_updated_blocks = false;
+  constexpr bool clear_updated_flag = false;
+  mesh_integrator.generateMesh(only_mesh_updated_blocks, clear_updated_flag);
+
+  // Extract mesh from mesh layer, either by simply concatenating all meshes
+  // (there is one per block) or by connecting them.
+  if (connected_mesh) {
+    mesh_layer.getConnectedMesh(mesh, vertex_proximity_threshold);
+  } else {
+    mesh_layer.getMesh(mesh);
+  }
+  return mesh->size() > 0u;
+}
+template <typename VoxelType>
+bool convertLayerToMesh(
+    const Layer<VoxelType>& layer, voxblox::Mesh* mesh,
+    const bool connected_mesh = true,
+    const FloatingPoint vertex_proximity_threshold = 1e-10) {
+  MeshIntegratorConfig mesh_config;
+  return convertLayerToMesh(layer, mesh_config, mesh, connected_mesh,
+                            vertex_proximity_threshold);
+}
+
+// Output the layer to ply file. Depending on the ply output type, this either
+// exports all voxel centers colored by th SDF values or extracts the ISO
+// surface as mesh. The parameter max_sdf_range is used to color the points for
+// modes that use an SDF-based point cloud coloring function.
+template <typename VoxelType>
+bool outputLayerAsPly(const Layer<VoxelType>& layer,
+                      const std::string& filename, PlyOutputTypes type,
+                      const FloatingPoint max_sdf_range = 0.3) {
+  CHECK(!filename.empty());
+  switch (type) {
+    case PlyOutputTypes::kSdfColoredDistanceField: {
+      voxblox::Mesh point_cloud;
+      if (!convertVoxelGridToPointCloud(layer, max_sdf_range, &point_cloud)) {
+        return false;
+      }
+
+      return outputMeshAsPly(filename, point_cloud);
     }
     case PlyOutputTypes::kSdfIsosurface: {
-      typename MeshIntegrator<VoxelType>::Config mesh_config;
-      MeshLayer::Ptr mesh(new MeshLayer(layer.block_size()));
-      MeshIntegrator<VoxelType> mesh_integrator(mesh_config, layer, mesh.get());
+      constexpr bool kConnectedMesh = false;
 
-      constexpr bool only_mesh_updated_blocks = false;
-      constexpr bool clear_updated_flag = false;
-      mesh_integrator.generateMesh(only_mesh_updated_blocks,
-                                   clear_updated_flag);
-
-      return outputMeshLayerAsPly(filename, *mesh);
+      voxblox::Mesh mesh;
+      if (!convertLayerToMesh(layer, &mesh, kConnectedMesh)) {
+        return false;
+      }
+      return outputMeshAsPly(filename, mesh);
     }
+    case PlyOutputTypes::kSdfIsosurfaceConnected: {
+      constexpr bool kConnectedMesh = true;
+
+      voxblox::Mesh mesh;
+      if (!convertLayerToMesh(layer, &mesh, kConnectedMesh)) {
+        return false;
+      }
+      return outputMeshAsPly(filename, mesh);
+    }
+
     default:
       LOG(FATAL) << "Unknown layer to ply output type: "
                  << static_cast<int>(type);

--- a/voxblox/include/voxblox/mesh/marching_cubes.h
+++ b/voxblox/include/voxblox/mesh/marching_cubes.h
@@ -142,13 +142,16 @@ class MarchingCubes {
   static inline Point interpolateVertex(const Point& vertex1,
                                         const Point& vertex2, float sdf1,
                                         float sdf2) {
-    const FloatingPoint min_diff = 1e-6;
+    static constexpr FloatingPoint kMinSdfDifference = 1e-6;
     const FloatingPoint sdf_diff = sdf1 - sdf2;
-    if (std::abs(sdf_diff) < min_diff) {
-      return Point(vertex1 + 0.5 * vertex2);
+    // Only compute the actual interpolation value if the sdf_difference is not
+    // too small, this is to counteract issues with floating point precision.
+    if (std::abs(sdf_diff) >= kMinSdfDifference) {
+      const FloatingPoint t = sdf1 / sdf_diff;
+      return Point(vertex1 + t * (vertex2 - vertex1));
+    } else {
+      return Point(0.5 * (vertex1 + vertex2));
     }
-    const FloatingPoint t = sdf1 / sdf_diff;
-    return Point(vertex1 + t * (vertex2 - vertex1));
   }
 };
 

--- a/voxblox/include/voxblox/mesh/mesh.h
+++ b/voxblox/include/voxblox/mesh/mesh.h
@@ -24,6 +24,7 @@
 #define VOXBLOX_MESH_MESH_H_
 
 #include <cstdint>
+#include <memory>
 
 #include "voxblox/core/common.h"
 
@@ -36,20 +37,100 @@ struct Mesh {
   typedef std::shared_ptr<Mesh> Ptr;
   typedef std::shared_ptr<const Mesh> ConstPtr;
 
+  static constexpr FloatingPoint kInvalidBlockSize = -1.0;
+
+  Mesh()
+      : block_size(kInvalidBlockSize), origin(Point::Zero()), updated(false) {
+    // Do nothing.
+  }
+
   Mesh(FloatingPoint _block_size, const Point& _origin)
-      : block_size(_block_size), origin(_origin), updated(false) {}
+      : block_size(_block_size), origin(_origin), updated(false) {
+    CHECK_GT(block_size, 0.0);
+  }
   virtual ~Mesh() {}
 
   inline bool hasVertices() const { return !vertices.empty(); }
   inline bool hasNormals() const { return !normals.empty(); }
   inline bool hasColors() const { return !colors.empty(); }
-  inline bool hasIndices() const { return !indices.empty(); }
+  inline bool hasTriangles() const { return !indices.empty(); }
+
+  inline size_t size() const { return vertices.size(); }
 
   inline void clear() {
     vertices.clear();
     normals.clear();
     colors.clear();
     indices.clear();
+  }
+
+  inline void clearTriangles() { indices.clear(); }
+  inline void clearNormals() { normals.clear(); }
+  inline void clearColors() { colors.clear(); }
+
+  inline void resize(const size_t size, const bool has_normals = true,
+                     const bool has_colors = true,
+                     const bool has_indices = true) {
+    vertices.resize(size);
+
+    if (has_normals) {
+      normals.resize(size);
+    }
+
+    if (has_colors) {
+      colors.resize(size);
+    }
+
+    if (has_indices) {
+      indices.resize(size);
+    }
+  }
+
+  inline void reserve(const size_t size, const bool has_normals = true,
+                      const bool has_colors = true,
+                      const bool has_triangles = true) {
+    vertices.reserve(size);
+
+    if (has_normals) {
+      normals.reserve(size);
+    }
+
+    if (has_colors) {
+      colors.reserve(size);
+    }
+
+    if (has_triangles) {
+      indices.reserve(size);
+    }
+  }
+
+  void colorizeMesh(const Color& new_color) {
+    colors.clear();
+    colors.resize(vertices.size(), new_color);
+  }
+
+  void concatenateMesh(const Mesh& other_mesh) {
+    CHECK_EQ(other_mesh.hasColors(), hasColors());
+    CHECK_EQ(other_mesh.hasNormals(), hasNormals());
+    CHECK_EQ(other_mesh.hasTriangles(), hasTriangles());
+
+    reserve(size() + other_mesh.size(), hasNormals(), hasColors(),
+            hasTriangles());
+
+    const size_t num_vertices_before = vertices.size();
+
+    for (const Point& vertex : other_mesh.vertices) {
+      vertices.push_back(vertex);
+    }
+    for (const Color& color : other_mesh.colors) {
+      colors.push_back(color);
+    }
+    for (const Point& normal : other_mesh.normals) {
+      normals.push_back(normal);
+    }
+    for (const size_t index : other_mesh.indices) {
+      indices.push_back(index + num_vertices_before);
+    }
   }
 
   Pointcloud vertices;

--- a/voxblox/include/voxblox/mesh/mesh_layer.h
+++ b/voxblox/include/voxblox/mesh/mesh_layer.h
@@ -1,7 +1,9 @@
-#ifndef VOXBLOX_CORE_MESH_LAYER_H_
-#define VOXBLOX_CORE_MESH_LAYER_H_
+#ifndef VOXBLOX_MESH_MESH_LAYER_H_
+#define VOXBLOX_MESH_MESH_LAYER_H_
 
 #include <glog/logging.h>
+#include <iostream>
+#include <memory>
 #include <utility>
 
 #include "voxblox/core/block_hash.h"
@@ -136,7 +138,104 @@ class MeshLayer {
     }
   }
 
-  void combineMesh(Mesh::Ptr combined_mesh) const {
+  // Get mesh from mesh layer. NOTE: The triangles and vertices in this mesh are
+  // distinct, hence, this will not produce a connected mesh.
+  void getMesh(Mesh* combined_mesh) const {
+    CHECK_NOTNULL(combined_mesh);
+
+    // Combine everything in the layer into one giant combined mesh.
+
+    BlockIndexList mesh_indices;
+    getAllAllocatedMeshes(&mesh_indices);
+
+    // Check if color, normals and indices are enabled for the first non-empty
+    // mesh. If they are, they need to be enabled for all other ones as well.
+    bool has_colors = false;
+    bool has_normals = false;
+    bool has_indices = false;
+    if (!mesh_indices.empty()) {
+      for (const BlockIndex& block_index : mesh_indices) {
+        Mesh::ConstPtr mesh = getMeshPtrByIndex(block_index);
+        if (!mesh->vertices.empty()) {
+          has_colors = mesh->hasColors();
+          has_normals = mesh->hasNormals();
+          has_indices = mesh->hasTriangles();
+          break;
+        }
+      }
+    }
+
+    // Loop again over all meshes to figure out how big the mesh needs to be.
+    size_t mesh_size = 0;
+    for (const BlockIndex& block_index : mesh_indices) {
+      Mesh::ConstPtr mesh = getMeshPtrByIndex(block_index);
+      mesh_size += mesh->vertices.size();
+    }
+
+    // Reserve space for the mesh.
+    combined_mesh->reserve(mesh_size, has_normals, has_colors, has_indices);
+
+    size_t new_index = 0u;
+    for (const BlockIndex& block_index : mesh_indices) {
+      Mesh::ConstPtr mesh = getMeshPtrByIndex(block_index);
+
+      // Check assumption that all meshes have same configuration regarding
+      // colors, normals and indices.
+      if (!mesh->vertices.empty()) {
+        CHECK_EQ(has_colors, mesh->hasColors());
+        CHECK_EQ(has_normals, mesh->hasNormals());
+        CHECK_EQ(has_indices, mesh->hasTriangles());
+      }
+
+      // Copy the mesh content into the combined mesh. This is done in triplets
+      // for readability only, as one loop iteration will then copy one
+      // triangle.
+      for (size_t i = 0; i < mesh->vertices.size(); i += 3, new_index += 3) {
+        CHECK_LT(new_index + 2, mesh_size);
+
+        combined_mesh->vertices.push_back(mesh->vertices[i]);
+        combined_mesh->vertices.push_back(mesh->vertices[i + 1]);
+        combined_mesh->vertices.push_back(mesh->vertices[i + 2]);
+
+        if (has_colors) {
+          combined_mesh->colors.push_back(mesh->colors[i]);
+          combined_mesh->colors.push_back(mesh->colors[i + 1]);
+          combined_mesh->colors.push_back(mesh->colors[i + 2]);
+        }
+        if (has_normals) {
+          combined_mesh->normals.push_back(mesh->normals[i]);
+          combined_mesh->normals.push_back(mesh->normals[i + 1]);
+          combined_mesh->normals.push_back(mesh->normals[i + 2]);
+        }
+        if (has_indices) {
+          combined_mesh->indices.push_back(new_index);
+          combined_mesh->indices.push_back(new_index + 1);
+          combined_mesh->indices.push_back(new_index + 2);
+        }
+      }
+    }
+
+    if (combined_mesh->hasColors()) {
+      CHECK_EQ(combined_mesh->vertices.size(), combined_mesh->colors.size());
+    }
+    if (combined_mesh->hasNormals()) {
+      CHECK_EQ(combined_mesh->vertices.size(), combined_mesh->normals.size());
+    }
+
+    CHECK_EQ(combined_mesh->vertices.size(), combined_mesh->indices.size());
+  }
+
+  // Get a connected mesh by merging close vertices and removing triangles with
+  // zero surface area. If you only would like to connect vertices, make sure
+  // that the proximity threhsold <<< voxel size. If you would like to simplify
+  // the mesh, chose a threshold greater or near the voxel size until you
+  // reached the level of simpliciation desired.
+  void getConnectedMesh(
+      Mesh* combined_mesh,
+      const FloatingPoint approximate_vertex_proximity_threshold =
+          1e-10) const {
+    CHECK_NOTNULL(combined_mesh);
+
     // Used to prevent double ups in vertices
     AnyIndexHashMapType<IndexElement>::type uniques;
 
@@ -144,10 +243,8 @@ class MeshLayer {
     // them
     VertexIndexList temp_indices;
 
-    // If two vertexes are closer together than (voxel_size /
-    // key_multiplication_factor), then the second vertex will be discarded and
-    // the first one used in its place
-    constexpr FloatingPoint key_multiplication_factor = 10;
+    const FloatingPoint threshold_inv =
+        1. / approximate_vertex_proximity_threshold;
 
     // Combine everything in the layer into one giant combined mesh.
     size_t v = 0;
@@ -157,12 +254,16 @@ class MeshLayer {
       Mesh::ConstPtr mesh = getMeshPtrByIndex(block_index);
 
       for (size_t i = 0; i < mesh->vertices.size(); ++i) {
-        // convert from 3D point to key
-        BlockIndex vert_key =
-            (key_multiplication_factor * mesh->vertices[i] / block_size())
-                .cast<IndexElement>();
-        if (uniques.find(vert_key) == uniques.end()) {
-          uniques[vert_key] = v;
+        // We scale the vertices by the inverse of the merging tolerance and
+        // then compute a discretized grid index in that scale.
+        // This exhibits the behaviour of merging two vertices that are
+        // closer than the threshold.
+        const Point& vertex = mesh->vertices[i];
+        AnyIndex vertex_index(std::round(vertex.x() * threshold_inv),
+                              std::round(vertex.y() * threshold_inv),
+                              std::round(vertex.z() * threshold_inv));
+        if (uniques.find(vertex_index) == uniques.end()) {
+          uniques[vertex_index] = v;
           combined_mesh->vertices.push_back(mesh->vertices[i]);
 
           if (mesh->hasColors()) {
@@ -175,7 +276,7 @@ class MeshLayer {
           temp_indices.push_back(v);
           v++;
         } else {
-          temp_indices.push_back(uniques[vert_key]);
+          temp_indices.push_back(uniques[vertex_index]);
         }
       }
     }
@@ -210,4 +311,4 @@ class MeshLayer {
 
 }  // namespace voxblox
 
-#endif  // VOXBLOX_CORE_MESH_LAYER_H_
+#endif  // VOXBLOX_MESH_MESH_LAYER_H_

--- a/voxblox/include/voxblox/mesh/mesh_layer.h
+++ b/voxblox/include/voxblox/mesh/mesh_layer.h
@@ -1,10 +1,13 @@
 #ifndef VOXBLOX_MESH_MESH_LAYER_H_
 #define VOXBLOX_MESH_MESH_LAYER_H_
 
-#include <glog/logging.h>
+#include <cmath>
 #include <iostream>
 #include <memory>
 #include <utility>
+#include <vector>
+
+#include <glog/logging.h>
 
 #include "voxblox/core/block_hash.h"
 #include "voxblox/core/common.h"
@@ -215,6 +218,7 @@ class MeshLayer {
       }
     }
 
+    // Verify combined mesh.
     if (combined_mesh->hasColors()) {
       CHECK_EQ(combined_mesh->vertices.size(), combined_mesh->colors.size());
     }
@@ -236,62 +240,153 @@ class MeshLayer {
           1e-10) const {
     CHECK_NOTNULL(combined_mesh);
 
-    // Used to prevent double ups in vertices
-    AnyIndexHashMapType<IndexElement>::type uniques;
+    // Used to prevent double ups in vertices. We need to use a long long based
+    // index, to prevent overflows.
+    LongIndexHashMapType<size_t>::type uniques;
 
-    // Some triangles will have zero area we store them here first then filter
-    // them
-    VertexIndexList temp_indices;
-
-    const FloatingPoint threshold_inv =
-        1. / approximate_vertex_proximity_threshold;
+    const double threshold_inv =
+        1. / static_cast<double>(approximate_vertex_proximity_threshold);
 
     // Combine everything in the layer into one giant combined mesh.
-    size_t v = 0;
+    size_t new_vertex_index = 0u;
     BlockIndexList mesh_indices;
     getAllAllocatedMeshes(&mesh_indices);
     for (const BlockIndex& block_index : mesh_indices) {
       Mesh::ConstPtr mesh = getMeshPtrByIndex(block_index);
 
-      for (size_t i = 0; i < mesh->vertices.size(); ++i) {
+      // Skip empty meshes.
+      if (mesh->vertices.empty()) {
+        continue;
+      }
+
+      // Make sure there are 3 distinct vertices for every triangle before
+      // merging.
+      CHECK_EQ(mesh->vertices.size(), mesh->indices.size());
+      CHECK_EQ(mesh->vertices.size() % 3u, 0u);
+      CHECK_EQ(mesh->indices.size() % 3u, 0u);
+
+      // Stores the mapping from old vertex index to the new one in the combined
+      // mesh. This is later used to adapt the triangles to the new, global
+      // indexing of the combined mesh.
+      std::vector<size_t> old_to_new_indices;
+      old_to_new_indices.resize(mesh->vertices.size());
+
+      size_t new_num_vertices_from_this_block = 0u;
+      for (size_t old_vertex_idx = 0u; old_vertex_idx < mesh->vertices.size();
+           ++old_vertex_idx) {
         // We scale the vertices by the inverse of the merging tolerance and
         // then compute a discretized grid index in that scale.
         // This exhibits the behaviour of merging two vertices that are
         // closer than the threshold.
-        const Point& vertex = mesh->vertices[i];
-        AnyIndex vertex_index(std::round(vertex.x() * threshold_inv),
-                              std::round(vertex.y() * threshold_inv),
-                              std::round(vertex.z() * threshold_inv));
-        if (uniques.find(vertex_index) == uniques.end()) {
-          uniques[vertex_index] = v;
-          combined_mesh->vertices.push_back(mesh->vertices[i]);
+        CHECK_LT(old_vertex_idx, mesh->vertices.size());
+        const Point vertex = mesh->vertices[old_vertex_idx];
+        const Eigen::Vector3d scaled_vector =
+            vertex.cast<double>() * threshold_inv;
+        const LongIndex vertex_3D_index = LongIndex(
+            std::round(scaled_vector.x()), std::round(scaled_vector.y()),
+            std::round(scaled_vector.z()));
+
+        // If the current vertex falls into the same grid cell as a previous
+        // vertex, we merge them. This is done by assigning the new vertex to
+        // the same vertex index as the first vertex that fell into that cell.
+
+        LongIndexHashMapType<size_t>::type::const_iterator it =
+            uniques.find(vertex_3D_index);
+
+        const bool vertex_is_unique_so_far = (it == uniques.end());
+        if (vertex_is_unique_so_far) {
+          // Copy vertex and associated data to combined mesh.
+          combined_mesh->vertices.push_back(vertex);
 
           if (mesh->hasColors()) {
-            combined_mesh->colors.push_back(mesh->colors[i]);
+            CHECK_LT(old_vertex_idx, mesh->colors.size());
+            combined_mesh->colors.push_back(mesh->colors[old_vertex_idx]);
           }
           if (mesh->hasNormals()) {
-            combined_mesh->normals.push_back(mesh->normals[i]);
+            CHECK_LT(old_vertex_idx, mesh->normals.size());
+            combined_mesh->normals.push_back(mesh->normals[old_vertex_idx]);
           }
 
-          temp_indices.push_back(v);
-          v++;
+          // Store the new vertex index in the unique-vertex-map to be able to
+          // retrieve this index later if we encounter vertices that are
+          // supposed to be merged with this one.
+          CHECK(uniques.emplace(vertex_3D_index, new_vertex_index).second);
+
+          // Also store a mapping from old index to new index for this mesh
+          // block to later adapt the triangle indexing.
+          CHECK_LT(old_vertex_idx, old_to_new_indices.size());
+          old_to_new_indices[old_vertex_idx] = new_vertex_index;
+
+          ++new_vertex_index;
+          ++new_num_vertices_from_this_block;
         } else {
-          temp_indices.push_back(uniques[vertex_index]);
+          // If this vertex is not unique, we map it's vertex index to the new
+          // vertex index.
+          CHECK_LT(old_vertex_idx, old_to_new_indices.size());
+          old_to_new_indices[old_vertex_idx] = it->second;
+        }
+
+        // Make sure the indexing is correct.
+        CHECK_EQ(combined_mesh->vertices.size(), new_vertex_index);
+      }
+
+      // Make sure we have a mapping for every old vertex index.
+      CHECK_EQ(old_to_new_indices.size(), mesh->vertices.size());
+
+      // Append triangles and adjust their indices if necessary.
+      // We discard triangles where all old vertices were mapped to the same
+      // vertex.
+      size_t new_num_triangle_from_this_block = 0u;
+      for (size_t triangle_idx = 0u; triangle_idx < mesh->indices.size();
+           triangle_idx += 3u) {
+        CHECK_LT(triangle_idx + 2u, mesh->indices.size());
+
+        // Retrieve old vertex indices.
+        size_t vertex_0 = mesh->indices[triangle_idx];
+        size_t vertex_1 = mesh->indices[triangle_idx + 1u];
+        size_t vertex_2 = mesh->indices[triangle_idx + 2u];
+
+        // Make sure the old indices were valid before remapping.
+        CHECK_LT(vertex_0, old_to_new_indices.size());
+        CHECK_LT(vertex_1, old_to_new_indices.size());
+        CHECK_LT(vertex_2, old_to_new_indices.size());
+
+        // Apply vertex index mapping.
+        vertex_0 = old_to_new_indices[vertex_0];
+        vertex_1 = old_to_new_indices[vertex_1];
+        vertex_2 = old_to_new_indices[vertex_2];
+
+        // Make sure the new indices are valid after remapping.
+        CHECK_LT(vertex_0, new_vertex_index);
+        CHECK_LT(vertex_1, new_vertex_index);
+        CHECK_LT(vertex_2, new_vertex_index);
+
+        // Get rid of triangles where all two or three vertices have been
+        // merged.
+        const bool two_or_three_vertex_indices_are_the_same =
+            (vertex_0 == vertex_1) || (vertex_1 == vertex_2) ||
+            (vertex_0 == vertex_2);
+
+        if (!two_or_three_vertex_indices_are_the_same) {
+          combined_mesh->indices.push_back(vertex_0);
+          combined_mesh->indices.push_back(vertex_1);
+          combined_mesh->indices.push_back(vertex_2);
+          ++new_num_triangle_from_this_block;
         }
       }
     }
 
-    // extract indices of triangles with non-zero area
-    for (size_t i = 0; i < temp_indices.size(); i += 3) {
-      // check that corners of triangles have not been merged
-      if ((temp_indices[i] != temp_indices[i + 1]) &&
-          (temp_indices[i] != temp_indices[i + 2]) &&
-          (temp_indices[i + 1] != temp_indices[i + 2])) {
-        combined_mesh->indices.push_back(temp_indices[i]);
-        combined_mesh->indices.push_back(temp_indices[i + 1]);
-        combined_mesh->indices.push_back(temp_indices[i + 2]);
-      }
+    // Verify combined mesh.
+    if (combined_mesh->hasColors()) {
+      CHECK_EQ(combined_mesh->vertices.size(), combined_mesh->colors.size());
     }
+    if (combined_mesh->hasNormals()) {
+      CHECK_EQ(combined_mesh->vertices.size(), combined_mesh->normals.size());
+    }
+
+    // The number of vertices should now be less or equal the amount of triangle
+    // indices, since we merged some of the vertices.
+    CHECK_LE(combined_mesh->vertices.size(), combined_mesh->indices.size());
   }
 
   size_t getNumberOfAllocatedMeshes() const { return mesh_map_.size(); }

--- a/voxblox/include/voxblox/utils/layer_utils.h
+++ b/voxblox/include/voxblox/utils/layer_utils.h
@@ -129,16 +129,22 @@ void centerBlocksOfLayer(Layer<VoxelType>* layer, Point* new_layer_origin) {
   BlockIndexList block_indices;
   layer->getAllAllocatedBlocks(&block_indices);
   for (const BlockIndex block_index : block_indices) {
-    centroid += block_index.cast<FloatingPoint>();
+    centroid += layer->getBlockByIndex(block_index).origin();
   }
   centroid /= static_cast<FloatingPoint>(block_indices.size());
 
   // Round to nearest block index to centroid.
+  centroid /= layer->block_size();
   const BlockIndex index_centroid =
       (centroid + 0.5 * Point::Ones()).cast<IndexElement>();
 
-  VLOG(1) << "The index centroid of all allocated blocks is: "
-          << index_centroid;
+  // Return the new origin expressed in the old origins coordinate frame.
+  const FloatingPoint block_size = layer->block_size();
+  *new_layer_origin = index_centroid.cast<FloatingPoint>() * block_size;
+
+  VLOG(1) << "The new origin of the coordinate frame (expressed in the old "
+             "coordinate frame) is: "
+          << *new_layer_origin;
 
   // Loop over all blocks and change their spatial indices.
   // The only way to do this is to remove them all, store them in a temporary
@@ -148,11 +154,14 @@ void centerBlocksOfLayer(Layer<VoxelType>* layer, Point* new_layer_origin) {
   const size_t num_allocated_blocks_before =
       layer->getNumberOfAllocatedBlocks();
   typename Layer<VoxelType>::BlockHashMap temporary_map;
-  layer->getAllAllocatedBlocks(&block_indices);
   for (const BlockIndex& block_index : block_indices) {
+    typename Block<VoxelType>::Ptr block_ptr =
+        layer->getBlockPtrByIndex(block_index);
+    const Point new_origin = block_ptr->origin() - *new_layer_origin;
+    block_ptr->setOrigin(new_origin);
+
     // Extract block and shift block index.
-    temporary_map.emplace(block_index - index_centroid,
-                          layer->getBlockPtrByIndex(block_index));
+    temporary_map.emplace(block_index - index_centroid, block_ptr);
   }
 
   layer->removeAllBlocks();
@@ -164,10 +173,6 @@ void centerBlocksOfLayer(Layer<VoxelType>* layer, Point* new_layer_origin) {
     layer->insertBlock(idx_block_pair);
   }
   CHECK_EQ(layer->getNumberOfAllocatedBlocks(), num_allocated_blocks_before);
-
-  // Return the new origin expressed in the old origins coordinate frame.
-  const FloatingPoint block_size = layer->block_size();
-  *new_layer_origin = index_centroid.cast<FloatingPoint>() * block_size;
 }
 
 }  // namespace utils

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -121,10 +121,11 @@ void TsdfIntegratorBase::updateLayerWithStoredBlocks() {
 }
 
 // Updates tsdf_voxel. Thread safe.
-void TsdfIntegratorBase::updateTsdfVoxel(
-    const Point& origin, const Point& point_G,
-    const VoxelIndex& global_voxel_idx, const Color& color, const float weight,
-    TsdfVoxel* tsdf_voxel) {
+void TsdfIntegratorBase::updateTsdfVoxel(const Point& origin,
+                                         const Point& point_G,
+                                         const VoxelIndex& global_voxel_idx,
+                                         const Color& color, const float weight,
+                                         TsdfVoxel* tsdf_voxel) {
   DCHECK(tsdf_voxel != nullptr);
 
   const Point voxel_center =
@@ -187,9 +188,9 @@ void TsdfIntegratorBase::updateTsdfVoxel(
 // To do this, project the voxel_center onto the ray from origin to point G.
 // Then check if the the magnitude of the vector is smaller or greater than
 // the original distance...
-inline float TsdfIntegratorBase::computeDistance(
-    const Point& origin, const Point& point_G,
-    const Point& voxel_center) const {
+float TsdfIntegratorBase::computeDistance(const Point& origin,
+                                          const Point& point_G,
+                                          const Point& voxel_center) const {
   const Point v_voxel_origin = voxel_center - origin;
   const Point v_point_origin = point_G - origin;
 

--- a/voxblox/src/io/sdf_ply.cc
+++ b/voxblox/src/io/sdf_ply.cc
@@ -10,7 +10,8 @@ namespace io {
 
 template <>
 bool getColorFromVoxel(const TsdfVoxel& voxel,
-                       const FloatingPoint max_sdf_distance, Color* color) {
+                       const FloatingPoint sdf_color_range,
+                       const FloatingPoint sdf_max_value, Color* color) {
   CHECK_NOTNULL(color);
 
   static constexpr float kTolerance = 1e-6;
@@ -18,11 +19,15 @@ bool getColorFromVoxel(const TsdfVoxel& voxel,
     return false;
   }
 
+  if (std::abs(voxel.distance) > sdf_max_value && sdf_max_value > 0.0) {
+    return false;
+  }
+
   FloatingPoint truncated_voxel_distance =
-      std::min(std::max(voxel.distance, -max_sdf_distance), max_sdf_distance);
+      std::min(std::max(voxel.distance, -sdf_color_range), sdf_color_range);
 
   FloatingPoint color_factor =
-      0.5 * (1.0 + (truncated_voxel_distance / max_sdf_distance));
+      0.5 * (1.0 + (truncated_voxel_distance / sdf_color_range));
 
   CHECK_LE(color_factor, 1.0);
   CHECK_GE(color_factor, 0.0);
@@ -34,17 +39,22 @@ bool getColorFromVoxel(const TsdfVoxel& voxel,
 
 template <>
 bool getColorFromVoxel(const EsdfVoxel& voxel,
-                       const FloatingPoint max_sdf_distance, Color* color) {
+                       const FloatingPoint sdf_color_range,
+                       const FloatingPoint sdf_max_value, Color* color) {
   CHECK_NOTNULL(color);
   if (!voxel.observed) {
     return false;
   }
 
+  if (std::abs(voxel.distance) > sdf_max_value && sdf_max_value > 0.0) {
+    return false;
+  }
+
   FloatingPoint truncated_voxel_distance =
-      std::min(std::max(voxel.distance, -max_sdf_distance), max_sdf_distance);
+      std::min(std::max(voxel.distance, -sdf_color_range), sdf_color_range);
 
   FloatingPoint color_factor =
-      0.5 * (1.0 + (truncated_voxel_distance / max_sdf_distance));
+      0.5 * (1.0 + (truncated_voxel_distance / sdf_color_range));
 
   CHECK_LE(color_factor, 1.0);
   CHECK_GE(color_factor, 0.0);

--- a/voxblox/src/io/sdf_ply.cc
+++ b/voxblox/src/io/sdf_ply.cc
@@ -1,0 +1,58 @@
+#include "voxblox/io/sdf_ply.h"
+
+#include <algorithm>
+
+#include "voxblox/core/layer.h"
+
+namespace voxblox {
+
+namespace io {
+
+template <>
+bool getColorFromVoxel(const TsdfVoxel& voxel,
+                       const FloatingPoint max_sdf_distance, Color* color) {
+  CHECK_NOTNULL(color);
+
+  static constexpr float kTolerance = 1e-6;
+  if (voxel.weight <= kTolerance) {
+    return false;
+  }
+
+  FloatingPoint truncated_voxel_distance =
+      std::min(std::max(voxel.distance, -max_sdf_distance), max_sdf_distance);
+
+  FloatingPoint color_factor =
+      0.5 * (1.0 + (truncated_voxel_distance / max_sdf_distance));
+
+  CHECK_LE(color_factor, 1.0);
+  CHECK_GE(color_factor, 0.0);
+
+  *color = rainbowColorMap(0.66 - 0.66 * color_factor);
+
+  return true;
+}
+
+template <>
+bool getColorFromVoxel(const EsdfVoxel& voxel,
+                       const FloatingPoint max_sdf_distance, Color* color) {
+  CHECK_NOTNULL(color);
+  if (!voxel.observed) {
+    return false;
+  }
+
+  FloatingPoint truncated_voxel_distance =
+      std::min(std::max(voxel.distance, -max_sdf_distance), max_sdf_distance);
+
+  FloatingPoint color_factor =
+      0.5 * (1.0 + (truncated_voxel_distance / max_sdf_distance));
+
+  CHECK_LE(color_factor, 1.0);
+  CHECK_GE(color_factor, 0.0);
+
+  *color = rainbowColorMap(0.66 - 0.66 * color_factor);
+
+  return true;
+}
+
+}  // namespace io
+}  // namespace voxblox

--- a/voxblox/src/utils/evaluation_utils.cc
+++ b/voxblox/src/utils/evaluation_utils.cc
@@ -66,5 +66,49 @@ VoxelEvaluationResult computeVoxelError(
   return VoxelEvaluationResult::kEvaluated;
 }
 
+template <>
+bool isObservedVoxel(const TsdfVoxel& voxel) {
+  return voxel.weight > 1e-6;
+}
+
+template <>
+bool isObservedVoxel(const EsdfVoxel& voxel) {
+  return voxel.observed;
+}
+
+template <>
+FloatingPoint getVoxelSdf(const TsdfVoxel& voxel) {
+  return voxel.distance;
+}
+
+template <>
+FloatingPoint getVoxelSdf(const EsdfVoxel& voxel) {
+  return voxel.distance;
+}
+
+template <>
+void setVoxelSdf(const FloatingPoint sdf, TsdfVoxel* voxel) {
+  CHECK_NOTNULL(voxel);
+  voxel->distance = sdf;
+}
+
+template <>
+void setVoxelSdf(const FloatingPoint sdf, EsdfVoxel* voxel) {
+  CHECK_NOTNULL(voxel);
+  voxel->distance = sdf;
+}
+
+template <>
+void setVoxelWeight(const FloatingPoint weight, TsdfVoxel* voxel) {
+  CHECK_NOTNULL(voxel);
+  voxel->weight = weight;
+}
+
+template <>
+void setVoxelWeight(const FloatingPoint weight, EsdfVoxel* voxel) {
+  CHECK_NOTNULL(voxel);
+  voxel->observed = weight > 0.;
+}
+
 }  // namespace utils
 }  // namespace voxblox

--- a/voxblox/test/test_layer_utils.cc
+++ b/voxblox/test/test_layer_utils.cc
@@ -4,6 +4,7 @@
 #include "voxblox/core/block.h"
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"
+#include "voxblox/simulation/simulation_world.h"
 #include "voxblox/test/layer_test_utils.h"
 #include "voxblox/utils/layer_utils.h"
 
@@ -13,23 +14,51 @@ template <typename VoxelType>
 class LayerUtilsTest : public ::testing::Test,
                        public voxblox::test::LayerTest<VoxelType> {
  protected:
-  virtual void SetUp() {
-    layer_.reset(new Layer<VoxelType>(voxel_size_, voxels_per_side_));
-    SetUpLayer();
+  void initializeSimulatedWorld() {
+    world_.reset(new Layer<VoxelType>(voxel_size_, voxels_per_side_));
+
+    SimulationWorld simulation;
+    Point lower_bound, upper_bound;
+    lower_bound << -0.5, -0.5, -0.5;
+    upper_bound << 1.0, 1.0, 1.0;
+    expected_new_coordinate_origin_ << 0.16, 0.16, 0.16;
+
+    simulation.setBounds(lower_bound, upper_bound);
+
+    // Define sphere 1.
+    Point c1_A;
+    c1_A << 0.104, 0.104, 0.106;
+    constexpr FloatingPoint sphere_1_radius_m = 0.05;
+
+    // Define sphere 2.
+    Point c2_A;
+    c2_A << -0.104, 0.103, 0.203;
+    constexpr FloatingPoint sphere_2_radius_m = 0.03;
+
+    // Define sphere 3.
+    Point c3_A;
+    c3_A << 0.401, 0.151, 0.203;
+    constexpr FloatingPoint sphere_3_radius_m = 0.075;
+
+    // Prepare world A
+    simulation.addObject(std::unique_ptr<Object>(
+        new Sphere(c1_A, sphere_1_radius_m, Color(255u, 0u, 0u))));
+    simulation.addObject(std::unique_ptr<Object>(
+        new Sphere(c2_A, sphere_2_radius_m, Color(255u, 0u, 0u))));
+    simulation.addObject(std::unique_ptr<Object>(
+        new Sphere(c3_A, sphere_3_radius_m, Color(255u, 0u, 0u))));
+    simulation.generateSdfFromWorld(max_distance_world, world_.get());
   }
 
-  void SetUpLayer() const {
-    test::SetUpTestLayer(kBlockVolumeDiameter, kBlockVolumeOffset,
-                         layer_.get());
-  }
+  virtual void SetUp() { initializeSimulatedWorld(); }
 
-  typename Layer<VoxelType>::Ptr layer_;
+  typename Layer<VoxelType>::Ptr world_;
 
-  const double voxel_size_ = 0.02;
+  Point expected_new_coordinate_origin_;
+
+  const double voxel_size_ = 0.005;
   const size_t voxels_per_side_ = 16u;
-
-  static constexpr IndexElement kBlockVolumeDiameter = 10u;
-  static constexpr IndexElement kBlockVolumeOffset = 5u;
+  const double max_distance_world = 2.0;
 
   static constexpr FloatingPoint kPrecision = 1e-6;
 };
@@ -40,32 +69,18 @@ typedef LayerUtilsTest<OccupancyVoxel> OccupancyLayerUtilsTest;
 
 TEST_F(TsdfLayerUtilsTest, centerBlocksOfLayerTsdfTest) {
   Point new_layer_origin;
-  utils::centerBlocksOfLayer(layer_.get(), &new_layer_origin);
+  utils::centerBlocksOfLayer(world_.get(), &new_layer_origin);
 
-  EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-      new_layer_origin,
-      voxel_size_ * voxels_per_side_ * kBlockVolumeOffset * Point::Ones(),
-      kPrecision));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(new_layer_origin,
+                                expected_new_coordinate_origin_, kPrecision));
 }
 
 TEST_F(EsdfLayerUtilsTest, centerBlocksOfLayerEsdfTest) {
   Point new_layer_origin;
-  utils::centerBlocksOfLayer(layer_.get(), &new_layer_origin);
+  utils::centerBlocksOfLayer(world_.get(), &new_layer_origin);
 
-  EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-      new_layer_origin,
-      voxel_size_ * voxels_per_side_ * kBlockVolumeOffset * Point::Ones(),
-      kPrecision));
-}
-
-TEST_F(OccupancyLayerUtilsTest, centerBlocksOfLayerOccupancyTest) {
-  Point new_layer_origin;
-  utils::centerBlocksOfLayer(layer_.get(), &new_layer_origin);
-
-  EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-      new_layer_origin,
-      voxel_size_ * voxels_per_side_ * kBlockVolumeOffset * Point::Ones(),
-      kPrecision));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(new_layer_origin,
+                                expected_new_coordinate_origin_, kPrecision));
 }
 
 int main(int argc, char** argv) {

--- a/voxblox/test/test_merge_integration.cc
+++ b/voxblox/test/test_merge_integration.cc
@@ -42,13 +42,13 @@ class LayerMergeToolTest : public ::testing::Test,
     // Transformation generated at random by minkindr
     // Translation 0.15m, Rotation: 28.6479 degrees
     // clang-format off
-    Eigen::Matrix<FloatingPoint, 4, 4> T_A_B;
-    T_A_B <<  0.959292,  0.233991, 0.158138, -0.0627464,
+    Eigen::Matrix<FloatingPoint, 4, 4> T_B_A;
+    T_B_A <<  0.959292,  0.233991, 0.158138, -0.0627464,
              -0.277701,  0.883428, 0.377407,  0.126472,
              -0.051394, -0.405959, 0.912445, -0.0506717,
               0.      ,  0.      , 0.      ,  1.;
     // clang-format on
-    T_A_B_ = Transformation(T_A_B);
+    T_B_A_ = Transformation(T_B_A);
 
     // Define sphere 1.
     Point c1_A;
@@ -77,16 +77,16 @@ class LayerMergeToolTest : public ::testing::Test,
 
     // Prepare world B
     simulation.addObject(std::unique_ptr<Object>(new Sphere(
-        T_A_B_.transform(c1_A), sphere_1_radius_m, Color(0u, 255u, 0u))));
+        T_B_A_.transform(c1_A), sphere_1_radius_m, Color(0u, 255u, 0u))));
     simulation.addObject(std::unique_ptr<Object>(new Sphere(
-        T_A_B_.transform(c2_A), sphere_2_radius_m, Color(0u, 255u, 0u))));
+        T_B_A_.transform(c2_A), sphere_2_radius_m, Color(0u, 255u, 0u))));
     simulation.addObject(std::unique_ptr<Object>(new Sphere(
-        T_A_B_.transform(c3_A), sphere_3_radius_m, Color(0u, 255u, 0u))));
+        T_B_A_.transform(c3_A), sphere_3_radius_m, Color(0u, 255u, 0u))));
     simulation.generateSdfFromWorld(max_distance_world, world_B_.get());
     simulation.generateSdfFromWorld(max_distance_world, world_B_compare_.get());
   }
 
-  Transformation T_A_B_;
+  Transformation T_B_A_;
   typename Layer<VoxelType>::Ptr world_A_;
   typename Layer<VoxelType>::Ptr world_B_;
   typename Layer<VoxelType>::Ptr world_B_compare_;
@@ -116,7 +116,7 @@ TEST_F(TsdfLayerMergeToolTest, MergeTwoTsdfLayers) {
 
   LOG(INFO) << "Merging world A into world B...";
   constexpr bool kUseNaiveMethod = false;
-  mergeLayerAintoLayerB(*world_A_, T_A_B_, world_B_.get(), kUseNaiveMethod);
+  mergeLayerAintoLayerB(*world_A_, T_B_A_, world_B_.get(), kUseNaiveMethod);
 
   LOG(INFO) << "Evaluating merged world...";
   utils::VoxelEvaluationDetails result;

--- a/voxblox/test/test_merge_integration.cc
+++ b/voxblox/test/test_merge_integration.cc
@@ -94,6 +94,7 @@ class LayerMergeToolTest : public ::testing::Test,
   const double voxel_size_ = 0.005;
   const size_t voxels_per_side_ = 16u;
   const double max_distance_world = 2.0;
+  const double max_sdf_value_to_visualize = 0.015;
 };
 
 typedef LayerMergeToolTest<TsdfVoxel> TsdfLayerMergeToolTest;
@@ -107,12 +108,20 @@ TEST_F(TsdfLayerMergeToolTest, MergeTwoTsdfLayers) {
   const std::string kWorldAPlyFile = kFolderPrefix + "world_A.tsdf.ply";
   LOG(INFO) << "Writing world A to : " << kWorldAPlyFile;
   io::outputLayerAsPly(*world_A_, kWorldAPlyFile,
-                       io::PlyOutputTypes::kSdfIsosurface);
+                       io::PlyOutputTypes::kSdfIsosurfaceConnected);
+  const std::string kWorldASdfPlyFile = kFolderPrefix + "world_A.tsdf_sdf.ply";
+  io::outputLayerAsPly(*world_A_, kWorldASdfPlyFile,
+                       io::PlyOutputTypes::kSdfColoredDistanceField,
+                       max_sdf_value_to_visualize, max_sdf_value_to_visualize);
 
   const std::string kWorldBPlyFile = kFolderPrefix + "world_B.tsdf.ply";
   LOG(INFO) << "Writing world B to : " << kWorldBPlyFile;
   io::outputLayerAsPly(*world_B_, kWorldBPlyFile,
-                       io::PlyOutputTypes::kSdfIsosurface);
+                       io::PlyOutputTypes::kSdfIsosurfaceConnected);
+  const std::string kWorldBSdfPlyFile = kFolderPrefix + "world_B.tsdf_sdf.ply";
+  io::outputLayerAsPly(*world_B_, kWorldBSdfPlyFile,
+                       io::PlyOutputTypes::kSdfColoredDistanceField,
+                       max_sdf_value_to_visualize, max_sdf_value_to_visualize);
 
   LOG(INFO) << "Merging world A into world B...";
   constexpr bool kUseNaiveMethod = false;
@@ -140,7 +149,12 @@ TEST_F(TsdfLayerMergeToolTest, MergeTwoTsdfLayers) {
       kFolderPrefix + "world_A_and_B.tsdf.ply";
   LOG(INFO) << "Writing merged world to : " << kMergedLayerPlyFile;
   io::outputLayerAsPly(*world_B_, kMergedLayerPlyFile,
-                       io::PlyOutputTypes::kSdfIsosurface);
+                       io::PlyOutputTypes::kSdfIsosurfaceConnected);
+  const std::string kMergedLayerSdfPlyFile =
+      kFolderPrefix + "world_A_and_B.tsdf_sdf.ply";
+  io::outputLayerAsPly(*world_B_, kMergedLayerSdfPlyFile,
+                       io::PlyOutputTypes::kSdfColoredDistanceField,
+                       max_sdf_value_to_visualize, max_sdf_value_to_visualize);
   LOG(INFO) << "Done.";
 }
 

--- a/voxblox/test/test_tsdf_map.cc
+++ b/voxblox/test/test_tsdf_map.cc
@@ -1,5 +1,5 @@
-#include <eigen-checks/gtest.h>
 #include <eigen-checks/entrypoint.h>
+#include <eigen-checks/gtest.h>
 #include <gtest/gtest.h>
 
 #include "voxblox/core/tsdf_map.h"
@@ -9,13 +9,16 @@ using namespace voxblox;  // NOLINT
 class TsdfMapTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
-    TsdfMap::Config config;
-    config.tsdf_voxel_size = 0.1f;
-    config.tsdf_voxels_per_side = 8u;
-    map_ = aligned_shared<TsdfMap>(config);
+    config_.tsdf_voxel_size = 0.1f;
+    config_.tsdf_voxels_per_side = 8u;
+    block_size_ = config_.tsdf_voxel_size * config_.tsdf_voxels_per_side;
+    map_ = aligned_shared<TsdfMap>(config_);
   }
 
   TsdfMap::Ptr map_;
+  TsdfMap::Config config_;
+  FloatingPoint block_size_;
+  static constexpr FloatingPoint kEpsilon = 1e-12;
 };
 
 TEST_F(TsdfMapTest, BlockAllocation) {
@@ -31,48 +34,244 @@ TEST_F(TsdfMapTest, BlockAllocation) {
 }
 
 TEST_F(TsdfMapTest, IndexLookups) {
-  Block<TsdfVoxel>::Ptr block =
+  // BLOCK 0 0 0  (cordinate at origin)
+  Block<TsdfVoxel>::Ptr block_0_0_0 =
       map_->getTsdfLayerPtr()->allocateNewBlockByCoordinates(
           Point(0.0, 0.0, 0.0));
+  EXPECT_TRUE(
+      EIGEN_MATRIX_NEAR(block_0_0_0->origin(), Point(0.0, 0.0, 0.0), kEpsilon));
+  EXPECT_TRUE(
+      EIGEN_MATRIX_EQUAL(block_0_0_0->block_index(), AnyIndex(0, 0, 0)));
+  EXPECT_NEAR(block_0_0_0->block_size(), block_size_, kEpsilon);
 
-  Block<TsdfVoxel>::Ptr block2 =
-      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(Point(0.0, 0.1, 0.0));
-  EXPECT_EQ(block, block2);
+  // BLOCK 0 0 0  (cordinate within block)
+  Block<TsdfVoxel>::Ptr block_0_0_0_v2 =
+      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(
+          Point(0.0, config_.tsdf_voxel_size, 0.0));
+  EXPECT_EQ(block_0_0_0, block_0_0_0_v2);
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_0_0_0_v2->origin(), Point(0.0, 0.0, 0.0),
+                                kEpsilon));
+  EXPECT_TRUE(
+      EIGEN_MATRIX_EQUAL(block_0_0_0_v2->block_index(), AnyIndex(0, 0, 0)));
+  EXPECT_NEAR(block_0_0_0_v2->block_size(), block_size_, kEpsilon);
 
-  // Now check voxel indexing within this block.
-  Point test_point(0.0, 0.2, 0.0);
-  TsdfVoxel& voxel = block->getVoxelByCoordinates(test_point);
-  voxel.weight = 1.0;
-  voxel.distance = 0.5;
+  // BLOCK 1 1 1 (coordinate at origin)
+  Block<TsdfVoxel>::Ptr block_1_1_1 =
+      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(
+          Point(block_size_, block_size_, block_size_));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_1_1_1->origin(),
+                                Point(block_size_, block_size_, block_size_),
+                                kEpsilon));
+  EXPECT_TRUE(
+      EIGEN_MATRIX_EQUAL(block_1_1_1->block_index(), AnyIndex(1, 1, 1)));
+  EXPECT_NEAR(block_1_1_1->block_size(), block_size_, kEpsilon);
 
-  size_t linear_index = block->computeLinearIndexFromCoordinates(test_point);
-  VoxelIndex voxel_index = block->computeVoxelIndexFromCoordinates(test_point);
+  // BLOCK 1 1 1 (coordinate within block)
+  Block<TsdfVoxel>::Ptr block_1_1_1_v2 =
+      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(Point(
+          block_size_, block_size_ + config_.tsdf_voxel_size, block_size_));
+  EXPECT_EQ(block_1_1_1, block_1_1_1_v2);
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_1_1_1_v2->origin(),
+                                Point(block_size_, block_size_, block_size_),
+                                kEpsilon));
+  EXPECT_TRUE(
+      EIGEN_MATRIX_EQUAL(block_1_1_1_v2->block_index(), AnyIndex(1, 1, 1)));
+  EXPECT_NEAR(block_1_1_1_v2->block_size(), block_size_, kEpsilon);
 
-  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
-      voxel_index, block->computeVoxelIndexFromLinearIndex(linear_index)));
+  // BLOCK -1 -1 -1 (coordinate at origin)
+  Block<TsdfVoxel>::Ptr block_negative_1_1_1 =
+      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(
+          Point(-block_size_, -block_size_, -block_size_));
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_negative_1_1_1->origin(),
+                                Point(-block_size_, -block_size_, -block_size_),
+                                kEpsilon));
+  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(block_negative_1_1_1->block_index(),
+                                 AnyIndex(-1, -1, -1)));
+  EXPECT_NEAR(block_negative_1_1_1->block_size(), block_size_, kEpsilon);
 
-  EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-      test_point, block->computeCoordinatesFromLinearIndex(linear_index), 0.1));
-  EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-      test_point, block->computeCoordinatesFromVoxelIndex(voxel_index), 0.1));
+  // BLOCK -1 -1 -1 (coordinate within block)
+  Block<TsdfVoxel>::Ptr block_negative_1_1_1_v2 =
+      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(Point(
+          -block_size_, -block_size_ - config_.tsdf_voxel_size, -block_size_));
+  EXPECT_EQ(block_negative_1_1_1, block_negative_1_1_1_v2);
+  EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_negative_1_1_1_v2->origin(),
+                                Point(-block_size_, -block_size_, -block_size_),
+                                kEpsilon));
+  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(block_negative_1_1_1_v2->block_index(),
+                                 AnyIndex(-1, -1, -1)));
+  EXPECT_NEAR(block_negative_1_1_1_v2->block_size(), block_size_, kEpsilon);
 
-  test_point = Point(-0.4, -0.2, 0.6);
-  block = map_->getTsdfLayerPtr()->allocateNewBlockByCoordinates(test_point);
+  // Check voxel indexing.
 
-  linear_index = block->computeLinearIndexFromCoordinates(test_point);
-  voxel_index = block->computeVoxelIndexFromCoordinates(test_point);
+  // Test in Block 0 0 0
+  {
+    // Test Voxel 0 1 0
+    Point test_point(0.0, 2. * config_.tsdf_voxel_size, 0.0);
+    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(test_point), nullptr);
 
-  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
-      voxel_index, block->computeVoxelIndexFromLinearIndex(linear_index)));
+    size_t linear_index =
+        block_0_0_0->computeLinearIndexFromCoordinates(test_point);
+    EXPECT_EQ(linear_index, 8u);
+    VoxelIndex voxel_index =
+        block_0_0_0->computeVoxelIndexFromCoordinates(test_point);
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 1, 0)));
 
-  EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-      test_point, block->computeCoordinatesFromLinearIndex(linear_index), 0.1));
-  EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-      test_point, block->computeCoordinatesFromVoxelIndex(voxel_index), 0.1));
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+        voxel_index,
+        block_0_0_0->computeVoxelIndexFromLinearIndex(linear_index)));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_0_0_0->computeCoordinatesFromLinearIndex(linear_index),
+        config_.tsdf_voxel_size));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point, block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
+        config_.tsdf_voxel_size));
+  }
+  {
+    // Test Voxel 0 0 0
+    Point test_point(0.0, 0.0, 0.0);
+    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(test_point), nullptr);
+
+    size_t linear_index =
+        block_0_0_0->computeLinearIndexFromCoordinates(test_point);
+    EXPECT_EQ(linear_index, 0u);
+    VoxelIndex voxel_index =
+        block_0_0_0->computeVoxelIndexFromCoordinates(test_point);
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 0, 0)));
+
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+        voxel_index,
+        block_0_0_0->computeVoxelIndexFromLinearIndex(linear_index)));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_0_0_0->computeCoordinatesFromLinearIndex(linear_index),
+        config_.tsdf_voxel_size));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point, block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
+        config_.tsdf_voxel_size));
+  }
+  {
+    // Test Voxel 7 7 7
+    Point test_point(config_.tsdf_voxel_size, config_.tsdf_voxel_size,
+                     config_.tsdf_voxel_size);
+    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(test_point), nullptr);
+
+    size_t linear_index =
+        block_0_0_0->computeLinearIndexFromCoordinates(test_point);
+    EXPECT_EQ(linear_index, block_0_0_0->num_voxels() - 1u);
+    VoxelIndex voxel_index =
+        block_0_0_0->computeVoxelIndexFromCoordinates(test_point);
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index,
+                                   AnyIndex(config_.tsdf_voxels_per_side - 1,
+                                            config_.tsdf_voxels_per_side - 1,
+                                            config_.tsdf_voxels_per_side - 1)));
+
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+        voxel_index,
+        block_0_0_0->computeVoxelIndexFromLinearIndex(linear_index)));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_0_0_0->computeCoordinatesFromLinearIndex(linear_index),
+        config_.tsdf_voxel_size));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point, block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
+        config_.tsdf_voxel_size));
+  }
+  // Test in Block -1 -1 -1
+  {
+    // Test Voxel 0 0 0
+    Point test_point(-config_.tsdf_voxel_size, -config_.tsdf_voxel_size,
+                     -config_.tsdf_voxel_size);
+    EXPECT_NE(block_negative_1_1_1->getVoxelPtrByCoordinates(test_point),
+              nullptr);
+
+    size_t linear_index =
+        block_negative_1_1_1->computeLinearIndexFromCoordinates(test_point);
+    EXPECT_EQ(linear_index, 0u);
+    VoxelIndex voxel_index =
+        block_negative_1_1_1->computeVoxelIndexFromCoordinates(test_point);
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 0, 0)));
+
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+        voxel_index,
+        block_negative_1_1_1->computeVoxelIndexFromLinearIndex(linear_index)));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_negative_1_1_1->computeCoordinatesFromLinearIndex(linear_index),
+        config_.tsdf_voxel_size));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_negative_1_1_1->computeCoordinatesFromVoxelIndex(voxel_index),
+        config_.tsdf_voxel_size));
+  }
+  {
+    // Test Voxel 7 7 7
+    Point test_point(-kEpsilon, -kEpsilon, -kEpsilon);
+    EXPECT_NE(block_negative_1_1_1->getVoxelPtrByCoordinates(test_point),
+              nullptr);
+
+    size_t linear_index =
+        block_negative_1_1_1->computeLinearIndexFromCoordinates(test_point);
+    EXPECT_EQ(linear_index, block_negative_1_1_1->num_voxels() - 1u);
+    VoxelIndex voxel_index =
+        block_negative_1_1_1->computeVoxelIndexFromCoordinates(test_point);
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index,
+                                   AnyIndex(config_.tsdf_voxels_per_side - 1,
+                                            config_.tsdf_voxels_per_side - 1,
+                                            config_.tsdf_voxels_per_side - 1)));
+
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+        voxel_index,
+        block_negative_1_1_1->computeVoxelIndexFromLinearIndex(linear_index)));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_negative_1_1_1->computeCoordinatesFromLinearIndex(linear_index),
+        config_.tsdf_voxel_size));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_negative_1_1_1->computeCoordinatesFromVoxelIndex(voxel_index),
+        config_.tsdf_voxel_size));
+  }
+
+  // Test in Block -1 -1 0
+  {
+    // Test Voxel 3 6 5
+    Point test_point =
+        Point(-4. * config_.tsdf_voxel_size, -2. * config_.tsdf_voxel_size,
+              6. * config_.tsdf_voxel_size);
+    Block<TsdfVoxel>::Ptr block_neg_1_neg_1_0 =
+        map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(test_point);
+    EXPECT_NE(block_neg_1_neg_1_0->getVoxelPtrByCoordinates(test_point),
+              nullptr);
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_neg_1_neg_1_0->origin(),
+                                  Point(-block_size_, -block_size_, 0.0),
+                                  kEpsilon));
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(block_neg_1_neg_1_0->block_index(),
+                                   AnyIndex(-1, -1, 0)));
+    EXPECT_NEAR(block_neg_1_neg_1_0->block_size(), block_size_, kEpsilon);
+
+    size_t linear_index =
+        block_negative_1_1_1->computeLinearIndexFromCoordinates(test_point);
+    EXPECT_EQ(linear_index, 363u);
+    VoxelIndex voxel_index =
+        block_negative_1_1_1->computeVoxelIndexFromCoordinates(test_point);
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(3, 6, 5)));
+
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+        voxel_index,
+        block_negative_1_1_1->computeVoxelIndexFromLinearIndex(linear_index)));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_negative_1_1_1->computeCoordinatesFromLinearIndex(linear_index),
+        config_.tsdf_voxel_size));
+    EXPECT_TRUE(EIGEN_MATRIX_NEAR(
+        test_point,
+        block_negative_1_1_1->computeCoordinatesFromVoxelIndex(voxel_index),
+        config_.tsdf_voxel_size));
+  }
 }
 
 TEST_F(TsdfMapTest, ComputeBlockIndexFromOriginFromBlockIndexTest) {
-
   constexpr size_t kBlockVolumeDiameter = 100u;
   constexpr FloatingPoint kBlockSize = 0.32;
   constexpr FloatingPoint kBlockSizeInv = 1.0 / 0.32;
@@ -82,24 +281,25 @@ TEST_F(TsdfMapTest, ComputeBlockIndexFromOriginFromBlockIndexTest) {
   for (int32_t x = -half_index_range; x <= half_index_range; ++x) {
     for (int32_t y = -half_index_range; y <= half_index_range; ++y) {
       for (int32_t z = -half_index_range; z <= half_index_range; ++z) {
-        BlockIndex block_idx = { x, y, z };
+        BlockIndex block_idx = {x, y, z};
         Point block_origin = getOriginPointFromGridIndex(block_idx, kBlockSize);
-        BlockIndex block_idx_from_origin = getGridIndexFromOriginPoint(
-            block_origin, kBlockSizeInv);
+        BlockIndex block_idx_from_origin =
+            getGridIndexFromPoint(block_origin, kBlockSizeInv);
 
         EXPECT_EQ(block_idx.x(), block_idx_from_origin.x());
         EXPECT_EQ(block_idx.y(), block_idx_from_origin.y());
         EXPECT_EQ(block_idx.z(), block_idx_from_origin.z());
 
-        if ((block_idx.x() != block_idx_from_origin.x())
-            || (block_idx.y() != block_idx_from_origin.y())
-            || (block_idx.z() != block_idx_from_origin.z())) {
+        if ((block_idx.x() != block_idx_from_origin.x()) ||
+            (block_idx.y() != block_idx_from_origin.y()) ||
+            (block_idx.z() != block_idx_from_origin.z())) {
           std::cout << std::endl << std::endl;
           std::cout << "Block idx: " << block_idx.transpose() << std::endl;
           std::cout << "Block origin: " << block_origin.transpose()
-              << std::endl;
+                    << std::endl;
           std::cout << "Block idx after: " << block_idx_from_origin.transpose()
-              << std::endl << std::endl;
+                    << std::endl
+                    << std::endl;
         }
       }
     }

--- a/voxblox/test/test_tsdf_map.cc
+++ b/voxblox/test/test_tsdf_map.cc
@@ -35,9 +35,13 @@ TEST_F(TsdfMapTest, BlockAllocation) {
 
 TEST_F(TsdfMapTest, IndexLookups) {
   // BLOCK 0 0 0  (cordinate at origin)
+  Point point_in_0_0_0(0.0, 0.0, 0.0);
   Block<TsdfVoxel>::Ptr block_0_0_0 =
-      map_->getTsdfLayerPtr()->allocateNewBlockByCoordinates(
-          Point(0.0, 0.0, 0.0));
+      map_->getTsdfLayerPtr()->allocateNewBlockByCoordinates(point_in_0_0_0);
+  ASSERT_TRUE(block_0_0_0.get() != nullptr);
+  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+      map_->getTsdfLayerPtr()->computeBlockIndexFromCoordinates(point_in_0_0_0),
+      AnyIndex(0, 0, 0)));
   EXPECT_TRUE(
       EIGEN_MATRIX_NEAR(block_0_0_0->origin(), Point(0.0, 0.0, 0.0), kEpsilon));
   EXPECT_TRUE(
@@ -45,9 +49,14 @@ TEST_F(TsdfMapTest, IndexLookups) {
   EXPECT_NEAR(block_0_0_0->block_size(), block_size_, kEpsilon);
 
   // BLOCK 0 0 0  (cordinate within block)
+  Point point_in_0_0_0_v2(0.0, config_.tsdf_voxel_size, 0.0);
   Block<TsdfVoxel>::Ptr block_0_0_0_v2 =
-      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(
-          Point(0.0, config_.tsdf_voxel_size, 0.0));
+      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(point_in_0_0_0_v2);
+  ASSERT_TRUE(block_0_0_0_v2.get() != nullptr);
+  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+      map_->getTsdfLayerPtr()->computeBlockIndexFromCoordinates(
+          point_in_0_0_0_v2),
+      AnyIndex(0, 0, 0)));
   EXPECT_EQ(block_0_0_0, block_0_0_0_v2);
   EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_0_0_0_v2->origin(), Point(0.0, 0.0, 0.0),
                                 kEpsilon));
@@ -56,9 +65,13 @@ TEST_F(TsdfMapTest, IndexLookups) {
   EXPECT_NEAR(block_0_0_0_v2->block_size(), block_size_, kEpsilon);
 
   // BLOCK 1 1 1 (coordinate at origin)
+  Point point_in_1_1_1(block_size_, block_size_, block_size_);
   Block<TsdfVoxel>::Ptr block_1_1_1 =
-      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(
-          Point(block_size_, block_size_, block_size_));
+      map_->getTsdfLayerPtr()->allocateNewBlockByCoordinates(point_in_1_1_1);
+  ASSERT_TRUE(block_1_1_1.get() != nullptr);
+  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+      map_->getTsdfLayerPtr()->computeBlockIndexFromCoordinates(point_in_1_1_1),
+      AnyIndex(1, 1, 1)));
   EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_1_1_1->origin(),
                                 Point(block_size_, block_size_, block_size_),
                                 kEpsilon));
@@ -67,9 +80,15 @@ TEST_F(TsdfMapTest, IndexLookups) {
   EXPECT_NEAR(block_1_1_1->block_size(), block_size_, kEpsilon);
 
   // BLOCK 1 1 1 (coordinate within block)
+  Point point_in_1_1_1_v2(block_size_, block_size_ + config_.tsdf_voxel_size,
+                          block_size_);
   Block<TsdfVoxel>::Ptr block_1_1_1_v2 =
-      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(Point(
-          block_size_, block_size_ + config_.tsdf_voxel_size, block_size_));
+      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(point_in_1_1_1_v2);
+  ASSERT_TRUE(block_1_1_1_v2.get() != nullptr);
+  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+      map_->getTsdfLayerPtr()->computeBlockIndexFromCoordinates(
+          point_in_1_1_1_v2),
+      AnyIndex(1, 1, 1)));
   EXPECT_EQ(block_1_1_1, block_1_1_1_v2);
   EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_1_1_1_v2->origin(),
                                 Point(block_size_, block_size_, block_size_),
@@ -79,9 +98,15 @@ TEST_F(TsdfMapTest, IndexLookups) {
   EXPECT_NEAR(block_1_1_1_v2->block_size(), block_size_, kEpsilon);
 
   // BLOCK -1 -1 -1 (coordinate at origin)
+  Point point_in_neg_1_1_1(-block_size_, -block_size_, -block_size_);
   Block<TsdfVoxel>::Ptr block_negative_1_1_1 =
-      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(
-          Point(-block_size_, -block_size_, -block_size_));
+      map_->getTsdfLayerPtr()->allocateNewBlockByCoordinates(
+          point_in_neg_1_1_1);
+  ASSERT_TRUE(block_negative_1_1_1.get() != nullptr);
+  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+      map_->getTsdfLayerPtr()->computeBlockIndexFromCoordinates(
+          point_in_neg_1_1_1),
+      AnyIndex(-1, -1, -1)));
   EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_negative_1_1_1->origin(),
                                 Point(-block_size_, -block_size_, -block_size_),
                                 kEpsilon));
@@ -90,9 +115,16 @@ TEST_F(TsdfMapTest, IndexLookups) {
   EXPECT_NEAR(block_negative_1_1_1->block_size(), block_size_, kEpsilon);
 
   // BLOCK -1 -1 -1 (coordinate within block)
+  Point point_in_neg_1_1_1_v2(
+      -block_size_, -block_size_ + config_.tsdf_voxel_size, -block_size_);
   Block<TsdfVoxel>::Ptr block_negative_1_1_1_v2 =
-      map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(Point(
-          -block_size_, -block_size_ - config_.tsdf_voxel_size, -block_size_));
+      map_->getTsdfLayerPtr()->allocateBlockPtrByCoordinates(
+          point_in_neg_1_1_1_v2);
+  EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+      map_->getTsdfLayerPtr()->computeBlockIndexFromCoordinates(
+          point_in_neg_1_1_1_v2),
+      AnyIndex(-1, -1, -1)));
+  ASSERT_TRUE(block_negative_1_1_1_v2.get() != nullptr);
   EXPECT_EQ(block_negative_1_1_1, block_negative_1_1_1_v2);
   EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_negative_1_1_1_v2->origin(),
                                 Point(-block_size_, -block_size_, -block_size_),
@@ -106,61 +138,64 @@ TEST_F(TsdfMapTest, IndexLookups) {
   // Test in Block 0 0 0
   {
     // Test Voxel 0 1 0
-    Point test_point(0.0, 2. * config_.tsdf_voxel_size, 0.0);
-    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(test_point), nullptr);
+    Point point_in_0_0_0(0.0, 1. * config_.tsdf_voxel_size, 0.0);
+    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(point_in_0_0_0), nullptr);
 
     size_t linear_index =
-        block_0_0_0->computeLinearIndexFromCoordinates(test_point);
+        block_0_0_0->computeLinearIndexFromCoordinates(point_in_0_0_0);
     EXPECT_EQ(linear_index, 8u);
     VoxelIndex voxel_index =
-        block_0_0_0->computeVoxelIndexFromCoordinates(test_point);
+        block_0_0_0->computeVoxelIndexFromCoordinates(point_in_0_0_0);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 1, 0)));
 
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
         voxel_index,
         block_0_0_0->computeVoxelIndexFromLinearIndex(linear_index)));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
+        point_in_0_0_0,
         block_0_0_0->computeCoordinatesFromLinearIndex(linear_index),
         config_.tsdf_voxel_size));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point, block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
+        point_in_0_0_0,
+        block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
         config_.tsdf_voxel_size));
   }
   {
     // Test Voxel 0 0 0
-    Point test_point(0.0, 0.0, 0.0);
-    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(test_point), nullptr);
+    Point point_in_0_0_0(0.0, 0.0, 0.0);
+    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(point_in_0_0_0), nullptr);
 
     size_t linear_index =
-        block_0_0_0->computeLinearIndexFromCoordinates(test_point);
+        block_0_0_0->computeLinearIndexFromCoordinates(point_in_0_0_0);
     EXPECT_EQ(linear_index, 0u);
     VoxelIndex voxel_index =
-        block_0_0_0->computeVoxelIndexFromCoordinates(test_point);
+        block_0_0_0->computeVoxelIndexFromCoordinates(point_in_0_0_0);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 0, 0)));
 
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
         voxel_index,
         block_0_0_0->computeVoxelIndexFromLinearIndex(linear_index)));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
+        point_in_0_0_0,
         block_0_0_0->computeCoordinatesFromLinearIndex(linear_index),
         config_.tsdf_voxel_size));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point, block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
+        point_in_0_0_0,
+        block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
         config_.tsdf_voxel_size));
   }
   {
     // Test Voxel 7 7 7
-    Point test_point(config_.tsdf_voxel_size, config_.tsdf_voxel_size,
-                     config_.tsdf_voxel_size);
-    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(test_point), nullptr);
+    Point point_in_0_0_0(7.0 * config_.tsdf_voxel_size,
+                         7.0 * config_.tsdf_voxel_size,
+                         7.0 * config_.tsdf_voxel_size);
+    EXPECT_NE(block_0_0_0->getVoxelPtrByCoordinates(point_in_0_0_0), nullptr);
 
     size_t linear_index =
-        block_0_0_0->computeLinearIndexFromCoordinates(test_point);
+        block_0_0_0->computeLinearIndexFromCoordinates(point_in_0_0_0);
     EXPECT_EQ(linear_index, block_0_0_0->num_voxels() - 1u);
     VoxelIndex voxel_index =
-        block_0_0_0->computeVoxelIndexFromCoordinates(test_point);
+        block_0_0_0->computeVoxelIndexFromCoordinates(point_in_0_0_0);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index,
                                    AnyIndex(config_.tsdf_voxels_per_side - 1,
                                             config_.tsdf_voxels_per_side - 1,
@@ -170,51 +205,59 @@ TEST_F(TsdfMapTest, IndexLookups) {
         voxel_index,
         block_0_0_0->computeVoxelIndexFromLinearIndex(linear_index)));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
+        point_in_0_0_0,
         block_0_0_0->computeCoordinatesFromLinearIndex(linear_index),
         config_.tsdf_voxel_size));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point, block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
+        point_in_0_0_0,
+        block_0_0_0->computeCoordinatesFromVoxelIndex(voxel_index),
         config_.tsdf_voxel_size));
   }
   // Test in Block -1 -1 -1
   {
     // Test Voxel 0 0 0
-    Point test_point(-config_.tsdf_voxel_size, -config_.tsdf_voxel_size,
-                     -config_.tsdf_voxel_size);
-    EXPECT_NE(block_negative_1_1_1->getVoxelPtrByCoordinates(test_point),
-              nullptr);
+    Point point_in_neg_1_1_1(-block_negative_1_1_1->block_size(),
+                             -block_negative_1_1_1->block_size(),
+                             -block_negative_1_1_1->block_size());
+    EXPECT_NE(
+        block_negative_1_1_1->getVoxelPtrByCoordinates(point_in_neg_1_1_1),
+        nullptr);
 
     size_t linear_index =
-        block_negative_1_1_1->computeLinearIndexFromCoordinates(test_point);
+        block_negative_1_1_1->computeLinearIndexFromCoordinates(
+            point_in_neg_1_1_1);
     EXPECT_EQ(linear_index, 0u);
     VoxelIndex voxel_index =
-        block_negative_1_1_1->computeVoxelIndexFromCoordinates(test_point);
+        block_negative_1_1_1->computeVoxelIndexFromCoordinates(
+            point_in_neg_1_1_1);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 0, 0)));
 
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
         voxel_index,
         block_negative_1_1_1->computeVoxelIndexFromLinearIndex(linear_index)));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
+        point_in_neg_1_1_1,
         block_negative_1_1_1->computeCoordinatesFromLinearIndex(linear_index),
         config_.tsdf_voxel_size));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
+        point_in_neg_1_1_1,
         block_negative_1_1_1->computeCoordinatesFromVoxelIndex(voxel_index),
         config_.tsdf_voxel_size));
   }
   {
     // Test Voxel 7 7 7
-    Point test_point(-kEpsilon, -kEpsilon, -kEpsilon);
-    EXPECT_NE(block_negative_1_1_1->getVoxelPtrByCoordinates(test_point),
-              nullptr);
+    Point point_in_neg_1_1_1(-kEpsilon, -kEpsilon, -kEpsilon);
+    EXPECT_NE(
+        block_negative_1_1_1->getVoxelPtrByCoordinates(point_in_neg_1_1_1),
+        nullptr);
 
     size_t linear_index =
-        block_negative_1_1_1->computeLinearIndexFromCoordinates(test_point);
+        block_negative_1_1_1->computeLinearIndexFromCoordinates(
+            point_in_neg_1_1_1);
     EXPECT_EQ(linear_index, block_negative_1_1_1->num_voxels() - 1u);
     VoxelIndex voxel_index =
-        block_negative_1_1_1->computeVoxelIndexFromCoordinates(test_point);
+        block_negative_1_1_1->computeVoxelIndexFromCoordinates(
+            point_in_neg_1_1_1);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index,
                                    AnyIndex(config_.tsdf_voxels_per_side - 1,
                                             config_.tsdf_voxels_per_side - 1,
@@ -224,11 +267,11 @@ TEST_F(TsdfMapTest, IndexLookups) {
         voxel_index,
         block_negative_1_1_1->computeVoxelIndexFromLinearIndex(linear_index)));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
+        point_in_neg_1_1_1,
         block_negative_1_1_1->computeCoordinatesFromLinearIndex(linear_index),
         config_.tsdf_voxel_size));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
+        point_in_neg_1_1_1,
         block_negative_1_1_1->computeCoordinatesFromVoxelIndex(voxel_index),
         config_.tsdf_voxel_size));
   }
@@ -236,12 +279,18 @@ TEST_F(TsdfMapTest, IndexLookups) {
   // Test in Block -1 -1 0
   {
     // Test Voxel 3 6 5
-    Point test_point =
-        Point(-4. * config_.tsdf_voxel_size, -2. * config_.tsdf_voxel_size,
-              6. * config_.tsdf_voxel_size);
+    Point point_in_neg_1_1_0(-5. * config_.tsdf_voxel_size,
+                             -2. * config_.tsdf_voxel_size,
+                             5. * config_.tsdf_voxel_size);
     Block<TsdfVoxel>::Ptr block_neg_1_neg_1_0 =
-        map_->getTsdfLayerPtr()->getBlockPtrByCoordinates(test_point);
-    EXPECT_NE(block_neg_1_neg_1_0->getVoxelPtrByCoordinates(test_point),
+        map_->getTsdfLayerPtr()->allocateNewBlockByCoordinates(
+            point_in_neg_1_1_0);
+    ASSERT_TRUE(block_neg_1_neg_1_0.get() != nullptr);
+    EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
+        map_->getTsdfLayerPtr()->computeBlockIndexFromCoordinates(
+            point_in_neg_1_1_0),
+        AnyIndex(-1, -1, 0)));
+    EXPECT_NE(block_neg_1_neg_1_0->getVoxelPtrByCoordinates(point_in_neg_1_1_0),
               nullptr);
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(block_neg_1_neg_1_0->origin(),
                                   Point(-block_size_, -block_size_, 0.0),
@@ -251,22 +300,24 @@ TEST_F(TsdfMapTest, IndexLookups) {
     EXPECT_NEAR(block_neg_1_neg_1_0->block_size(), block_size_, kEpsilon);
 
     size_t linear_index =
-        block_negative_1_1_1->computeLinearIndexFromCoordinates(test_point);
-    EXPECT_EQ(linear_index, 363u);
+        block_neg_1_neg_1_0->computeLinearIndexFromCoordinates(
+            point_in_neg_1_1_0);
+    EXPECT_EQ(linear_index, 371u);
     VoxelIndex voxel_index =
-        block_negative_1_1_1->computeVoxelIndexFromCoordinates(test_point);
+        block_neg_1_neg_1_0->computeVoxelIndexFromCoordinates(
+            point_in_neg_1_1_0);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(3, 6, 5)));
 
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
         voxel_index,
-        block_negative_1_1_1->computeVoxelIndexFromLinearIndex(linear_index)));
+        block_neg_1_neg_1_0->computeVoxelIndexFromLinearIndex(linear_index)));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
-        block_negative_1_1_1->computeCoordinatesFromLinearIndex(linear_index),
+        point_in_neg_1_1_0,
+        block_neg_1_neg_1_0->computeCoordinatesFromLinearIndex(linear_index),
         config_.tsdf_voxel_size));
     EXPECT_TRUE(EIGEN_MATRIX_NEAR(
-        test_point,
-        block_negative_1_1_1->computeCoordinatesFromVoxelIndex(voxel_index),
+        point_in_neg_1_1_0,
+        block_neg_1_neg_1_0->computeCoordinatesFromVoxelIndex(voxel_index),
         config_.tsdf_voxel_size));
   }
 }
@@ -274,7 +325,7 @@ TEST_F(TsdfMapTest, IndexLookups) {
 TEST_F(TsdfMapTest, ComputeBlockIndexFromOriginFromBlockIndexTest) {
   constexpr size_t kBlockVolumeDiameter = 100u;
   constexpr FloatingPoint kBlockSize = 0.32;
-  constexpr FloatingPoint kBlockSizeInv = 1.0 / 0.32;
+  constexpr FloatingPoint kBlockSizeInv = 1.0 / kBlockSize;
 
   int32_t half_index_range = kBlockVolumeDiameter / 2;
 
@@ -284,7 +335,7 @@ TEST_F(TsdfMapTest, ComputeBlockIndexFromOriginFromBlockIndexTest) {
         BlockIndex block_idx = {x, y, z};
         Point block_origin = getOriginPointFromGridIndex(block_idx, kBlockSize);
         BlockIndex block_idx_from_origin =
-            getGridIndexFromPoint(block_origin, kBlockSizeInv);
+            getGridIndexFromOriginPoint(block_origin, kBlockSizeInv);
 
         EXPECT_EQ(block_idx.x(), block_idx_from_origin.x());
         EXPECT_EQ(block_idx.y(), block_idx_from_origin.y());
@@ -300,6 +351,7 @@ TEST_F(TsdfMapTest, ComputeBlockIndexFromOriginFromBlockIndexTest) {
           std::cout << "Block idx after: " << block_idx_from_origin.transpose()
                     << std::endl
                     << std::endl;
+          ASSERT_TRUE(false);
         }
       }
     }

--- a/voxblox_ros/include/voxblox_ros/conversions_inl.h
+++ b/voxblox_ros/include/voxblox_ros/conversions_inl.h
@@ -66,6 +66,7 @@ bool deserializeMsgToLayer(const voxblox_msgs::Layer& msg,
     std::vector<uint32_t> data = block_msg.data;
     block_ptr->deserializeFromIntegers(data);
   }
+  CHECK_EQ(layer->getNumberOfAllocatedBlocks(), msg.blocks.size());
 
   return true;
 }

--- a/voxblox_ros/src/simulation_server.cc
+++ b/voxblox_ros/src/simulation_server.cc
@@ -321,7 +321,7 @@ void SimulationServer::visualize() {
 
   if (generate_mesh_) {
     // Generate TSDF GT mesh.
-    MeshIntegrator<TsdfVoxel>::Config mesh_config;
+    MeshIntegratorConfig mesh_config;
     MeshLayer::Ptr mesh(new MeshLayer(tsdf_gt_->block_size()));
     MeshIntegrator<TsdfVoxel> mesh_integrator(mesh_config, tsdf_gt_.get(),
                                               mesh.get());

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -121,7 +121,7 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
         integrator_config, tsdf_map_->getTsdfLayerPtr()));
   }
 
-  MeshIntegrator<TsdfVoxel>::Config mesh_config;
+  MeshIntegratorConfig mesh_config;
   nh_private_.param("mesh_min_weight", mesh_config.min_weight,
                     mesh_config.min_weight);
 

--- a/voxblox_ros/src/visualize_tsdf.cc
+++ b/voxblox_ros/src/visualize_tsdf.cc
@@ -23,7 +23,7 @@
 namespace voxblox {
 class SimpleTsdfVisualizer {
  public:
-  SimpleTsdfVisualizer(const ros::NodeHandle& nh_private)
+  explicit SimpleTsdfVisualizer(const ros::NodeHandle& nh_private)
       : nh_private_(nh_private),
         tsdf_surface_distance_threshold_factor_(2.0),
         tsdf_world_frame_("world"),
@@ -134,7 +134,7 @@ void SimpleTsdfVisualizer::run(const Layer<TsdfVoxel>& tsdf_layer) {
   {
     std::shared_ptr<MeshLayer> mesh_layer;
     mesh_layer.reset(new MeshLayer(tsdf_layer.block_size()));
-    MeshIntegrator<TsdfVoxel>::Config mesh_config;
+    MeshIntegratorConfig mesh_config;
     std::shared_ptr<MeshIntegrator<TsdfVoxel>> mesh_integrator;
     mesh_integrator.reset(new MeshIntegrator<TsdfVoxel>(mesh_config, tsdf_layer,
                                                         mesh_layer.get()));
@@ -157,7 +157,7 @@ void SimpleTsdfVisualizer::run(const Layer<TsdfVoxel>& tsdf_layer) {
 
     // Output as pcl mesh.
     pcl::PolygonMesh polygon_mesh;
-    toPCLPolygonMesh(*mesh_layer, tsdf_world_frame_, &polygon_mesh);
+    toConnectedPCLPolygonMesh(*mesh_layer, tsdf_world_frame_, &polygon_mesh);
     pcl_msgs::PolygonMesh pcl_mesh_msg;
     pcl_conversions::fromPCL(polygon_mesh, pcl_mesh_msg);
     mesh_msg.header.stamp = ros::Time::now();

--- a/voxblox_ros/src/voxblox_eval.cc
+++ b/voxblox_ros/src/voxblox_eval.cc
@@ -224,7 +224,7 @@ void VoxbloxEvaluator::evaluate() {
 
 void VoxbloxEvaluator::visualize() {
   // Generate the mesh.
-  MeshIntegrator<TsdfVoxel>::Config mesh_config;
+  MeshIntegratorConfig mesh_config;
   mesh_layer_.reset(new MeshLayer(tsdf_layer_->block_size()));
   mesh_integrator_.reset(new MeshIntegrator<TsdfVoxel>(
       mesh_config, tsdf_layer_.get(), mesh_layer_.get()));

--- a/voxblox_ros/src/voxblox_node.cc
+++ b/voxblox_ros/src/voxblox_node.cc
@@ -412,7 +412,7 @@ VoxbloxNode::VoxbloxNode(const ros::NodeHandle& nh,
     color_mode_ = ColorMode::kGray;
   }
 
-  MeshIntegrator<TsdfVoxel>::Config mesh_config;
+  MeshIntegratorConfig mesh_config;
   nh_private_.param("mesh_min_weight", mesh_config.min_weight,
                     mesh_config.min_weight);
 
@@ -813,7 +813,7 @@ bool VoxbloxNode::generateMeshCallback(
 
   if (output_mesh_as_pcl_mesh_) {
     pcl::PolygonMesh polygon_mesh;
-    toPCLPolygonMesh(*mesh_layer_, world_frame_, &polygon_mesh);
+    toConnectedPCLPolygonMesh(*mesh_layer_, world_frame_, &polygon_mesh);
     pcl_msgs::PolygonMesh mesh_msg;
     pcl_conversions::fromPCL(polygon_mesh, mesh_msg);
     mesh_msg.header.stamp = ros::Time::now();

--- a/voxblox_tango_interface/test/mesh_tango_tsdf.cc
+++ b/voxblox_tango_interface/test/mesh_tango_tsdf.cc
@@ -26,7 +26,7 @@ int main(int argc, char** argv) {
   LOG(INFO) << "Layer voxels per side: " << layer_from_file->voxels_per_side();
 
   // Mesh accessories.
-  MeshIntegrator<TsdfVoxel>::Config mesh_config;
+  MeshIntegratorConfig mesh_config;
   std::shared_ptr<MeshLayer> mesh_layer_;
   std::unique_ptr<MeshIntegrator<TsdfVoxel> > mesh_integrator_;
 
@@ -37,7 +37,8 @@ int main(int argc, char** argv) {
   constexpr bool only_mesh_updated_blocks = false;
   constexpr bool clear_updated_flag = true;
   mesh_integrator_->generateMesh(only_mesh_updated_blocks, clear_updated_flag);
-  LOG(INFO) << "Number of meshes: " << mesh_layer_->getNumberOfAllocatedMeshes();
+  LOG(INFO) << "Number of meshes: "
+            << mesh_layer_->getNumberOfAllocatedMeshes();
   const bool mesh_success = outputMeshLayerAsPly(argv[2], *mesh_layer_);
 
   if (mesh_success == false) {


### PR DESCRIPTION
First of all: Sorry about the huge PR...
Second: big thanks to @ffurrer for his help with these fixes!

Changes:
 - More thorough unit testing for the indexing functions
 - Fix center voxel layer functions and their unit tests
 - Fix naming of the layer merging/transformation/interpolation logic
 - Move the mesh intergrator config out of the integrator to make it independent of the template
 - Make the mesh class more general and support normals
 - Fix bug in meshing
    - Corner case in zero crossing interpolation when the sdf values of two voxels are very close
    - Meshing at block boundaries. 
 - write vertex normals and alpha to PLY
 - fix some compilation warnings
 - Add additional functions to compare two layers, including an error layer output:
![cow_optimized](https://user-images.githubusercontent.com/5071588/37213191-8f749098-23b1-11e8-96b3-7ea30d864271.gif)
![scene](https://user-images.githubusercontent.com/5071588/37227888-01f3eaa6-23df-11e8-9e66-dd26778114b9.gif)
*Results of evaluating the alignment of two TSDF layers (cyan and magenta), TSDF errors of the overlapping voxels are visualized using colored points (red = high error, green = low error)* 

 - fix the TSDF visualization such that the user can specify the SDF range that is visualized (e.g. only close to surface within some threshold, and the colors are mapped correctly from - to + truncation distance) the rainbow colors only go from red to blue and green is actually at the zero crossing, not cyan.
![image](https://user-images.githubusercontent.com/5071588/37218394-920f0464-23c0-11e8-8054-92cb1afca4f9.png)
*Visualization of the TSDF field, white dots represent the extracted surface, colored dots the TSDF values of the grid within a adjustable range around the surface (otherwise the pointclouds get to large)*

 - refactor and fix getConnectedMesh function that was suffering from integer overflows:
![get_connected_mesh_after_bugfix](https://user-images.githubusercontent.com/5071588/37224405-9c8a172c-23d3-11e8-8590-02d4a5a29295.png)
*Meshes resulting from getConnectedMesh before and after bugfix. Even though the bug was there in the implementation in master, there it only showed up at certain voxel sizes. The refactoring of the combineMesh() function made it more apparent, because the vertex similarity threshold was chosen much tighter.*
