### PR TITLE
switch to DECO hashing

### DIFF
--- a/voxblox/include/voxblox/core/block_hash.h
+++ b/voxblox/include/voxblox/core/block_hash.h
@@ -15,13 +15,11 @@ namespace voxblox {
 struct AnyIndexHash {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  static constexpr size_t prime1 = 73856093;
-  static constexpr size_t prime2 = 19349663;
-  static constexpr size_t prime3 = 83492791;
+  static constexpr size_t sl = 17191;
+  static constexpr size_t sl2 = sl*sl;
 
   std::size_t operator()(const AnyIndex& index) const {
-    return (static_cast<unsigned int>(index.x()) * prime1 ^ index.y() * prime2 ^
-            index.z() * prime3);
+    return static_cast<unsigned int>(index.x() + index.y()*sl + index.z()*sl2);
   }
 };
 
@@ -49,13 +47,11 @@ typedef typename HierarchicalIndexMap::value_type HierarchicalIndex;
 struct LongIndexHash {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  static constexpr size_t prime1 = 73856093;
-  static constexpr size_t prime2 = 19349663;
-  static constexpr size_t prime3 = 83492791;
+  static constexpr size_t sl = 17191;
+  static constexpr size_t sl2 = sl*sl;
 
   std::size_t operator()(const LongIndex& index) const {
-    return (static_cast<unsigned int>(index.x()) * prime1 ^ index.y() * prime2 ^
-            index.z() * prime3);
+    return static_cast<unsigned int>(index.x() + index.y()*sl + index.z()*sl2);
   }
 };
 

--- a/voxblox/include/voxblox/core/block_hash.h
+++ b/voxblox/include/voxblox/core/block_hash.h
@@ -16,10 +16,11 @@ struct AnyIndexHash {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   static constexpr size_t sl = 17191;
-  static constexpr size_t sl2 = sl*sl;
+  static constexpr size_t sl2 = sl * sl;
 
   std::size_t operator()(const AnyIndex& index) const {
-    return static_cast<unsigned int>(index.x() + index.y()*sl + index.z()*sl2);
+    return static_cast<unsigned int>(index.x() + index.y() * sl +
+                                     index.z() * sl2);
   }
 };
 
@@ -48,10 +49,11 @@ struct LongIndexHash {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   static constexpr size_t sl = 17191;
-  static constexpr size_t sl2 = sl*sl;
+  static constexpr size_t sl2 = sl * sl;
 
   std::size_t operator()(const LongIndex& index) const {
-    return static_cast<unsigned int>(index.x() + index.y()*sl + index.z()*sl2);
+    return static_cast<unsigned int>(index.x() + index.y() * sl +
+                                     index.z() * sl2);
   }
 };
 
@@ -65,11 +67,9 @@ struct LongIndexHashMapType {
       type;
 };
 
-
 typedef std::unordered_set<LongIndex, LongIndexHash, std::equal_to<LongIndex>,
                            Eigen::aligned_allocator<LongIndex> >
     LongIndexSet;
-
 
 }  // namespace voxblox
 


### PR DESCRIPTION
I have a google scholar alert setup for papers about TSDFs and it suggested [this](https://www.researchgate.net/profile/Leonie_Buckley/publication/327117558_Investigating_the_impact_of_Suboptimal_Hashing_Functions/links/5b7ac2254585151fd1228802/Investigating-the-impact-of-Suboptimal-Hashing-Functions.pdf)  paper to me today.

The paper claims that the simplest hashing scheme imaginable actually beats XOR hashing in every metric. I thought there was no way it could be true, but it was a super quick change so tried it out in voxblox

cow and lady XOR hashing:
integrate/fast             2700 42.611443       (00.015782 +- 00.003119)        [00.005790,00.029168]
cow and lady DECO hashing:
integrate/fast             2699 40.275292       (00.014922 +- 00.002926)        [00.005420,00.029245]

basement XOR hashing:
integrate/fast             1375 06.608367       (00.004806 +- 00.000436)        [00.002522,00.009713]
basement DECO hashing:
integrate/fast             1376 06.139858       (00.004462 +- 00.000367)        [00.002469,00.008745]

It is noticeably faster in both datasets. They don't give their side length in the paper so I just grabbed an arbitrary prime that I thought would work.
