### PR TITLE
remove check

### DIFF
--- a/voxblox/include/voxblox/mesh/mesh_utils.h
+++ b/voxblox/include/voxblox/mesh/mesh_utils.h
@@ -172,10 +172,6 @@ inline void createConnectedMesh(
   if (connected_mesh->hasNormals()) {
     CHECK_EQ(connected_mesh->vertices.size(), connected_mesh->normals.size());
   }
-
-  // The number of vertices should now be less or equal the amount of triangle
-  // indices, since we merged some of the vertices.
-  CHECK_LE(connected_mesh->vertices.size(), connected_mesh->indices.size());
 }
 
 inline void createConnectedMesh(


### PR DESCRIPTION
The check can fail for valid meshes. The connection process may result in a triangle using the same vertex for two of its corners, in this case the triangle indices are removed but not the vertex. This can result in more vertices than indices. This situation generally only occurs on meshs that have only one triangle meshed and it is in an extreme corner.