### PR TITLE
Fix ESDF voxel serialization

### DIFF
--- a/voxblox/include/voxblox/core/voxel.h
+++ b/voxblox/include/voxblox/core/voxel.h
@@ -21,12 +21,14 @@ struct EsdfVoxel {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   float distance = 0.0f;
+
   bool observed = false;
-  bool in_queue = false;
-  bool fixed = false;
   // Whether the voxel was copied from the TSDF (false) or created from a pose
   // or some other source (true). This member is not serialized!!!
   bool hallucinated = false;
+  bool in_queue = false;
+  bool fixed = false;
+
   // Relative direction toward parent. If itself, then either uninitialized
   // or in the fixed frontier.
   Eigen::Vector3i parent = Eigen::Vector3i::Zero();

--- a/voxblox/include/voxblox/test/layer_test_utils.h
+++ b/voxblox/include/voxblox/test/layer_test_utils.h
@@ -90,14 +90,16 @@ void LayerTest<EsdfVoxel>::CompareVoxel(const EsdfVoxel& voxel_A,
   constexpr double kTolerance = 1e-10;
 
   EXPECT_NEAR(voxel_A.distance, voxel_B.distance, kTolerance);
+
+  // Flags
   EXPECT_EQ(voxel_A.observed, voxel_B.observed);
+  EXPECT_EQ(voxel_A.hallucinated, voxel_B.hallucinated);
   EXPECT_EQ(voxel_A.in_queue, voxel_B.in_queue);
   EXPECT_EQ(voxel_A.fixed, voxel_B.fixed);
 
-  // TODO(helenol): is this not serialized?
-  // EXPECT_EQ(voxel_A.parent.x(), voxel_B.parent.x());
-  // EXPECT_EQ(voxel_A.parent.y(), voxel_B.parent.y());
-  // EXPECT_EQ(voxel_A.parent.z(), voxel_B.parent.z());
+  EXPECT_EQ(voxel_A.parent.x(), voxel_B.parent.x());
+  EXPECT_EQ(voxel_A.parent.y(), voxel_B.parent.y());
+  EXPECT_EQ(voxel_A.parent.z(), voxel_B.parent.z());
 }
 
 template <>
@@ -179,9 +181,9 @@ inline void fillVoxelWithTestData(size_t x, size_t y, size_t z,
                                   EsdfVoxel* voxel) {
   CHECK_NOTNULL(voxel);
   voxel->distance = x * y * 0.66 + z;
-  voxel->parent.x() = x % 255;
-  voxel->parent.y() = y % 255;
-  voxel->parent.z() = z % 255;
+  voxel->parent.x() = x % INT8_MAX;
+  voxel->parent.y() = y % INT8_MAX;
+  voxel->parent.z() = z % INT8_MAX;
 
   voxel->observed = true;
   voxel->in_queue = true;

--- a/voxblox/src/core/block.cc
+++ b/voxblox/src/core/block.cc
@@ -3,31 +3,61 @@
 
 namespace voxblox {
 
-// Hidden serialization helpers:
-uint8_t serializeDirection(const Eigen::Vector3i& dir) {
-  uint8_t data = 0;
-  // [0 0] = 0, [1 0] = -1, [0 1] = 1.
-  uint8_t dir_x = dir.x() == 0 ? 0 : dir.x() > 0 ? 1 : 2;
-  uint8_t dir_y = dir.y() == 0 ? 0 : dir.y() > 0 ? 1 : 2;
-  uint8_t dir_z = dir.z() == 0 ? 0 : dir.z() > 0 ? 1 : 2;
+// Hidden serialization helpers
+void serializeDirection(const Eigen::Vector3i& parent_direction,
+                        uint32_t* data) {
+  CHECK_NOTNULL(data);
+  CHECK_EQ(*data, 0u);
 
-  // Leading 2 bits are 0.
-  data = dir_x << 4 | dir_y << 2 | dir_z;
-  return data;
+  // NOTE: these checks will fail until the TODO below is adressed.
+  DCHECK_GE(parent_direction.x(), INT8_MIN);
+  DCHECK_LE(parent_direction.x(), INT8_MAX);
+
+  DCHECK_GE(parent_direction.y(), INT8_MIN);
+  DCHECK_LE(parent_direction.y(), INT8_MAX);
+
+  DCHECK_GE(parent_direction.z(), INT8_MIN);
+  DCHECK_LE(parent_direction.z(), INT8_MAX);
+
+  // TODO(helenol, mfehr):
+  // Serialization should never change the values, the parent values will either
+  // need to be truncated in the ESDF integrator or we need to use more bytes to
+  // serialize the ESDF voxel.
+  const int8_t parent_direction_x =
+      std::min(INT8_MAX, std::max(parent_direction.x(), INT8_MIN));
+  const int8_t parent_direction_y =
+      std::min(INT8_MAX, std::max(parent_direction.y(), INT8_MIN));
+  const int8_t parent_direction_z =
+      std::min(INT8_MAX, std::max(parent_direction.z(), INT8_MIN));
+
+  // Layout:
+  // | 3x8bit (int8_t) for parent (X,Y,Z) | 8bit ESDF |
+
+  *data |= static_cast<uint32_t>(static_cast<int8_t>(parent_direction_x) << 24);
+  *data |= static_cast<uint32_t>(static_cast<int8_t>(parent_direction_y) << 16);
+  *data |= static_cast<uint32_t>(static_cast<int8_t>(parent_direction_z) << 8);
 }
 
-Eigen::Vector3i deserializeDirection(uint8_t data) {
-  Eigen::Vector3i dir;
-  uint8_t byte_x = data >> 4;
-  uint8_t byte_y = (data >> 2) & (2 | 1);
-  uint8_t byte_z = data & (2 | 1);
+Eigen::Vector3i deserializeDirection(const uint32_t data) {
+  // Layout:
+  // | 3x8bit (int8_t) for parent (X,Y,Z) | 8bit ESDF |
 
-  // [0 0] = 0, [1 0] = -1, [0 1] = 1.
-  dir.x() = byte_x == 0 ? 0 : byte_x == 2 ? -1 : 1;
-  dir.y() = byte_y == 0 ? 0 : byte_y == 2 ? -1 : 1;
-  dir.z() = byte_z == 0 ? 0 : byte_z == 2 ? -1 : 1;
+  Eigen::Vector3i parent_direction;
 
-  return dir;
+  parent_direction.x() = static_cast<int8_t>((data >> 24) & 0x000000FF);
+  parent_direction.y() = static_cast<int8_t>((data >> 16) & 0x000000FF);
+  parent_direction.z() = static_cast<int8_t>((data >> 8) & 0x000000FF);
+
+  DCHECK_GE(parent_direction.x(), INT8_MIN);
+  DCHECK_LE(parent_direction.x(), INT8_MAX);
+
+  DCHECK_GE(parent_direction.y(), INT8_MIN);
+  DCHECK_LE(parent_direction.y(), INT8_MAX);
+
+  DCHECK_GE(parent_direction.z(), INT8_MIN);
+  DCHECK_LE(parent_direction.z(), INT8_MAX);
+
+  return parent_direction;
 }
 
 // Deserialization functions:
@@ -86,6 +116,9 @@ void Block<EsdfVoxel>::deserializeFromIntegers(
   for (size_t voxel_idx = 0u, data_idx = 0u;
        voxel_idx < num_voxels_ && data_idx < num_data_packets;
        ++voxel_idx, data_idx += kNumDataPacketsPerVoxel) {
+    // Layout:
+    // | 32 bit sdf | 3x8bit (int8_t) parent | 8 bit flags|
+
     const uint32_t bytes_1 = data[data_idx];
     const uint32_t bytes_2 = data[data_idx + 1u];
 
@@ -93,11 +126,12 @@ void Block<EsdfVoxel>::deserializeFromIntegers(
 
     memcpy(&(voxel.distance), &bytes_1, sizeof(bytes_1));
 
-    voxel.observed = static_cast<bool>(bytes_2 & 0x000000FF);
-    voxel.in_queue = static_cast<bool>(bytes_2 & 0x0000FF00);
-    voxel.fixed = static_cast<bool>(bytes_2 & 0x00FF0000);
-    voxel.parent =
-        deserializeDirection(static_cast<uint8_t>(bytes_2 & 0xFF000000));
+    voxel.observed = static_cast<bool>(bytes_2 & 0x00000001);
+    voxel.hallucinated = static_cast<bool>((bytes_2 & 0x00000002));
+    voxel.in_queue = static_cast<bool>((bytes_2 & 0x00000004));
+    voxel.fixed = static_cast<bool>((bytes_2 & 0x00000008));
+
+    voxel.parent = deserializeDirection(bytes_2);
   }
 }
 
@@ -155,23 +189,26 @@ void Block<EsdfVoxel>::serializeToIntegers(std::vector<uint32_t>* data) const {
   for (size_t voxel_idx = 0u; voxel_idx < num_voxels_; ++voxel_idx) {
     const EsdfVoxel& voxel = voxels_[voxel_idx];
 
+    // Current Layout:
+    // | 32 bit sdf | 3x8bit (int8_t) parent | 8 bit flags|
+
     const uint32_t* bytes_1_ptr =
         reinterpret_cast<const uint32_t*>(&voxel.distance);
     data->push_back(*bytes_1_ptr);
-    // Repack this as a bunch of bools. Could also pack into a since uint8_t
-    // to save space, but this maybe simpler.
-    // observed is byte 1, in_queue is byte 2, fixed is byte 3,
-    // then direction is packed into byte 4.
-    uint8_t byte1 = voxel.observed;
-    uint8_t byte2 = voxel.in_queue;
-    uint8_t byte3 = voxel.fixed;
-    // Packing here is a bit more creative. 2 bits per direction.
-    // [0 0] = 0, [1 0] = -1, [0 1] = 1.
-    uint8_t byte4 = serializeDirection(voxel.parent);
-    data->push_back(static_cast<uint32_t>(byte1) |
-                    (static_cast<uint32_t>(byte2) << 8) |
-                    (static_cast<uint32_t>(byte3) << 16) |
-                    (static_cast<uint32_t>(byte4) << 24));
+
+    uint32_t bytes_2 = 0u;
+    serializeDirection(voxel.parent, &bytes_2);
+
+    uint8_t flag_byte = 0b00000000;
+    flag_byte |= static_cast<uint8_t>(voxel.observed ? 0b00000001 : 0b00000000);
+    flag_byte |=
+        static_cast<uint8_t>(voxel.hallucinated ? 0b00000010 : 0b00000000);
+    flag_byte |= static_cast<uint8_t>(voxel.in_queue ? 0b00000100 : 0b00000000);
+    flag_byte |= static_cast<uint8_t>(voxel.fixed ? 0b00001000 : 0b00000000);
+
+    bytes_2 |= static_cast<uint32_t>(flag_byte) & 0x000000FF;
+
+    data->push_back(bytes_2);
   }
   CHECK_EQ(num_voxels_ * kNumDataPacketsPerVoxel, data->size());
 }


### PR DESCRIPTION
This PR fixes the ESDF voxel serialization and makes sure the unit tests actually check it.

There is one issue remaining. The current serialization of the ESDF voxel is truncating the parent member of the voxel to the range of `int8_t`. The ESDF integrator however does not respect that range, hence, data will be lost during serialization. There are two options to solve this. Change the integrator or  expand the ESDF serialization to cover the full integer range.