### PR TITLE
Move out GSM label field

### DIFF
--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -62,13 +62,10 @@ typedef AlignedVector<LongIndex> LongIndexVector;
 typedef LongIndexVector GlobalIndexVector;
 
 struct Color;
-typedef uint32_t Label;
-typedef uint32_t LabelConfidence;
 
 // Pointcloud types for external interface.
 typedef AlignedVector<Point> Pointcloud;
 typedef AlignedVector<Color> Colors;
-typedef AlignedVector<Label> Labels;
 
 // For triangle meshing/vertex access.
 typedef size_t VertexIndex;


### PR DESCRIPTION
Move out the label-related fields from voxblox headers, for them to be declared in GSM headers instead, as for the existing types LabelVoxel, etc.

Makes it easier for GSM developers to modify this types, and also keeps all-label-things in one place.