### PR TITLE
Inlined member function of TsdfIntegratorBase in header.

### DIFF
--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -102,7 +102,7 @@ class TsdfIntegratorBase {
 
  protected:
   /// Thread safe.
-  bool isPointValid(const Point& point_C, const bool freespace_point,
+  inline bool isPointValid(const Point& point_C, const bool freespace_point,
                     bool* is_clearing) const {
     DCHECK(is_clearing != nullptr);
     const FloatingPoint ray_distance = point_C.norm();

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -102,8 +102,24 @@ class TsdfIntegratorBase {
 
  protected:
   /// Thread safe.
-  inline bool isPointValid(const Point& point_C, const bool freespace_point,
-                           bool* is_clearing) const;
+  bool isPointValid(const Point& point_C, const bool freespace_point,
+                    bool* is_clearing) const {
+    DCHECK(is_clearing != nullptr);
+    const FloatingPoint ray_distance = point_C.norm();
+    if (ray_distance < config_.min_ray_length_m) {
+      return false;
+    } else if (ray_distance > config_.max_ray_length_m) {
+      if (config_.allow_clear || freespace_point) {
+        *is_clearing = true;
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      *is_clearing = freespace_point;
+      return true;
+    }
+  }
 
   /**
    * Will return a pointer to a voxel located at global_voxel_idx in the tsdf

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -78,27 +78,6 @@ void TsdfIntegratorBase::setLayer(Layer<TsdfVoxel>* layer) {
   voxels_per_side_inv_ = 1.0 / voxels_per_side_;
 }
 
-// Thread safe.
-inline bool TsdfIntegratorBase::isPointValid(const Point& point_C,
-                                             const bool point_in_freespace,
-                                             bool* is_clearing) const {
-  DCHECK(is_clearing != nullptr);
-  const FloatingPoint ray_distance = point_C.norm();
-  if (ray_distance < config_.min_ray_length_m) {
-    return false;
-  } else if (ray_distance > config_.max_ray_length_m) {
-    if (config_.allow_clear || point_in_freespace) {
-      *is_clearing = true;
-      return true;
-    } else {
-      return false;
-    }
-  } else {
-    *is_clearing = point_in_freespace;
-    return true;
-  }
-}
-
 // Will return a pointer to a voxel located at global_voxel_idx in the tsdf
 // layer. Thread safe.
 // Takes in the last_block_idx and last_block to prevent unneeded map lookups.


### PR DESCRIPTION
Otherwise derived tsdf integrator classes outside of `src/integrator/tsdf_integrator.cc` will not see the definition of this method. Also, [explicitly defining a class method as `inline` is not necessary](https://stackoverflow.com/a/9370630).