### PR TITLE
Made Interpolator::getVoxelsAndQVector public for use in voxgraph

### DIFF
--- a/voxblox/include/voxblox/interpolator/interpolator.h
+++ b/voxblox/include/voxblox/interpolator/interpolator.h
@@ -38,6 +38,9 @@ class Interpolator {
   bool getNearestDistanceAndWeight(const Point& pos, FloatingPoint* distance,
                                    float* weight) const;
 
+  bool getVoxelsAndQVector(const Point& pos, const VoxelType** voxels,
+                           InterpVector* q_vector) const;
+
  private:
   bool setIndexes(const Point& pos, BlockIndex* block_index,
                   InterpIndexes* voxel_indexes) const;
@@ -52,9 +55,6 @@ class Interpolator {
   bool getVoxelsAndQVector(const BlockIndex& block_index,
                            const InterpIndexes& voxel_indexes, const Point& pos,
                            const VoxelType** voxels,
-                           InterpVector* q_vector) const;
-
-  bool getVoxelsAndQVector(const Point& pos, const VoxelType** voxels,
                            InterpVector* q_vector) const;
 
   bool getInterpDistance(const Point& pos, FloatingPoint* distance) const;


### PR DESCRIPTION
This PR makes voxblox's Interpolator::getVoxelsAndQVector(...) method public.

Having access to the Q-vector entries in other packages allows them to calculate the analytic gradient of an SDF's trilinear interpolation function directly. This is for example useful in [voxgraph](https://github.com/ethz-asl/mbzirc_2020_challenge_3/tree/victorr/voxgraph_mapper/voxgraph), where we use this gradient to register a collection of SDF submaps.