### PR TITLE
Sorting rays for FastTsdfIntegrator

### DIFF
--- a/voxblox/include/voxblox/core/tsdf_map.h
+++ b/voxblox/include/voxblox/core/tsdf_map.h
@@ -26,6 +26,8 @@ class TsdfMap {
 
     FloatingPoint tsdf_voxel_size = 0.2;
     size_t tsdf_voxels_per_side = 16u;
+
+    std::string print() const;
   };
 
   explicit TsdfMap(const Config& config)

--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -18,40 +18,70 @@ namespace voxblox {
 /**
  * Small class that can be used by multiple threads that need mutually exclusive
  * indexes to the same array, while still covering all elements.
- * The class attempts to ensure that the points are read in an order that gives
- * good coverage over the pointcloud very quickly. This is so that the
- * integrator can be terminated before all points have been read (due to time
- * constraints) and still capture most of the geometry.
  */
 class ThreadSafeIndex {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-  explicit ThreadSafeIndex(size_t number_of_points);
 
   /// returns true if index is valid, false otherwise
   bool getNextIndex(size_t* idx);
 
   void reset();
 
- private:
-  size_t getMixedIndex(size_t base_idx);
+ protected:
+  explicit ThreadSafeIndex(size_t number_of_points);
+
+  virtual size_t getNextIndexImpl(size_t base_idx) = 0;
 
   std::atomic<size_t> atomic_idx_;
   const size_t number_of_points_;
+};
+
+/*
+ * The class attempts to ensure that the points are read in an order that gives
+ * good coverage over the pointcloud very quickly. This is so that the
+ * integrator can be terminated before all points have been read (due to time
+ * constraints) and still capture most of the geometry.
+ */
+class MixedThreadSafeIndex : public ThreadSafeIndex {
+ public:
+  explicit MixedThreadSafeIndex(size_t number_of_points);
+
+ protected:
+  virtual size_t getNextIndexImpl(size_t sequential_idx);
+
+ private:
   const size_t number_of_groups_;
 
   /// 1024 bins
   static constexpr size_t num_bits = 10;
   static constexpr size_t step_size_ = 1 << num_bits;
   static constexpr size_t bit_mask_ = step_size_ - 1;
+};
 
-  /**
-   * Lookup table for the order points in a group should be read in. This is
-   * simply a list from 0 to 1023 where each number has had the order of its
-   * bits reversed.
-   */
-  static const std::array<size_t, step_size_> offset_lookup_;
+/*
+ * This class will sort the indices such that the nearest points are integrated
+ * first. This has two favorable effects. First, in case the integration reaches
+ * the time limit, we are more likely to have integratedg geometry in the robots
+ * immediate vacinity, which is more relevant for planning/collision avoidance.
+ * The other reason is that the FastTsdfIntegrator will behave nicer and is less
+ * likely to destroy small features in the geometry.
+ */
+class SortedThreadSafeIndex : public ThreadSafeIndex {
+ public:
+  explicit SortedThreadSafeIndex(const Pointcloud& points_C);
+
+ protected:
+  virtual size_t getNextIndexImpl(size_t sequential_idx);
+
+ private:
+  std::vector<std::pair<size_t, double>> indices_and_squared_norms_;
+};
+
+class ThreadSafeIndexFactory {
+ public:
+  static ThreadSafeIndex* get(const std::string& mode,
+                              const Pointcloud& points_C);
 };
 
 /**

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -66,6 +66,9 @@ class TsdfIntegratorBase {
     bool use_weight_dropoff = true;
     bool use_sparsity_compensation_factor = false;
     float sparsity_compensation_factor = 1.0f;
+
+    bool voxel_carving_ignores_voxels_near_surface = false;
+
     size_t integrator_threads = std::thread::hardware_concurrency();
 
     /// merge integrator specific
@@ -79,6 +82,8 @@ class TsdfIntegratorBase {
     int clear_checks_every_n_frames = 1;
     /// fast integrator specific
     float max_integration_time_s = std::numeric_limits<float>::max();
+
+    std::string print() const;
   };
 
   TsdfIntegratorBase(const Config& config, Layer<TsdfVoxel>* layer);

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -67,8 +67,6 @@ class TsdfIntegratorBase {
     bool use_sparsity_compensation_factor = false;
     float sparsity_compensation_factor = 1.0f;
 
-    bool voxel_carving_ignores_voxels_near_surface = false;
-
     size_t integrator_threads = std::thread::hardware_concurrency();
 
     /// Mode of the ThreadSafeIndex, determines the integration order of the

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -71,6 +71,10 @@ class TsdfIntegratorBase {
 
     size_t integrator_threads = std::thread::hardware_concurrency();
 
+    /// Mode of the ThreadSafeIndex, determines the integration order of the
+    /// rays. Options: "mixed", "sorted"
+    std::string integration_order_mode = "mixed";
+
     /// merge integrator specific
     bool enable_anti_grazing = false;
 

--- a/voxblox/include/voxblox/io/mesh_ply.h
+++ b/voxblox/include/voxblox/io/mesh_ply.h
@@ -46,7 +46,7 @@ bool outputMeshLayerAsPly(const std::string& filename,
                           const MeshLayer& mesh_layer);
 
 /**
- * @param connected_mesh if true veracities will be shared between triangles
+ * @param connected_mesh if true vertices will be shared between triangles
  */
 bool outputMeshLayerAsPly(const std::string& filename,
                           const bool connected_mesh,

--- a/voxblox/include/voxblox/mesh/mesh.h
+++ b/voxblox/include/voxblox/mesh/mesh.h
@@ -59,6 +59,19 @@ struct Mesh {
   inline bool hasTriangles() const { return !indices.empty(); }
 
   inline size_t size() const { return vertices.size(); }
+  inline size_t getMemorySize() const {
+    size_t size_bytes = 0u;
+    size_bytes += sizeof(Pointcloud) + vertices.size() * sizeof(Point);
+    size_bytes += sizeof(Pointcloud) + normals.size() * sizeof(Point);
+    size_bytes += sizeof(Colors) + vertices.size() * sizeof(Color);
+    size_bytes +=
+        sizeof(VertexIndexList) + indices.size() * sizeof(VertexIndex);
+
+    size_bytes += sizeof(block_size);
+    size_bytes += sizeof(origin);
+    size_bytes += sizeof(updated);
+    return size_bytes;
+  }
 
   inline void clear() {
     vertices.clear();

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -49,6 +49,18 @@ struct MeshIntegratorConfig {
   float min_weight = 1e-4;
 
   size_t integrator_threads = std::thread::hardware_concurrency();
+
+  inline std::string print() const {
+    std::stringstream ss;
+    // clang-format off
+    ss << "================== Mesh Integrator Config ====================\n";
+    ss << " - use_color:                 " << use_color << "\n";
+    ss << " - min_weight:                " << min_weight << "\n";
+    ss << " - integrator_threads:        " << integrator_threads << "\n";
+    ss << "==============================================================\n";
+    // clang-format on
+    return ss.str();
+  }
 };
 
 /**

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -145,13 +145,14 @@ class MeshIntegrator {
       mesh_layer_->allocateMeshPtrByIndex(block_index);
     }
 
-    ThreadSafeIndex index_getter(all_tsdf_blocks.size());
+    std::unique_ptr<ThreadSafeIndex> index_getter(
+        new MixedThreadSafeIndex(all_tsdf_blocks.size()));
 
     std::list<std::thread> integration_threads;
     for (size_t i = 0; i < config_.integrator_threads; ++i) {
       integration_threads.emplace_back(
           &MeshIntegrator::generateMeshBlocksFunction, this, all_tsdf_blocks,
-          clear_updated_flag, &index_getter);
+          clear_updated_flag, index_getter.get());
     }
 
     for (std::thread& thread : integration_threads) {

--- a/voxblox/include/voxblox/mesh/mesh_layer.h
+++ b/voxblox/include/voxblox/mesh/mesh_layer.h
@@ -276,6 +276,21 @@ class MeshLayer {
 
   size_t getNumberOfAllocatedMeshes() const { return mesh_map_.size(); }
 
+  inline size_t getMemorySize() const {
+    size_t size_bytes = 0u;
+
+    // Calculate size of members
+    size_bytes += sizeof(block_size_);
+    size_bytes += sizeof(block_size_inv_);
+
+    // Calculate size of mesh blocks
+    for (const auto& idx_mesh_pair : mesh_map_) {
+      CHECK(idx_mesh_pair.second);
+      size_bytes += idx_mesh_pair.second->getMemorySize();
+    }
+    return size_bytes;
+  }
+
   /// Deletes ALL parts of the mesh.
   void clear() { mesh_map_.clear(); }
 

--- a/voxblox/src/core/tsdf_map.cc
+++ b/voxblox/src/core/tsdf_map.cc
@@ -78,4 +78,15 @@ unsigned int TsdfMap::coordPlaneSliceGetDistanceWeight(
   return count;
 }
 
+std::string TsdfMap::Config::print() const {
+  std::stringstream ss;
+  // clang-format off
+  ss << "====================== TSDF Map Config ========================\n";
+  ss << " - tsdf_voxel_size:               " << tsdf_voxel_size << "\n";
+  ss << " - tsdf_voxels_per_side:          " << tsdf_voxels_per_side << "\n";
+  ss << "==============================================================\n";
+  // clang-format on
+  return ss.str();
+}
+
 }  // namespace voxblox

--- a/voxblox/src/integrator/integrator_utils.cc
+++ b/voxblox/src/integrator/integrator_utils.cc
@@ -2,16 +2,39 @@
 
 namespace voxblox {
 
-// Small class that can be used by multiple threads that need mutually exclusive
-// indexes to the same array, while still covering all elements.
-// The class attempts to ensure that the points are read in an order that gives
-// good coverage over the pointcloud very quickly. This is so that the
-// integrator can be terminated before all points have been read (due to time
-// constraints) and still capture most of the geometry.
+ThreadSafeIndex* ThreadSafeIndexFactory::get(const std::string& mode,
+                                             const Pointcloud& points_C) {
+  if (mode == "mixed") {
+    return new MixedThreadSafeIndex(points_C.size());
+  } else if (mode == "sorted") {
+    return new SortedThreadSafeIndex(points_C);
+  } else {
+    LOG(FATAL) << "Unknown integration order mode: '" << mode << "'!";
+  }
+  return nullptr;
+}
+
 ThreadSafeIndex::ThreadSafeIndex(size_t number_of_points)
-    : atomic_idx_(0),
-      number_of_points_(number_of_points),
+    : atomic_idx_(0), number_of_points_(number_of_points) {}
+
+MixedThreadSafeIndex::MixedThreadSafeIndex(size_t number_of_points)
+    : ThreadSafeIndex(number_of_points),
       number_of_groups_(number_of_points / step_size_) {}
+
+SortedThreadSafeIndex::SortedThreadSafeIndex(const Pointcloud& points_C)
+    : ThreadSafeIndex(points_C.size()) {
+  indices_and_squared_norms_.reserve(points_C.size());
+  size_t idx = 0;
+  for (const Point& point_C : points_C) {
+    indices_and_squared_norms_.emplace_back(idx, point_C.squaredNorm());
+    ++idx;
+  }
+
+  std::sort(
+      indices_and_squared_norms_.begin(), indices_and_squared_norms_.end(),
+      [](const std::pair<size_t, double>& a,
+         const std::pair<size_t, double>& b) { return a.second < b.second; });
+}
 
 // returns true if index is valid, false otherwise
 bool ThreadSafeIndex::getNextIndex(size_t* idx) {
@@ -21,117 +44,27 @@ bool ThreadSafeIndex::getNextIndex(size_t* idx) {
   if (sequential_idx >= number_of_points_) {
     return false;
   } else {
-    *idx = getMixedIndex(sequential_idx);
+    *idx = getNextIndexImpl(sequential_idx);
     return true;
   }
 }
 
 void ThreadSafeIndex::reset() { atomic_idx_.store(0); }
 
-size_t ThreadSafeIndex::getMixedIndex(size_t base_idx) {
-  if (number_of_groups_ * step_size_ <= base_idx) {
-    return base_idx;
+size_t MixedThreadSafeIndex::getNextIndexImpl(size_t sequential_idx) {
+  if (number_of_groups_ * step_size_ <= sequential_idx) {
+    return sequential_idx;
   }
 
-  const size_t group_num = base_idx % number_of_groups_;
-  const size_t position_in_group = base_idx / number_of_groups_;
+  const size_t group_num = sequential_idx % number_of_groups_;
+  const size_t position_in_group = sequential_idx / number_of_groups_;
 
   return group_num * step_size_ + position_in_group;
 }
 
-// Lookup table for the order points in a group should be read in. This is
-// simply a list from 0 to 1023 where each number has had the order of its
-// bits reversed.
-// clang-format off
-const std::array<size_t, ThreadSafeIndex::step_size_>
-    ThreadSafeIndex::offset_lookup_ = {
-        {0,   512, 256, 768,  128, 640, 384, 896,  64,  576, 320, 832,
-         192, 704, 448, 960,  32,  544, 288, 800,  160, 672, 416, 928,
-         96,  608, 352, 864,  224, 736, 480, 992,  16,  528, 272, 784,
-         144, 656, 400, 912,  80,  592, 336, 848,  208, 720, 464, 976,
-         48,  560, 304, 816,  176, 688, 432, 944,  112, 624, 368, 880,
-         240, 752, 496, 1008, 8,   520, 264, 776,  136, 648, 392, 904,
-         72,  584, 328, 840,  200, 712, 456, 968,  40,  552, 296, 808,
-         168, 680, 424, 936,  104, 616, 360, 872,  232, 744, 488, 1000,
-         24,  536, 280, 792,  152, 664, 408, 920,  88,  600, 344, 856,
-         216, 728, 472, 984,  56,  568, 312, 824,  184, 696, 440, 952,
-         120, 632, 376, 888,  248, 760, 504, 1016, 4,   516, 260, 772,
-         132, 644, 388, 900,  68,  580, 324, 836,  196, 708, 452, 964,
-         36,  548, 292, 804,  164, 676, 420, 932,  100, 612, 356, 868,
-         228, 740, 484, 996,  20,  532, 276, 788,  148, 660, 404, 916,
-         84,  596, 340, 852,  212, 724, 468, 980,  52,  564, 308, 820,
-         180, 692, 436, 948,  116, 628, 372, 884,  244, 756, 500, 1012,
-         12,  524, 268, 780,  140, 652, 396, 908,  76,  588, 332, 844,
-         204, 716, 460, 972,  44,  556, 300, 812,  172, 684, 428, 940,
-         108, 620, 364, 876,  236, 748, 492, 1004, 28,  540, 284, 796,
-         156, 668, 412, 924,  92,  604, 348, 860,  220, 732, 476, 988,
-         60,  572, 316, 828,  188, 700, 444, 956,  124, 636, 380, 892,
-         252, 764, 508, 1020, 2,   514, 258, 770,  130, 642, 386, 898,
-         66,  578, 322, 834,  194, 706, 450, 962,  34,  546, 290, 802,
-         162, 674, 418, 930,  98,  610, 354, 866,  226, 738, 482, 994,
-         18,  530, 274, 786,  146, 658, 402, 914,  82,  594, 338, 850,
-         210, 722, 466, 978,  50,  562, 306, 818,  178, 690, 434, 946,
-         114, 626, 370, 882,  242, 754, 498, 1010, 10,  522, 266, 778,
-         138, 650, 394, 906,  74,  586, 330, 842,  202, 714, 458, 970,
-         42,  554, 298, 810,  170, 682, 426, 938,  106, 618, 362, 874,
-         234, 746, 490, 1002, 26,  538, 282, 794,  154, 666, 410, 922,
-         90,  602, 346, 858,  218, 730, 474, 986,  58,  570, 314, 826,
-         186, 698, 442, 954,  122, 634, 378, 890,  250, 762, 506, 1018,
-         6,   518, 262, 774,  134, 646, 390, 902,  70,  582, 326, 838,
-         198, 710, 454, 966,  38,  550, 294, 806,  166, 678, 422, 934,
-         102, 614, 358, 870,  230, 742, 486, 998,  22,  534, 278, 790,
-         150, 662, 406, 918,  86,  598, 342, 854,  214, 726, 470, 982,
-         54,  566, 310, 822,  182, 694, 438, 950,  118, 630, 374, 886,
-         246, 758, 502, 1014, 14,  526, 270, 782,  142, 654, 398, 910,
-         78,  590, 334, 846,  206, 718, 462, 974,  46,  558, 302, 814,
-         174, 686, 430, 942,  110, 622, 366, 878,  238, 750, 494, 1006,
-         30,  542, 286, 798,  158, 670, 414, 926,  94,  606, 350, 862,
-         222, 734, 478, 990,  62,  574, 318, 830,  190, 702, 446, 958,
-         126, 638, 382, 894,  254, 766, 510, 1022, 1,   513, 257, 769,
-         129, 641, 385, 897,  65,  577, 321, 833,  193, 705, 449, 961,
-         33,  545, 289, 801,  161, 673, 417, 929,  97,  609, 353, 865,
-         225, 737, 481, 993,  17,  529, 273, 785,  145, 657, 401, 913,
-         81,  593, 337, 849,  209, 721, 465, 977,  49,  561, 305, 817,
-         177, 689, 433, 945,  113, 625, 369, 881,  241, 753, 497, 1009,
-         9,   521, 265, 777,  137, 649, 393, 905,  73,  585, 329, 841,
-         201, 713, 457, 969,  41,  553, 297, 809,  169, 681, 425, 937,
-         105, 617, 361, 873,  233, 745, 489, 1001, 25,  537, 281, 793,
-         153, 665, 409, 921,  89,  601, 345, 857,  217, 729, 473, 985,
-         57,  569, 313, 825,  185, 697, 441, 953,  121, 633, 377, 889,
-         249, 761, 505, 1017, 5,   517, 261, 773,  133, 645, 389, 901,
-         69,  581, 325, 837,  197, 709, 453, 965,  37,  549, 293, 805,
-         165, 677, 421, 933,  101, 613, 357, 869,  229, 741, 485, 997,
-         21,  533, 277, 789,  149, 661, 405, 917,  85,  597, 341, 853,
-         213, 725, 469, 981,  53,  565, 309, 821,  181, 693, 437, 949,
-         117, 629, 373, 885,  245, 757, 501, 1013, 13,  525, 269, 781,
-         141, 653, 397, 909,  77,  589, 333, 845,  205, 717, 461, 973,
-         45,  557, 301, 813,  173, 685, 429, 941,  109, 621, 365, 877,
-         237, 749, 493, 1005, 29,  541, 285, 797,  157, 669, 413, 925,
-         93,  605, 349, 861,  221, 733, 477, 989,  61,  573, 317, 829,
-         189, 701, 445, 957,  125, 637, 381, 893,  253, 765, 509, 1021,
-         3,   515, 259, 771,  131, 643, 387, 899,  67,  579, 323, 835,
-         195, 707, 451, 963,  35,  547, 291, 803,  163, 675, 419, 931,
-         99,  611, 355, 867,  227, 739, 483, 995,  19,  531, 275, 787,
-         147, 659, 403, 915,  83,  595, 339, 851,  211, 723, 467, 979,
-         51,  563, 307, 819,  179, 691, 435, 947,  115, 627, 371, 883,
-         243, 755, 499, 1011, 11,  523, 267, 779,  139, 651, 395, 907,
-         75,  587, 331, 843,  203, 715, 459, 971,  43,  555, 299, 811,
-         171, 683, 427, 939,  107, 619, 363, 875,  235, 747, 491, 1003,
-         27,  539, 283, 795,  155, 667, 411, 923,  91,  603, 347, 859,
-         219, 731, 475, 987,  59,  571, 315, 827,  187, 699, 443, 955,
-         123, 635, 379, 891,  251, 763, 507, 1019, 7,   519, 263, 775,
-         135, 647, 391, 903,  71,  583, 327, 839,  199, 711, 455, 967,
-         39,  551, 295, 807,  167, 679, 423, 935,  103, 615, 359, 871,
-         231, 743, 487, 999,  23,  535, 279, 791,  151, 663, 407, 919,
-         87,  599, 343, 855,  215, 727, 471, 983,  55,  567, 311, 823,
-         183, 695, 439, 951,  119, 631, 375, 887,  247, 759, 503, 1015,
-         15,  527, 271, 783,  143, 655, 399, 911,  79,  591, 335, 847,
-         207, 719, 463, 975,  47,  559, 303, 815,  175, 687, 431, 943,
-         111, 623, 367, 879,  239, 751, 495, 1007, 31,  543, 287, 799,
-         159, 671, 415, 927,  95,  607, 351, 863,  223, 735, 479, 991,
-         63,  575, 319, 831,  191, 703, 447, 959,  127, 639, 383, 895,
-         255, 767, 511, 1023}};
-// clang-format on
+size_t SortedThreadSafeIndex::getNextIndexImpl(size_t sequential_idx) {
+  return indices_and_squared_norms_[sequential_idx].first;
+}
 
 // This class assumes PRE-SCALED coordinates, where one unit = one voxel size.
 // The indices are also returned in this scales coordinate system, which should

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -200,22 +200,6 @@ void TsdfIntegratorBase::updateTsdfVoxel(const Point& origin,
   if (std::abs(sdf) < config_.default_truncation_distance) {
     tsdf_voxel->color = Color::blendTwoColors(
         tsdf_voxel->color, tsdf_voxel->weight, color, updated_weight);
-  } else if (config_.voxel_carving_ignores_voxels_near_surface) {
-    // If a clearing ray is passing a voxel, the only constraint it should be
-    // able to enforce on that voxel is that it is in free space, and
-    // therefore not interfering with the direct line of sight. It shouldn't
-    // contribute to the weighted average of the SDF, since the projective
-    // distance to the surface is always overestimating the real, euclidean
-    // distance and the further away we are from the observed surface the
-    // worse it gets. However, this does not fully solve the problem, because
-    // due to the discretization of the voxel grid, the clearing ray could be
-    // grazing a voxel that actually lies just within the boundaries of the
-    // surface without actually crossing the surface.
-    if (tsdf_voxel->distance > 0.0 &&
-        tsdf_voxel->distance < config_.default_truncation_distance &&
-        tsdf_voxel->weight > 0.0) {
-      return;
-    }
   }
   tsdf_voxel->distance =
       (new_sdf > 0.0) ? std::min(config_.default_truncation_distance, new_sdf)
@@ -619,7 +603,6 @@ std::string TsdfIntegratorBase::Config::print() const {
   ss << " - use_weight_dropoff:                        " << use_weight_dropoff << "\n";
   ss << " - use_sparsity_compensation_factor:          " << use_sparsity_compensation_factor << "\n";
   ss << " - sparsity_compensation_factor:              "  << sparsity_compensation_factor << "\n";
-  ss << " - voxel_carving_ignores_voxels_near_surface: " << voxel_carving_ignores_voxels_near_surface << "\n";
   ss << " - integrator_threads:                        " << integrator_threads << "\n";
   ss << " MergedTsdfIntegrator: \n";
   ss << " - enable_anti_grazing:                       " << enable_anti_grazing << "\n";

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -104,9 +104,6 @@ inline TsdfIntegratorBase::Config getTsdfIntegratorConfigFromRosParam(
   nh_private.param("sparsity_compensation_factor",
                    integrator_config.sparsity_compensation_factor,
                    integrator_config.sparsity_compensation_factor);
-  nh_private.param("voxel_carving_ignores_voxels_near_surface",
-                   integrator_config.voxel_carving_ignores_voxels_near_surface,
-                   integrator_config.voxel_carving_ignores_voxels_near_surface);
   nh_private.param("integration_order_mode",
                    integrator_config.integration_order_mode,
                    integrator_config.integration_order_mode);

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -106,6 +106,10 @@ inline TsdfIntegratorBase::Config getTsdfIntegratorConfigFromRosParam(
   nh_private.param("voxel_carving_ignores_voxels_near_surface",
                    integrator_config.voxel_carving_ignores_voxels_near_surface,
                    integrator_config.voxel_carving_ignores_voxels_near_surface);
+  nh_private.param("integration_order_mode",
+                   integrator_config.integration_order_mode,
+                   integrator_config.integration_order_mode);
+
   integrator_config.default_truncation_distance =
       static_cast<float>(truncation_distance);
   integrator_config.max_weight = static_cast<float>(max_weight);

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -103,6 +103,9 @@ inline TsdfIntegratorBase::Config getTsdfIntegratorConfigFromRosParam(
   nh_private.param("sparsity_compensation_factor",
                    integrator_config.sparsity_compensation_factor,
                    integrator_config.sparsity_compensation_factor);
+  nh_private.param("voxel_carving_ignores_voxels_near_surface",
+                   integrator_config.voxel_carving_ignores_voxels_near_surface,
+                   integrator_config.voxel_carving_ignores_voxels_near_surface);
   integrator_config.default_truncation_distance =
       static_cast<float>(truncation_distance);
   integrator_config.max_weight = static_cast<float>(max_weight);


### PR DESCRIPTION
For large voxel sizes smaller geometry will inevitably get cleared away. https://github.com/ethz-asl/voxblox/pull/239 exposed the "sparsity compensation factor" setting, which basically increases the weight of rays inside the truncation distance with respect to the rays outside to alleviate these effects, however, it also makes it harder to update a changing map, i.e. clear objects that have moved.

This PR tries to further improve this, by adding some more logic to fix that: 

 * ~~The first thing I tried was to correct how these clearing rays behave near the surface. The basic idea is that a ray outside the truncation distance should not contribute to the weighted average of the TSDF when passing a voxel with positive SDF that has previously been observed to be inside the truncation distance. The reason is that the only constraint on the geometry that these rays should be able to enforce is that nothing is obstructing the line of sight between sensor and measurement. If the voxel value is positive, this constraint is already fulfilled and updating the voxel with the weighted average of the truncation distance and the previous value only distorts geometry. That being said, this feature doesn't solve the problem entirely, if a voxel lies just below the surface, hence has a negative SDF, a ray passing near the outside of the surface will still update the SDF of that voxel and distort the geometry.~~
 **Edit:** Even though this logic helps preserve small geometry, it leads to problems later in planning, since it makes it harder to remove dynamic objects completely. Was removed again.

 * This one is rather simple, but was quite effective. I sort the rays before integration, such that close geometry is integrated first. For the FastTsdfIntegrator this makes more sense, since it integrates the rays backwards from point to sensor origin and aborts integration for a ray if the voxels have been touched by another ray in the same scan.

## Experiments

I ran some tests to see how these changes influences the 3D reconstruction:

| Experiment                             |      |      |      |        |        |        |       |
|----------------------------------------|------|------|------|--------|--------|--------|--------|
| integrator                             | fast | fast | fast | fast   | fast   |  fast  |  fast  |
| carving ignores freespace near surface | no   | yes  | no   | yes    |  no    |  yes   |  yes   |
| weighting (sparsity compensation)      | no   | no   | 10  | 10    |  no    |  no    |  2     |
| integration order                      |  mixed | mixed  | mixed  |  mixed | sorted  |   sorted     |  sorted  |
|                                        |      |      |      |        |        |        |       |
|  <img src="https://user-images.githubusercontent.com/5616392/53157285-73d7e600-35c1-11e9-9205-e7ab0880f145.png" alt="img" width="400"/>                                      | <img src="https://gist.githubusercontent.com/mfehr/4d8dcf522cec4ccbb7b6eec553ecc149/raw/f45adaa9d1c1343778f12f92d74b8a2012f5eb6a/april05_L01.png" alt="img" width="400"/> | <img src="https://gist.githubusercontent.com/mfehr/4d8dcf522cec4ccbb7b6eec553ecc149/raw/f45adaa9d1c1343778f12f92d74b8a2012f5eb6a/april05_L00.png" alt="img" width="400"/> | <img src="https://gist.githubusercontent.com/mfehr/4d8dcf522cec4ccbb7b6eec553ecc149/raw/f45adaa9d1c1343778f12f92d74b8a2012f5eb6a/april05_L02.png" alt="img" width="400"/> | <img src="https://gist.githubusercontent.com/mfehr/4d8dcf522cec4ccbb7b6eec553ecc149/raw/f45adaa9d1c1343778f12f92d74b8a2012f5eb6a/april05_L06.png" alt="img" width="400"/> |<img src="https://gist.githubusercontent.com/mfehr/4d8dcf522cec4ccbb7b6eec553ecc149/raw/cbc8a3371a4e0edd1fc0406a54f5e49f60df846a/april100_L01.png" alt="img" width="400"/> |<img src="https://gist.githubusercontent.com/mfehr/4d8dcf522cec4ccbb7b6eec553ecc149/raw/47a9f8bb571bfe925fa28df34993468ff78b799a/april200_L00.png" alt="img" width="400"/> |<img src="https://gist.githubusercontent.com/mfehr/4d8dcf522cec4ccbb7b6eec553ecc149/raw/47a9f8bb571bfe925fa28df34993468ff78b799a/april200_L02.png" alt="img" width="400"/> |

**The full experiments with more data/pictures can be found [here](https://gist.github.com/mfehr/4d8dcf522cec4ccbb7b6eec553ecc149).**


## Parameter

At least based on these qualitative tests, the current best parameters are:
 * sorted rays, some down-weighting of the voxel carving rays (e.g. 2x).

The ROS parameters are:
```xml
      <param name="method" value="fast" />
      <param name="use_sparsity_compensation_factor" value="true" />
      <param name="sparsity_compensation_factor" value="2.0" />
      <param name="use_const_weight" value="true" />
      <param name="use_weight_dropoff" value="true" />
      <param name="integration_order_mode" value="sorted" />
```

