### PR TITLE
adding checks to ensure preconditions

### DIFF
--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -214,7 +214,7 @@ void SimpleTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
                                                const Colors& colors,
                                                const bool freespace_points) {
   timing::Timer integrate_timer("integrate");
-
+  CHECK_EQ(points_C.size(), colors.size());
   ThreadSafeIndex index_getter(points_C.size());
 
   std::list<std::thread> integration_threads;
@@ -277,6 +277,7 @@ void MergedTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
                                                const Colors& colors,
                                                const bool freespace_points) {
   timing::Timer integrate_timer("integrate");
+  CHECK_EQ(points_C.size(), colors.size());
 
   // Pre-compute a list of unique voxels to end on.
   // Create a hashmap: VOXEL INDEX -> index in original cloud.
@@ -518,6 +519,7 @@ void FastTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
                                              const Colors& colors,
                                              const bool freespace_points) {
   timing::Timer integrate_timer("integrate");
+  CHECK_EQ(points_C.size(), colors.size());
 
   integration_start_time_ = std::chrono::steady_clock::now();
 


### PR DESCRIPTION
Some mistake in the calling code to the tsdf integrator (with num points != num colors) resulted in a segfault in voxblox. I therefore added the checks below, because this condition (num points == num colors) is a hard assumption in this part of the code, and leads to the said segfault if violated.