### PR TITLE
fix stack overflow

### DIFF
--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -69,7 +69,7 @@ class ApproxHashSet {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  ApproxHashSet() : offset_(0) {
+  ApproxHashSet() : offset_(0), pseudo_set_(pseudo_set_size_) {
     for (std::atomic<size_t>& value : pseudo_set_) {
       value.store(0, std::memory_order_relaxed);
     }
@@ -133,9 +133,9 @@ class ApproxHashSet {
 
   // If unmasked_bits is large, the array takes a lot of memory, this makes
   // clearing it slow.
-  // However offsetting which bin hashes are placed into have the same effect.
-  // Once we run out of room to offset by (determined by full_reset_threshold we
-  // clear the memory).
+  // However offsetting which bin hashes are placed into has the same effect.
+  // Once we run out of room to offset by (determined by full_reset_threshold)
+  // we clear the memory).
   // This function is not thread safe.
   void resetApproxSet() {
     if (++offset_ >= full_reset_threshold) {
@@ -158,7 +158,7 @@ class ApproxHashSet {
   static constexpr size_t bit_mask_ = (1 << unmasked_bits) - 1;
 
   size_t offset_;
-  std::array<std::atomic<size_t>, pseudo_set_size_> pseudo_set_;
+  std::vector<std::atomic<size_t>> pseudo_set_;
 
   AnyIndexHash hasher_;
 };


### PR DESCRIPTION
The fast integrator works by creating a really really large array it can use to (approximately) find if a voxel has already been seen. Previously it created two 8 mb arrays on the stack and in some situations (surprisingly not all) this was causing a stack overflow. This pr swaps to heap allocation and should allow the fast integrator to be used with maplab.

I need to do some more testing to see if this change will impact performance before merging.