### PR TITLE
Change log output to not trigger log parser error

### DIFF
--- a/voxblox/include/voxblox/utils/evaluation_utils.h
+++ b/voxblox/include/voxblox/utils/evaluation_utils.h
@@ -36,8 +36,8 @@ struct VoxelEvaluationDetails {
        << " num overlapping voxels:     " << num_overlapping_voxels << "\n"
        << " num non-overlapping voxels: " << num_non_overlapping_voxels << "\n"
        << " num ignored voxels:         " << num_ignored_voxels << "\n"
-       << " min error:                  " << min_error << "\n"
-       << " max error:                  " << max_error << "\n"
+       << " min-error:                  " << min_error << "\n"
+       << " max-error:                  " << max_error << "\n"
        << " RMSE:                       " << rmse << "\n"
        << "========================================\n";
     return ss.str();

--- a/voxblox/include/voxblox/utils/evaluation_utils.h
+++ b/voxblox/include/voxblox/utils/evaluation_utils.h
@@ -36,8 +36,8 @@ struct VoxelEvaluationDetails {
        << " num overlapping voxels:     " << num_overlapping_voxels << "\n"
        << " num non-overlapping voxels: " << num_non_overlapping_voxels << "\n"
        << " num ignored voxels:         " << num_ignored_voxels << "\n"
-       << " min-error:                  " << min_error << "\n"
-       << " max-error:                  " << max_error << "\n"
+       << " error min:                  " << min_error << "\n"
+       << " error max:                  " << max_error << "\n"
        << " RMSE:                       " << rmse << "\n"
        << "========================================\n";
     return ss.str();


### PR DESCRIPTION
The voxblox jenkins job was not failing if the log parser picked up an error. For example if any unit tests segfaulted, this probably didn't lead to a failed build. Only if the compilation failed or a unit test terminated with FAILED. When I enabled the check it turns out that two lines of some log output I generated triggers the log parser, so I had to modify it slightly. 

[Here](https://github.com/ethz-asl/continuous_integration/blob/master/logparser_rules) is a link to the log parser rules