### PR TITLE
Simulation, clearing sphere, and ESDF fixes

### DIFF
--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -111,50 +111,50 @@ add_custom_command(TARGET test_data
 
 #add_definitions(-DVISUALIZE_UNIT_TEST_RESULTS)
 
-# catkin_add_gtest(test_approx_hash_array
-#   test/test_approx_hash_array.cc
-# )
-# target_link_libraries(test_approx_hash_array ${PROJECT_NAME})
+catkin_add_gtest(test_approx_hash_array
+  test/test_approx_hash_array.cc
+)
+target_link_libraries(test_approx_hash_array ${PROJECT_NAME})
 
-# catkin_add_gtest(test_tsdf_map
-#   test/test_tsdf_map.cc
-# )
-# target_link_libraries(test_tsdf_map ${PROJECT_NAME})
+catkin_add_gtest(test_tsdf_map
+  test/test_tsdf_map.cc
+)
+target_link_libraries(test_tsdf_map ${PROJECT_NAME})
 
-# catkin_add_gtest(test_protobuf
-#   test/test_protobuf.cc
-# )
-# target_link_libraries(test_protobuf ${PROJECT_NAME})
+catkin_add_gtest(test_protobuf
+  test/test_protobuf.cc
+)
+target_link_libraries(test_protobuf ${PROJECT_NAME})
 
-# catkin_add_gtest(test_tsdf_interpolator
-#   test/test_tsdf_interpolator.cc
-# )
-# target_link_libraries(test_tsdf_interpolator ${PROJECT_NAME})
+catkin_add_gtest(test_tsdf_interpolator
+  test/test_tsdf_interpolator.cc
+)
+target_link_libraries(test_tsdf_interpolator ${PROJECT_NAME})
 
-# catkin_add_gtest(test_layer
-#   test/test_layer.cc
-# )
-# target_link_libraries(test_layer ${PROJECT_NAME})
+catkin_add_gtest(test_layer
+  test/test_layer.cc
+)
+target_link_libraries(test_layer ${PROJECT_NAME})
 
-# catkin_add_gtest(test_merge_integration
-#   test/test_merge_integration.cc
-# )
-# target_link_libraries(test_merge_integration ${PROJECT_NAME} ${catkin_LIBRARIES})
+catkin_add_gtest(test_merge_integration
+  test/test_merge_integration.cc
+)
+target_link_libraries(test_merge_integration ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-# catkin_add_gtest(test_layer_utils
-#  test/test_layer_utils.cc
-# )
-# target_link_libraries(test_layer_utils ${PROJECT_NAME})
+catkin_add_gtest(test_layer_utils
+ test/test_layer_utils.cc
+)
+target_link_libraries(test_layer_utils ${PROJECT_NAME})
 
-# catkin_add_gtest(test_sdf_integrators
-#   test/test_sdf_integrators.cc
-# )
-# target_link_libraries(test_sdf_integrators ${PROJECT_NAME})
+catkin_add_gtest(test_sdf_integrators
+  test/test_sdf_integrators.cc
+)
+target_link_libraries(test_sdf_integrators ${PROJECT_NAME})
 
-# catkin_add_gtest(test_bucket_queue
-#   test/test_bucket_queue.cc
-# )
-# target_link_libraries(test_bucket_queue ${PROJECT_NAME})
+catkin_add_gtest(test_bucket_queue
+  test/test_bucket_queue.cc
+)
+target_link_libraries(test_bucket_queue ${PROJECT_NAME})
 
 catkin_add_gtest(test_clear_spheres
   test/test_clear_spheres.cc

--- a/voxblox/CMakeLists.txt
+++ b/voxblox/CMakeLists.txt
@@ -111,50 +111,55 @@ add_custom_command(TARGET test_data
 
 #add_definitions(-DVISUALIZE_UNIT_TEST_RESULTS)
 
-catkin_add_gtest(test_approx_hash_array
-  test/test_approx_hash_array.cc
-)
-target_link_libraries(test_approx_hash_array ${PROJECT_NAME})
+# catkin_add_gtest(test_approx_hash_array
+#   test/test_approx_hash_array.cc
+# )
+# target_link_libraries(test_approx_hash_array ${PROJECT_NAME})
 
-catkin_add_gtest(test_tsdf_map
-  test/test_tsdf_map.cc
-)
-target_link_libraries(test_tsdf_map ${PROJECT_NAME})
+# catkin_add_gtest(test_tsdf_map
+#   test/test_tsdf_map.cc
+# )
+# target_link_libraries(test_tsdf_map ${PROJECT_NAME})
 
-catkin_add_gtest(test_protobuf
-  test/test_protobuf.cc
-)
-target_link_libraries(test_protobuf ${PROJECT_NAME})
+# catkin_add_gtest(test_protobuf
+#   test/test_protobuf.cc
+# )
+# target_link_libraries(test_protobuf ${PROJECT_NAME})
 
-catkin_add_gtest(test_tsdf_interpolator
-  test/test_tsdf_interpolator.cc
-)
-target_link_libraries(test_tsdf_interpolator ${PROJECT_NAME})
+# catkin_add_gtest(test_tsdf_interpolator
+#   test/test_tsdf_interpolator.cc
+# )
+# target_link_libraries(test_tsdf_interpolator ${PROJECT_NAME})
 
-catkin_add_gtest(test_layer
-  test/test_layer.cc
-)
-target_link_libraries(test_layer ${PROJECT_NAME})
+# catkin_add_gtest(test_layer
+#   test/test_layer.cc
+# )
+# target_link_libraries(test_layer ${PROJECT_NAME})
 
-catkin_add_gtest(test_merge_integration
-  test/test_merge_integration.cc
-)
-target_link_libraries(test_merge_integration ${PROJECT_NAME} ${catkin_LIBRARIES})
+# catkin_add_gtest(test_merge_integration
+#   test/test_merge_integration.cc
+# )
+# target_link_libraries(test_merge_integration ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-catkin_add_gtest(test_layer_utils
- test/test_layer_utils.cc
-)
-target_link_libraries(test_layer_utils ${PROJECT_NAME})
+# catkin_add_gtest(test_layer_utils
+#  test/test_layer_utils.cc
+# )
+# target_link_libraries(test_layer_utils ${PROJECT_NAME})
 
-catkin_add_gtest(test_sdf_integrators
-  test/test_sdf_integrators.cc
-)
-target_link_libraries(test_sdf_integrators ${PROJECT_NAME})
+# catkin_add_gtest(test_sdf_integrators
+#   test/test_sdf_integrators.cc
+# )
+# target_link_libraries(test_sdf_integrators ${PROJECT_NAME})
 
-catkin_add_gtest(test_bucket_queue
-  test/test_bucket_queue.cc
+# catkin_add_gtest(test_bucket_queue
+#   test/test_bucket_queue.cc
+# )
+# target_link_libraries(test_bucket_queue ${PROJECT_NAME})
+
+catkin_add_gtest(test_clear_spheres
+  test/test_clear_spheres.cc
 )
-target_link_libraries(test_bucket_queue ${PROJECT_NAME})
+target_link_libraries(test_clear_spheres ${PROJECT_NAME})
 
 ##########
 # EXPORT #

--- a/voxblox/include/voxblox/interpolator/interpolator_inl.h
+++ b/voxblox/include/voxblox/interpolator/interpolator_inl.h
@@ -58,8 +58,7 @@ bool Interpolator<VoxelType>::getGradient(const Point& pos, Point* grad,
     }
   }
   // Scale by correct size.
-  // This is central difference, so it's 2x voxel size between
-  // measurements.
+  // This is central difference, so it's 2x voxel size between measurements.
   *grad /= (2 * block_ptr->voxel_size());
   return true;
 }
@@ -131,7 +130,8 @@ bool Interpolator<VoxelType>::getAdaptiveDistanceAndGradient(
   // If we weren't able to get the original interpolated distance value, then
   // use the computed gradient to estimate what the value should be.
   if (!has_interpolated_distance) {
-    VoxelIndex voxel_index = block_ptr->computeTruncatedVoxelIndexFromCoordinates(pos);
+    VoxelIndex voxel_index =
+        block_ptr->computeTruncatedVoxelIndexFromCoordinates(pos);
     Point voxel_pos = block_ptr->computeCoordinatesFromVoxelIndex(voxel_index);
 
     Point voxel_offset = pos - voxel_pos;
@@ -153,7 +153,8 @@ bool Interpolator<VoxelType>::setIndexes(const Point& pos,
   if (block_ptr == nullptr) {
     return false;
   }
-  VoxelIndex voxel_index = block_ptr->computeTruncatedVoxelIndexFromCoordinates(pos);
+  VoxelIndex voxel_index =
+      block_ptr->computeTruncatedVoxelIndexFromCoordinates(pos);
 
   // shift index to bottom left corner voxel (makes math easier)
   Point center_offset =

--- a/voxblox/include/voxblox/utils/planning_utils_inl.h
+++ b/voxblox/include/voxblox/utils/planning_utils_inl.h
@@ -20,7 +20,7 @@ void getSphereAroundPoint(const Layer<VoxelType>& layer, const Point& center,
 
   const GlobalIndex center_index =
       getGridIndexFromPoint<GlobalIndex>(center, voxel_size_inv);
-  FloatingPoint radius_in_voxels = radius / voxel_size;
+  const FloatingPoint radius_in_voxels = radius / voxel_size;
 
   for (FloatingPoint x = -radius_in_voxels; x <= radius_in_voxels; x++) {
     for (FloatingPoint y = -radius_in_voxels; y <= radius_in_voxels; y++) {

--- a/voxblox/include/voxblox/utils/planning_utils_inl.h
+++ b/voxblox/include/voxblox/utils/planning_utils_inl.h
@@ -18,26 +18,27 @@ void getSphereAroundPoint(const Layer<VoxelType>& layer, const Point& center,
   float voxel_size_inv = 1.0 / layer.voxel_size();
   int voxels_per_side = layer.voxels_per_side();
 
-  for (voxblox::FloatingPoint x = -radius; x <= radius; x += voxel_size) {
-    for (voxblox::FloatingPoint y = -radius; y <= radius; y += voxel_size) {
-      for (voxblox::FloatingPoint z = -radius; z <= radius; z += voxel_size) {
-        Point point(x, y, z);
+  const GlobalIndex center_index =
+      getGridIndexFromPoint<GlobalIndex>(center, voxel_size_inv);
+  FloatingPoint radius_in_voxels = radius / voxel_size;
+
+  for (FloatingPoint x = -radius_in_voxels; x <= radius_in_voxels; x++) {
+    for (FloatingPoint y = -radius_in_voxels; y <= radius_in_voxels; y++) {
+      for (FloatingPoint z = -radius_in_voxels; z <= radius_in_voxels; z++) {
+        Point point_voxel_space(x, y, z);
 
         // check if point is inside the spheres radius
-        if (point.norm() <= radius) {
-          // convert to global coordinate
-          point += center;
-
-          // Get the global voxel index.
-          GlobalIndex global_index =
-              getGridIndexFromPoint<GlobalIndex>(point, voxel_size_inv);
+        if (point_voxel_space.norm() <= radius_in_voxels) {
+          GlobalIndex voxel_offset_index =
+              Eigen::floor(point_voxel_space.array()).cast<LongIndexElement>();
 
           // Get the block and voxel indices from this.
           BlockIndex block_index;
           VoxelIndex voxel_index;
 
           getBlockAndVoxelIndexFromGlobalVoxelIndex(
-              global_index, voxels_per_side, &block_index, &voxel_index);
+              voxel_offset_index + center_index, voxels_per_side, &block_index,
+              &voxel_index);
           (*block_voxel_list)[block_index].push_back(voxel_index);
         }
       }

--- a/voxblox/include/voxblox/utils/planning_utils_inl.h
+++ b/voxblox/include/voxblox/utils/planning_utils_inl.h
@@ -89,6 +89,7 @@ void fillSphereAroundPoint(const Point& center, const FloatingPoint radius,
       if (!voxel.observed || new_distance < voxel.distance) {
         voxel.distance = new_distance;
         voxel.observed = true;
+        voxel.hallucinated = true;
         voxel.fixed = true;
         block_ptr->updated() = true;
         block_ptr->has_data() = true;

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -51,6 +51,7 @@ void EsdfIntegrator::addNewRobotPosition(const Point& position) {
         esdf_voxel.distance = config_.default_distance_m;
         esdf_voxel.observed = true;
         esdf_voxel.hallucinated = true;
+        esdf_voxel.parent.setZero();
         updated_blocks_.insert(kv.first);
       }
     }
@@ -76,12 +77,13 @@ void EsdfIntegrator::addNewRobotPosition(const Point& position) {
         esdf_voxel.distance = -config_.default_distance_m;
         esdf_voxel.observed = true;
         esdf_voxel.hallucinated = true;
+        esdf_voxel.parent.setZero();
         updated_blocks_.insert(kv.first);
-      } /* else if (!esdf_voxel.in_queue) {
-         GlobalIndex global_index = getGlobalVoxelIndexFromBlockAndVoxelIndex(
-             kv.first, voxel_index, voxels_per_side_);
-         open_.push(global_index, esdf_voxel.distance);
-       } */
+      } else if (!esdf_voxel.in_queue) {
+        GlobalIndex global_index = getGlobalVoxelIndexFromBlockAndVoxelIndex(
+            kv.first, voxel_index, voxels_per_side_);
+        open_.push(global_index, esdf_voxel.distance);
+      }
     }
   }
 

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -263,15 +263,7 @@ void EsdfIntegrator::updateFromTsdfBlocks(const BlockIndexList& tsdf_blocks,
             raise_.push(global_index);
             num_raise++;
           }
-        } /* else if (std::abs(tsdf_voxel.distance) >
-                    std::abs(esdf_voxel.distance)) {
-           // ONE more case: if the ESDF is closer to the surface than the TSDF
-           // says it should be.
-           esdf_voxel.distance = tsdf_voxel.distance;
-           esdf_voxel.parent.setZero();
-           raise_.push(global_index);
-           num_raise++;
-         } */
+        }
         // Otherwise we just don't care. Not fixed voxels that match the right
         // sign can be whatever value that they want to be.
       }

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -42,12 +42,6 @@ void EsdfIntegrator::addNewRobotPosition(const Point& position) {
       EsdfVoxel& esdf_voxel = block_ptr->getVoxelByVoxelIndex(voxel_index);
       // We can clear unobserved or hallucinated voxels.
       if (!esdf_voxel.observed || esdf_voxel.hallucinated) {
-        if (esdf_voxel.hallucinated) {
-          // If this was hallucinated before, RAISE its neighbors!
-          GlobalIndex global_index = getGlobalVoxelIndexFromBlockAndVoxelIndex(
-              kv.first, voxel_index, voxels_per_side_);
-          // raise_.push(global_index);
-        }
         esdf_voxel.distance = config_.default_distance_m;
         esdf_voxel.observed = true;
         esdf_voxel.hallucinated = true;
@@ -171,12 +165,6 @@ void EsdfIntegrator::updateFromTsdfBlocks(const BlockIndexList& tsdf_blocks,
       const bool tsdf_fixed = isFixed(tsdf_voxel.distance);
       // If there was nothing there before:
       if (!esdf_voxel.observed) {
-        // Two options: ESDF is in the fixed truncation band, or outside.
-        /* if (esdf_voxel.hallucinated) {
-          raise_.push(global_index);
-          esdf_voxel.distance =
-              signum(tsdf_voxel.distance) * (config_.default_distance_m);
-        } */
         if (tsdf_fixed) {
           // In fixed band, just add and lock it.
           esdf_voxel.distance = tsdf_voxel.distance;
@@ -191,10 +179,10 @@ void EsdfIntegrator::updateFromTsdfBlocks(const BlockIndexList& tsdf_blocks,
           esdf_voxel.fixed = false;
 
           if (incremental) {
-            /* if (updateVoxelFromNeighbors(global_index)) {
+            if (updateVoxelFromNeighbors(global_index)) {
               esdf_voxel.in_queue = true;
               open_.push(global_index, esdf_voxel.distance);
-            } */
+            }
           }
         }
         // No matter what, basically, the parent is reset.

--- a/voxblox/src/simulation/simulation_world.cc
+++ b/voxblox/src/simulation/simulation_world.cc
@@ -69,8 +69,11 @@ void SimulationWorld::getPointcloudFromViewpoint(
   // Calculate transformation between nominal camera view direction and our
   // view direction. Nominal view is positive x direction.
   const Point nominal_view_direction(1.0, 0.0, 0.0);
-  const Rotation ray_rotation(Eigen::Quaternion<FloatingPoint>::FromTwoVectors(
-      nominal_view_direction, view_direction));
+  Eigen::Quaternion<FloatingPoint> rotation_quaternion =
+      Eigen::Quaternion<FloatingPoint>::FromTwoVectors(nominal_view_direction,
+                                                       view_direction);
+  rotation_quaternion.normalize();
+  const Rotation ray_rotation(rotation_quaternion);
 
   // Now actually iterate over all pixels.
   for (int u = -camera_res.x() / 2; u < camera_res.x() / 2; ++u) {

--- a/voxblox/test/test_clear_spheres.cc
+++ b/voxblox/test/test_clear_spheres.cc
@@ -1,0 +1,189 @@
+#include <gtest/gtest.h>
+
+#include "voxblox/core/layer.h"
+#include "voxblox/core/voxel.h"
+#include "voxblox/integrator/esdf_integrator.h"
+#include "voxblox/integrator/tsdf_integrator.h"
+#include "voxblox/io/layer_io.h"
+#include "voxblox/simulation/simulation_world.h"
+#include "voxblox/utils/evaluation_utils.h"
+#include "voxblox/utils/layer_utils.h"
+
+using namespace voxblox;  // NOLINT
+
+DECLARE_bool(alsologtostderr);
+DECLARE_bool(logtostderr);
+DECLARE_int32(v);
+
+class ClearSphereTest : public ::testing::TestWithParam<FloatingPoint> {
+ public:
+  ClearSphereTest()
+      : depth_camera_resolution_(Eigen::Vector2i(320, 240)),
+        fov_h_rad_(2.61799),  // 150 degrees
+        max_dist_(15.0),
+        min_dist_(0.5),
+        voxel_size_(0.10),
+        voxels_per_side_(16) {}
+
+  virtual void SetUp() {
+    voxel_size_ = GetParam();
+
+    // Create a test environment.
+    // It consists of a 10x10x7 m environment with an object in the middle and
+    // walls on the side.
+    Point min_bound(-5.0, -5.0, -1.0);
+    Point max_bound(5.0, 5.0, 6.0);
+    world_.setBounds(min_bound, max_bound);
+    world_.addPlaneBoundaries(-4.0, 4.0, -4.0, 4.0);
+    world_.addGroundLevel(0.0);
+
+    // Next, generate some poses.
+    FloatingPoint radius = 1.0;
+    FloatingPoint height = 2.0;
+    int num_poses = 10;
+    poses_.reserve(num_poses);
+
+    FloatingPoint max_angle = 2 * M_PI;
+
+    FloatingPoint angle_increment = max_angle / num_poses;
+    for (FloatingPoint angle = 0.0; angle < max_angle;
+         angle += angle_increment) {
+      // Generate a transformation to look at the center pose.
+      Point position(radius * sin(angle), radius * cos(angle), height);
+      Point facing_direction(sin(angle), cos(angle), 0.0);
+
+      FloatingPoint desired_yaw = 0.0;
+      if (std::abs(facing_direction.x()) > 1e-4 ||
+          std::abs(facing_direction.y()) > 1e-4) {
+        desired_yaw = atan2(facing_direction.y(), facing_direction.x());
+      }
+
+      // Face the desired yaw and pitch forward a bit to get some of the floor.
+      Quaternion rotation =
+          Quaternion(Eigen::AngleAxis<FloatingPoint>(-0.1, Point::UnitY())) *
+          Eigen::AngleAxis<FloatingPoint>(desired_yaw, Point::UnitZ());
+
+      poses_.emplace_back(Transformation(rotation, position));
+    }
+
+    // Finally, get the GT.
+    tsdf_gt_.reset(new Layer<TsdfVoxel>(voxel_size_, voxels_per_side_));
+    esdf_gt_.reset(new Layer<EsdfVoxel>(voxel_size_, voxels_per_side_));
+
+    truncation_distance_ = 4 * voxel_size_;
+    esdf_max_distance_ = 4.0f;
+
+    LOG(INFO) << "Truncation distance: " << truncation_distance_
+              << " ESDF max distance: " << esdf_max_distance_;
+
+    world_.generateSdfFromWorld(truncation_distance_, tsdf_gt_.get());
+    world_.generateSdfFromWorld(esdf_max_distance_, esdf_gt_.get());
+  }
+
+ protected:
+  SimulationWorld world_;
+
+  // Camera settings
+  Eigen::Vector2i depth_camera_resolution_;
+  FloatingPoint fov_h_rad_;
+  FloatingPoint max_dist_;
+  FloatingPoint min_dist_;
+  int num_viewpoints_;
+
+  // Map settings
+  FloatingPoint voxel_size_;
+  int voxels_per_side_;
+  FloatingPoint truncation_distance_;
+  FloatingPoint esdf_max_distance_;
+
+  // Generated viewpoints
+  AlignedVector<Transformation> poses_;
+
+  // Maps (GT and generates from sensors) generated here.
+  std::unique_ptr<Layer<TsdfVoxel> > tsdf_gt_;
+  std::unique_ptr<Layer<EsdfVoxel> > esdf_gt_;
+};
+
+TEST_P(ClearSphereTest, EsdfIntegrators) {
+  // TSDF layer + integrator
+  TsdfIntegratorBase::Config config;
+  config.default_truncation_distance = truncation_distance_;
+  config.integrator_threads = 1;
+  Layer<TsdfVoxel> tsdf_layer(voxel_size_, voxels_per_side_);
+  MergedTsdfIntegrator tsdf_integrator(config, &tsdf_layer);
+
+  // ESDF layers
+  Layer<EsdfVoxel> esdf_layer(voxel_size_, voxels_per_side_);
+
+  EsdfIntegrator::Config esdf_config;
+  esdf_config.max_distance_m = esdf_max_distance_;
+  esdf_config.default_distance_m = esdf_max_distance_;
+  esdf_config.min_distance_m = truncation_distance_ / 2.0;
+  esdf_config.min_diff_m = 0.0;
+  esdf_config.full_euclidean_distance = false;
+  esdf_config.add_occupied_crust = false;
+  esdf_config.multi_queue = false;
+  esdf_config.clear_sphere_radius = 1.0;
+  esdf_config.occupied_sphere_radius = 4.0;
+  EsdfIntegrator esdf_integrator(esdf_config, &tsdf_layer, &esdf_layer);
+
+  size_t i = 0;
+  Pointcloud ptcloud, ptcloud_C;
+  Colors colors;
+  constexpr bool clear_updated_flag = true;
+
+  // Ok for the first pose... Let's do this one at a time.
+  esdf_integrator.addNewRobotPosition(poses_[i].getPosition());
+
+  // Output for debugging.
+  io::SaveLayer(tsdf_layer, "esdf_clear1a.voxblox", true);
+  io::SaveLayer(esdf_layer, "esdf_clear1a.voxblox", false);
+
+  world_.getPointcloudFromTransform(poses_[i], depth_camera_resolution_,
+                                    fov_h_rad_, max_dist_, &ptcloud, &colors);
+  transformPointcloud(poses_[i].inverse(), ptcloud, &ptcloud_C);
+  tsdf_integrator.integratePointCloud(poses_[i], ptcloud_C, colors);
+
+  // Update the ESDF integrator.
+  esdf_integrator.updateFromTsdfLayer(clear_updated_flag);
+
+  io::SaveLayer(tsdf_layer, "esdf_clear1b.voxblox", true);
+  io::SaveLayer(esdf_layer, "esdf_clear1b.voxblox", false);
+  i = 4;
+
+  esdf_integrator.addNewRobotPosition(poses_[i].getPosition());
+
+  io::SaveLayer(tsdf_layer, "esdf_clear2a.voxblox", true);
+  io::SaveLayer(esdf_layer, "esdf_clear2a.voxblox", false);
+
+  world_.getPointcloudFromTransform(poses_[i], depth_camera_resolution_,
+                                    fov_h_rad_, max_dist_, &ptcloud, &colors);
+  transformPointcloud(poses_[i].inverse(), ptcloud, &ptcloud_C);
+  tsdf_integrator.integratePointCloud(poses_[i], ptcloud_C, colors);
+  esdf_integrator.updateFromTsdfLayer(clear_updated_flag);
+
+  io::SaveLayer(tsdf_layer, "esdf_clear2b.voxblox", true);
+  io::SaveLayer(esdf_layer, "esdf_clear2b.voxblox", false);
+
+  io::SaveLayer(*tsdf_gt_, "esdf_clear_gt.voxblox", true);
+  io::SaveLayer(*esdf_gt_, "esdf_clear_gt.voxblox", false);
+}
+
+INSTANTIATE_TEST_CASE_P(VoxelSizes, ClearSphereTest,
+                        ::testing::Values(0.1f /*, 0.2f, 0.3f, 0.4f, 0.5f*/));
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+  FLAGS_logtostderr = true;
+  FLAGS_alsologtostderr = true;
+  FLAGS_v = 1;
+
+  google::InitGoogleLogging(argv[0]);
+
+  int result = RUN_ALL_TESTS();
+
+  voxblox::timing::Timing::Print(std::cout);
+
+  return result;
+}

--- a/voxblox/test/test_clear_spheres.cc
+++ b/voxblox/test/test_clear_spheres.cc
@@ -207,7 +207,7 @@ TEST_P(ClearSphereTest, EsdfIntegrators) {
 }
 
 INSTANTIATE_TEST_CASE_P(VoxelSizes, ClearSphereTest,
-                        ::testing::Values(0.1f /*, 0.2f*/));
+                        ::testing::Values(0.1f, 0.2f));
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/voxblox/test/test_clear_spheres.cc
+++ b/voxblox/test/test_clear_spheres.cc
@@ -149,13 +149,16 @@ TEST_P(ClearSphereTest, EsdfIntegrators) {
 
   io::SaveLayer(tsdf_layer, "esdf_clear1b.voxblox", true);
   io::SaveLayer(esdf_layer, "esdf_clear1b.voxblox", false);
-  i = 4;
+  i = 2;
 
   esdf_integrator.addNewRobotPosition(poses_[i].getPosition());
 
   io::SaveLayer(tsdf_layer, "esdf_clear2a.voxblox", true);
   io::SaveLayer(esdf_layer, "esdf_clear2a.voxblox", false);
 
+  ptcloud.clear();
+  colors.clear();
+  ptcloud_C.clear();
   world_.getPointcloudFromTransform(poses_[i], depth_camera_resolution_,
                                     fov_h_rad_, max_dist_, &ptcloud, &colors);
   transformPointcloud(poses_[i].inverse(), ptcloud, &ptcloud_C);

--- a/voxblox/test/test_clear_spheres.cc
+++ b/voxblox/test/test_clear_spheres.cc
@@ -207,7 +207,7 @@ TEST_P(ClearSphereTest, EsdfIntegrators) {
 }
 
 INSTANTIATE_TEST_CASE_P(VoxelSizes, ClearSphereTest,
-                        ::testing::Values(0.1f, 0.2f));
+                        ::testing::Values(0.1f /*, 0.2f*/));
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
+++ b/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
@@ -279,7 +279,9 @@ inline bool visualizeOccupiedTsdfVoxels(const TsdfVoxel& voxel,
 inline bool visualizeFreeEsdfVoxels(const EsdfVoxel& voxel,
                                     const Point& /*coord*/, float min_distance,
                                     double* intensity) {
-  if (voxel.observed && voxel.distance >= min_distance) {
+  if (voxel.observed && !voxel.hallucinated && !voxel.fixed &&
+      voxel.parent ==
+          Eigen::Vector3i::Zero()) {  // voxel.distance >= min_distance) {
     *intensity = voxel.distance;
     return true;
   }

--- a/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
+++ b/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
@@ -279,9 +279,7 @@ inline bool visualizeOccupiedTsdfVoxels(const TsdfVoxel& voxel,
 inline bool visualizeFreeEsdfVoxels(const EsdfVoxel& voxel,
                                     const Point& /*coord*/, float min_distance,
                                     double* intensity) {
-  if (voxel.observed && !voxel.hallucinated && !voxel.fixed &&
-      voxel.parent ==
-          Eigen::Vector3i::Zero()) {  // voxel.distance >= min_distance) {
+  if (voxel.observed && voxel.distance >= min_distance) {
     *intensity = voxel.distance;
     return true;
   }

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -119,7 +119,7 @@ inline EsdfIntegrator::Config getEsdfIntegratorConfigFromRosParam(
       getTsdfIntegratorConfigFromRosParam(nh_private);
 
   esdf_integrator_config.min_distance_m =
-      tsdf_integrator_config.default_truncation_distance;
+      tsdf_integrator_config.default_truncation_distance / 2.0;
 
   nh_private.param("esdf_euclidean_distance",
                    esdf_integrator_config.full_euclidean_distance,

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -56,7 +56,7 @@ void EsdfServer::setupRos() {
                     clear_sphere_for_planning_);
   nh_private_.param("publish_esdf_map", publish_esdf_map_, publish_esdf_map_);
 
-  // Special output for traversible voxels. Publishes all voxels with distance
+  // Special output for traversable voxels. Publishes all voxels with distance
   // at least traversibility radius.
   nh_private_.param("publish_traversable", publish_traversable_,
                     publish_traversable_);

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -229,8 +229,7 @@ void EsdfServer::esdfMapCallback(const voxblox_msgs::Layer& layer_msg) {
     ROS_ERROR_THROTTLE(10, "Got an invalid ESDF map message!");
   } else {
     ROS_INFO_ONCE("Got an ESDF map from ROS topic!");
-    publishAllUpdatedEsdfVoxels();
-    publishSlices();
+    publishPointclouds();
   }
 }
 


### PR DESCRIPTION
 - Simulation world no longer crashes in very, very rare cases.
 - Fixed sphere computation to never miss voxels when centered near boundaries.
 - Fix issue https://github.com/ethz-asl/voxblox/issues/224 which was failing to mark hallucinated voxels as such.
 - Clean up visualization a bit in ESDF server.
 - Set default minimum ESDF distance to half truncation distance, which should lead to more accurate results.
 - **Most important**: fix bug with clear spheres which was causing erroneous lines on the border of previously-seen voxels when clearing space.