### PR TITLE
Expose a bunch of integrator settings to improve LIDAR performance.

### DIFF
--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -183,7 +183,7 @@ void TsdfIntegratorBase::updateTsdfVoxel(const Point& origin,
   // Compute updated weight in case we use weight dropoff. It's easier here
   // that in getVoxelWeight as here we have the actual SDF for the voxel
   // already computed.
-  const FloatingPoint dropoff_epsilon = voxel_size_;
+  const FloatingPoint dropoff_epsilon = 0.0;
   if (config_.use_weight_dropoff && sdf < -dropoff_epsilon) {
     updated_weight = weight * (config_.default_truncation_distance + sdf) /
                      (config_.default_truncation_distance - dropoff_epsilon);

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -183,7 +183,7 @@ void TsdfIntegratorBase::updateTsdfVoxel(const Point& origin,
   // Compute updated weight in case we use weight dropoff. It's easier here
   // that in getVoxelWeight as here we have the actual SDF for the voxel
   // already computed.
-  const FloatingPoint dropoff_epsilon = 0.0;
+  const FloatingPoint dropoff_epsilon = voxel_size_;
   if (config_.use_weight_dropoff && sdf < -dropoff_epsilon) {
     updated_weight = weight * (config_.default_truncation_distance + sdf) /
                      (config_.default_truncation_distance - dropoff_epsilon);

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -79,6 +79,8 @@ inline TsdfIntegratorBase::Config getTsdfIntegratorConfigFromRosParam(
   nh_private.param("max_weight", max_weight, max_weight);
   nh_private.param("use_const_weight", integrator_config.use_const_weight,
                    integrator_config.use_const_weight);
+  nh_private.param("use_weight_dropoff", integrator_config.use_weight_dropoff,
+                   integrator_config.use_weight_dropoff);
   nh_private.param("allow_clear", integrator_config.allow_clear,
                    integrator_config.allow_clear);
   nh_private.param("start_voxel_subsampling_factor",
@@ -95,6 +97,12 @@ inline TsdfIntegratorBase::Config getTsdfIntegratorConfigFromRosParam(
                    integrator_config.max_integration_time_s);
   nh_private.param("anti_grazing", integrator_config.enable_anti_grazing,
                    integrator_config.enable_anti_grazing);
+  nh_private.param("use_sparsity_compensation_factor",
+                   integrator_config.use_sparsity_compensation_factor,
+                   integrator_config.use_sparsity_compensation_factor);
+  nh_private.param("sparsity_compensation_factor",
+                   integrator_config.sparsity_compensation_factor,
+                   integrator_config.sparsity_compensation_factor);
   integrator_config.default_truncation_distance =
       static_cast<float>(truncation_distance);
   integrator_config.max_weight = static_cast<float>(max_weight);


### PR DESCRIPTION
Based on feedback that there are issues with laser mapping, most notably:
(1) holes in the ground, and
(2) destroying small objects.

We now expose more parameters and tentatively recommend the following settings for laser mapping:
```
      <param name="method" value="fast" />
      <param name="use_sparsity_compensation_factor" value="true" />
      <param name="sparsity_compensation_factor" value="10.0" />
      <param name="use_const_weight" value="true" />
      <param name="use_weight_dropoff" value="true" />
```

Before, mine dataset, 10 cm voxels:
![image](https://user-images.githubusercontent.com/5616392/53119553-0dff4600-3550-11e9-9b59-4df46f62b4e5.png)

After, same dataset, 10 cm voxels:
![image](https://user-images.githubusercontent.com/5616392/53119644-38e99a00-3550-11e9-834b-8b21f46602d8.png)
