### PR TITLE
Mark hallucinated voxels from addNewRobotPosition.

### DIFF
--- a/voxblox/include/voxblox/core/voxel.h
+++ b/voxblox/include/voxblox/core/voxel.h
@@ -24,6 +24,9 @@ struct EsdfVoxel {
   bool observed = false;
   bool in_queue = false;
   bool fixed = false;
+  // Whether the voxel was copied from the TSDF (false) or created from a pose
+  // or some other source (true).
+  bool hallucinated = false;
   // Relative direction toward parent. If itself, then either uninitialized
   // or in the fixed frontier.
   Eigen::Vector3i parent = Eigen::Vector3i::Zero();

--- a/voxblox/include/voxblox/core/voxel.h
+++ b/voxblox/include/voxblox/core/voxel.h
@@ -25,7 +25,7 @@ struct EsdfVoxel {
   bool in_queue = false;
   bool fixed = false;
   // Whether the voxel was copied from the TSDF (false) or created from a pose
-  // or some other source (true).
+  // or some other source (true). This member is not serialized!!!
   bool hallucinated = false;
   // Relative direction toward parent. If itself, then either uninitialized
   // or in the fixed frontier.

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -51,7 +51,9 @@ class EsdfIntegrator {
                  Layer<EsdfVoxel>* esdf_layer);
 
   // Used for planning - allocates sphere around as observed but occupied,
-  // and clears space in a sphere around current position.
+  // and clears space in a smaller sphere around current position.
+  // Points added this way are marked as "hallucinated," and can subsequently
+  // be cleared based on this.
   void addNewRobotPosition(const Point& position);
 
   // Update from a TSDF layer in batch, clearing the current ESDF layer in the

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -65,9 +65,11 @@ void EsdfIntegrator::addNewRobotPosition(const Point& position) {
         continue;
       }
       EsdfVoxel& esdf_voxel = block_ptr->getVoxelByVoxelIndex(voxel_index);
-      if (!esdf_voxel.observed) {
+      // We can clear unobserved or hallucinated voxels.
+      if (!esdf_voxel.observed || esdf_voxel.hallucinated) {
         esdf_voxel.distance = config_.default_distance_m;
         esdf_voxel.observed = true;
+        esdf_voxel.hallucinated = true;
         pushNeighborsToOpen(kv.first, voxel_index);
         updated_blocks_.insert(kv.first);
       }
@@ -91,6 +93,7 @@ void EsdfIntegrator::addNewRobotPosition(const Point& position) {
       if (!esdf_voxel.observed) {
         esdf_voxel.distance = -config_.default_distance_m;
         esdf_voxel.observed = true;
+        esdf_voxel.hallucinated = true;
         pushNeighborsToOpen(kv.first, voxel_index);
         updated_blocks_.insert(kv.first);
       }
@@ -264,6 +267,8 @@ void EsdfIntegrator::updateFromTsdfBlocks(const BlockIndexList& tsdf_blocks,
       }
 
       EsdfVoxel& esdf_voxel = esdf_block->getVoxelByLinearIndex(lin_index);
+      // This voxel definitely exists in the real map.
+      esdf_voxel.hallucinated = false;
       VoxelIndex voxel_index =
           esdf_block->computeVoxelIndexFromLinearIndex(lin_index);
       // Check for frontier voxels.


### PR DESCRIPTION
This fixes the issue that we can't start voxblox mapping while the drone is on the ground, and then its current position is marked as occupied in the map.
Now, all voxels added to the ESDF within the bounding spheres for marking unknown space as either occupied or free are marked as "hallucinated". This allows them to be cleared by future calls to addNewRobotPosition, making sure that the current pose of the drone, even if never observed, is always considered free. (If observed, of course, this takes priority).

As a note, the hallucination status isn't serialized, (1) because I don't think it's necessary to serialize and (2) because it's hard to do that without breaking back-compatibility. Then again if no one other than me serializes ESDFs....