### PR TITLE
Changes to make submapping possible

### DIFF
--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -260,6 +260,9 @@ class Layer {
   bool saveSubsetToFile(const std::string& file_path,
                         BlockIndexList blocks_to_include,
                         bool include_all_blocks, bool clear_file = true) const;
+  bool saveBlocksToStream(bool include_all_blocks,
+                          BlockIndexList blocks_to_include,
+                          std::fstream* outfile_ptr) const;
   bool addBlockFromProto(const BlockProto& block_proto,
                          BlockMergingStrategy strategy);
 

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -152,6 +152,17 @@ bool Layer<VoxelType>::saveSubsetToFile(const std::string& file_path,
   }
 
   // Serialize blocks.
+  saveBlocksToStream(include_all_blocks, blocks_to_include, &outfile);
+  
+  outfile.close();
+  return true;
+}
+
+template <typename VoxelType>
+bool Layer<VoxelType>::saveBlocksToStream(bool include_all_blocks,
+                                          BlockIndexList blocks_to_include,
+                                          std::fstream* outfile_ptr) const {
+  CHECK_NOTNULL(outfile_ptr);
   for (const BlockMapPair& pair : block_map_) {
     bool write_block_to_file = include_all_blocks;
     if (!write_block_to_file) {
@@ -165,14 +176,12 @@ bool Layer<VoxelType>::saveSubsetToFile(const std::string& file_path,
       BlockProto block_proto;
       pair.second->getProto(&block_proto);
 
-      if (!utils::writeProtoMsgToStream(block_proto, &outfile)) {
+      if (!utils::writeProtoMsgToStream(block_proto, outfile_ptr)) {
         LOG(ERROR) << "Could not write block message.";
-        outfile.close();
         return false;
       }
     }
   }
-  outfile.close();
   return true;
 }
 

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -83,6 +83,8 @@ class TsdfIntegratorBase {
   // Returns a CONST ref of the config.
   const Config& getConfig() const { return config_; }
 
+  void setLayer(Layer<TsdfVoxel>* layer);
+
  protected:
   // Thread safe.
   inline bool isPointValid(const Point& point_C, const bool freespace_point,

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -26,6 +26,12 @@ bool LoadBlocksFromFile(
     typename Layer<VoxelType>::BlockMergingStrategy strategy,
     bool multiple_layer_support, Layer<VoxelType>* layer_ptr);
 
+template <typename VoxelType>
+bool LoadBlocksFromStream(
+    const size_t num_blocks, typename Layer<VoxelType>::BlockMergingStrategy strategy,
+    std::fstream* proto_file_ptr, Layer<VoxelType>* layer_ptr,
+    uint32_t* tmp_byte_offset_ptr);
+
 // Unlike LoadBlocks above, this actually allocates the layer as well.
 // By default loads without multiple layer support (i.e., only checks the first
 // layer in the file).

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -82,19 +82,9 @@ bool LoadBlocksFromFile(
 
     // Read all blocks and add them to the layer.
     const size_t num_blocks = num_protos - 1;
-    for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
-      BlockProto block_proto;
-      if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
-                                         &tmp_byte_offset)) {
-        LOG(ERROR) << "Could not read block protobuf message number "
-                   << block_idx;
-        return false;
-      }
-
-      if (!layer_ptr->addBlockFromProto(block_proto, strategy)) {
-        LOG(ERROR) << "Could not add the block protobuf message to the layer!";
-        return false;
-      }
+    if (!LoadBlocksFromStream(num_blocks, strategy, &proto_file, layer_ptr,
+                              &tmp_byte_offset)) {
+      return false;
     }
   } while (multiple_layer_support && !layer_found && !proto_file.eof());
   return layer_found;
@@ -108,6 +98,30 @@ bool LoadBlocksFromFile(
   constexpr bool multiple_layer_support = false;
   return LoadBlocksFromFile(file_path, strategy, multiple_layer_support,
                             layer_ptr);
+}
+
+template <typename VoxelType>
+bool LoadBlocksFromStream(
+    const size_t num_blocks, typename Layer<VoxelType>::BlockMergingStrategy strategy,
+    std::fstream* proto_file_ptr, Layer<VoxelType>* layer_ptr,
+    uint32_t* tmp_byte_offset_ptr) {
+  CHECK_NOTNULL(layer_ptr);
+  // Read all blocks and add them to the layer.
+  for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
+    BlockProto block_proto;
+    if (!utils::readProtoMsgFromStream(proto_file_ptr, &block_proto,
+                                       tmp_byte_offset_ptr)) {
+      LOG(ERROR) << "Could not read block protobuf message number "
+                 << block_idx;
+      return false;
+    }
+
+    if (!layer_ptr->addBlockFromProto(block_proto, strategy)) {
+      LOG(ERROR) << "Could not add the block protobuf message to the layer!";
+      return false;
+    }
+  }
+  return true;
 }
 
 template <typename VoxelType>
@@ -189,22 +203,10 @@ bool LoadLayer(const std::string& file_path, const bool multiple_layer_support,
 
     // Read all blocks and add them to the layer.
     const size_t num_blocks = num_protos - 1;
-    for (uint32_t block_idx = 0u; block_idx < num_blocks; ++block_idx) {
-      BlockProto block_proto;
-      if (!utils::readProtoMsgFromStream(&proto_file, &block_proto,
-                                         &tmp_byte_offset)) {
-        LOG(ERROR) << "Could not read block protobuf message number "
-                   << block_idx;
-        return false;
-      }
-
-      if (!(*layer_ptr)
-               ->addBlockFromProto(
-                   block_proto,
-                   Layer<VoxelType>::BlockMergingStrategy::kProhibit)) {
-        LOG(ERROR) << "Could not add the block protobuf message to the layer!";
-        return false;
-      }
+    if (!LoadBlocksFromStream(
+            num_blocks, Layer<VoxelType>::BlockMergingStrategy::kProhibit,
+            &proto_file, (*layer_ptr).get(), &tmp_byte_offset)) {
+      return false;
     }
   } while (multiple_layer_support && !layer_found && !proto_file.eof());
   return layer_found;

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -53,13 +53,7 @@ TsdfIntegratorBase::TsdfIntegratorBase(const Config& config,
     : config_(config), layer_(layer) {
   DCHECK(layer_);
 
-  voxel_size_ = layer_->voxel_size();
-  block_size_ = layer_->block_size();
-  voxels_per_side_ = layer_->voxels_per_side();
-
-  voxel_size_inv_ = 1.0 / voxel_size_;
-  block_size_inv_ = 1.0 / block_size_;
-  voxels_per_side_inv_ = 1.0 / voxels_per_side_;
+  setLayer(layer);
 
   if (config_.integrator_threads == 0) {
     LOG(WARNING) << "Automatic core count failed, defaulting to 1 threads";
@@ -69,6 +63,20 @@ TsdfIntegratorBase::TsdfIntegratorBase(const Config& config,
   if (config_.allow_clear && !config_.voxel_carving_enabled) {
     config_.allow_clear = false;
   }
+}
+
+void TsdfIntegratorBase::setLayer(Layer<TsdfVoxel>* layer) {
+  DCHECK(layer);
+
+  layer_ = layer;
+
+  voxel_size_ = layer_->voxel_size();
+  block_size_ = layer_->block_size();
+  voxels_per_side_ = layer_->voxels_per_side();
+
+  voxel_size_inv_ = 1.0 / voxel_size_;
+  block_size_inv_ = 1.0 / block_size_;
+  voxels_per_side_inv_ = 1.0 / voxels_per_side_;
 }
 
 // Thread safe.


### PR DESCRIPTION
Changes are mainly to functions for saving and loading from protofiles. The reason these changes are necessary is that when saving a submap collection we want to be able to write collections of blocks interleaved with submap headers, not just a single collection of blocks.