### PR TITLE
Remove mesh color issue at block boundary

### DIFF
--- a/voxblox/include/voxblox/interpolator/interpolator_inl.h
+++ b/voxblox/include/voxblox/interpolator/interpolator_inl.h
@@ -131,7 +131,7 @@ bool Interpolator<VoxelType>::getAdaptiveDistanceAndGradient(
   // If we weren't able to get the original interpolated distance value, then
   // use the computed gradient to estimate what the value should be.
   if (!has_interpolated_distance) {
-    VoxelIndex voxel_index = block_ptr->computeVoxelIndexFromCoordinates(pos);
+    VoxelIndex voxel_index = block_ptr->computeTruncatedVoxelIndexFromCoordinates(pos);
     Point voxel_pos = block_ptr->computeCoordinatesFromVoxelIndex(voxel_index);
 
     Point voxel_offset = pos - voxel_pos;
@@ -153,7 +153,7 @@ bool Interpolator<VoxelType>::setIndexes(const Point& pos,
   if (block_ptr == nullptr) {
     return false;
   }
-  VoxelIndex voxel_index = block_ptr->computeVoxelIndexFromCoordinates(pos);
+  VoxelIndex voxel_index = block_ptr->computeTruncatedVoxelIndexFromCoordinates(pos);
 
   // shift index to bottom left corner voxel (makes math easier)
   Point center_offset =

--- a/voxblox/include/voxblox/utils/planning_utils.h
+++ b/voxblox/include/voxblox/utils/planning_utils.h
@@ -41,7 +41,7 @@ inline void fillSphereAroundPoint(Layer<EsdfVoxel>* layer,
          const Block<EsdfVoxel>::Ptr block_ptr =
              layer->allocateBlockPtrByCoordinates(point);
          const VoxelIndex voxel_index =
-             block_ptr->computeVoxelIndexFromCoordinates(point);
+             block_ptr->computeTruncatedVoxelIndexFromCoordinates(point);
          EsdfVoxel& voxel = block_ptr->getVoxelByVoxelIndex(voxel_index);
          const Point voxel_center =
              block_ptr->computeCoordinatesFromVoxelIndex(voxel_index);
@@ -88,7 +88,7 @@ inline void clearSphereAroundPoint(Layer<EsdfVoxel>* layer,
           const typename Block<EsdfVoxel>::Ptr block_ptr =
               layer->allocateBlockPtrByCoordinates(point);
           const VoxelIndex voxel_index =
-              block_ptr->computeVoxelIndexFromCoordinates(point);
+              block_ptr->computeTruncatedVoxelIndexFromCoordinates(point);
           EsdfVoxel& voxel = block_ptr->getVoxelByVoxelIndex(voxel_index);
           const Point voxel_center =
               block_ptr->computeCoordinatesFromVoxelIndex(voxel_index);

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -39,7 +39,7 @@ void EsdfIntegrator::getSphereAroundPoint(
 
           (*block_voxel_list)[block_index].push_back(
               esdf_layer_->allocateBlockPtrByIndex(block_index)
-                  ->computeVoxelIndexFromCoordinates(point));
+                  ->computeTruncatedVoxelIndexFromCoordinates(point));
         }
       }
     }

--- a/voxblox/test/test_tsdf_map.cc
+++ b/voxblox/test/test_tsdf_map.cc
@@ -145,7 +145,7 @@ TEST_F(TsdfMapTest, IndexLookups) {
         block_0_0_0->computeLinearIndexFromCoordinates(point_in_0_0_0);
     EXPECT_EQ(linear_index, 8u);
     VoxelIndex voxel_index =
-        block_0_0_0->computeVoxelIndexFromCoordinates(point_in_0_0_0);
+        block_0_0_0->computeTruncatedVoxelIndexFromCoordinates(point_in_0_0_0);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 1, 0)));
 
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
@@ -169,7 +169,7 @@ TEST_F(TsdfMapTest, IndexLookups) {
         block_0_0_0->computeLinearIndexFromCoordinates(point_in_0_0_0);
     EXPECT_EQ(linear_index, 0u);
     VoxelIndex voxel_index =
-        block_0_0_0->computeVoxelIndexFromCoordinates(point_in_0_0_0);
+        block_0_0_0->computeTruncatedVoxelIndexFromCoordinates(point_in_0_0_0);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 0, 0)));
 
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(
@@ -195,7 +195,7 @@ TEST_F(TsdfMapTest, IndexLookups) {
         block_0_0_0->computeLinearIndexFromCoordinates(point_in_0_0_0);
     EXPECT_EQ(linear_index, block_0_0_0->num_voxels() - 1u);
     VoxelIndex voxel_index =
-        block_0_0_0->computeVoxelIndexFromCoordinates(point_in_0_0_0);
+        block_0_0_0->computeTruncatedVoxelIndexFromCoordinates(point_in_0_0_0);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index,
                                    AnyIndex(config_.tsdf_voxels_per_side - 1,
                                             config_.tsdf_voxels_per_side - 1,
@@ -228,7 +228,7 @@ TEST_F(TsdfMapTest, IndexLookups) {
             point_in_neg_1_1_1);
     EXPECT_EQ(linear_index, 0u);
     VoxelIndex voxel_index =
-        block_negative_1_1_1->computeVoxelIndexFromCoordinates(
+        block_negative_1_1_1->computeTruncatedVoxelIndexFromCoordinates(
             point_in_neg_1_1_1);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(0, 0, 0)));
 
@@ -256,7 +256,7 @@ TEST_F(TsdfMapTest, IndexLookups) {
             point_in_neg_1_1_1);
     EXPECT_EQ(linear_index, block_negative_1_1_1->num_voxels() - 1u);
     VoxelIndex voxel_index =
-        block_negative_1_1_1->computeVoxelIndexFromCoordinates(
+        block_negative_1_1_1->computeTruncatedVoxelIndexFromCoordinates(
             point_in_neg_1_1_1);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index,
                                    AnyIndex(config_.tsdf_voxels_per_side - 1,
@@ -304,7 +304,7 @@ TEST_F(TsdfMapTest, IndexLookups) {
             point_in_neg_1_1_0);
     EXPECT_EQ(linear_index, 371u);
     VoxelIndex voxel_index =
-        block_neg_1_neg_1_0->computeVoxelIndexFromCoordinates(
+        block_negative_1_1_1->computeTruncatedVoxelIndexFromCoordinates(
             point_in_neg_1_1_0);
     EXPECT_TRUE(EIGEN_MATRIX_EQUAL(voxel_index, AnyIndex(3, 6, 5)));
 


### PR DESCRIPTION
Renamed one block member function and added a new one to compute the voxel index from coordinates which doesn't truncate the result to the [0, voxels_per_side] range. 
The new function, used with Block::isValidVoxelIndex gets rid of the color artifacts at the block boundaries in a mesh.

Before:
![image](https://user-images.githubusercontent.com/2853614/39130805-498b6e78-470e-11e8-9355-0a7db6aa93d9.png)

After:
![image](https://user-images.githubusercontent.com/2853614/39130743-2cc08a12-470e-11e8-92f7-e0561441b773.png)

