### PR TITLE
Feature/mesh integrator config params

### DIFF
--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -21,7 +21,8 @@ class EsdfServer : public TsdfServer {
              const EsdfMap::Config& esdf_config,
              const EsdfIntegrator::Config& esdf_integrator_config,
              const TsdfMap::Config& tsdf_config,
-             const TsdfIntegratorBase::Config& tsdf_integrator_config);
+             const TsdfIntegratorBase::Config& tsdf_integrator_config,
+             const MeshIntegratorConfig& mesh_config);
   virtual ~EsdfServer() {}
 
   bool generateEsdfCallback(std_srvs::Empty::Request& request,     // NOLINT

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -166,8 +166,7 @@ inline MeshIntegratorConfig getMeshIntegratorConfigFromRosParam(
     const ros::NodeHandle& nh_private) {
   MeshIntegratorConfig mesh_integrator_config;
 
-  nh_private.param("mesh_min_weight",
-                   mesh_integrator_config.min_weight,
+  nh_private.param("mesh_min_weight", mesh_integrator_config.min_weight,
                    mesh_integrator_config.min_weight);
   nh_private.param("mesh_use_color", mesh_integrator_config.use_color,
                    mesh_integrator_config.use_color);

--- a/voxblox_ros/include/voxblox_ros/ros_params.h
+++ b/voxblox_ros/include/voxblox_ros/ros_params.h
@@ -8,6 +8,7 @@
 #include <voxblox/core/tsdf_map.h>
 #include <voxblox/integrator/esdf_integrator.h>
 #include <voxblox/integrator/tsdf_integrator.h>
+#include <voxblox/mesh/mesh_integrator.h>
 
 namespace voxblox {
 
@@ -159,6 +160,19 @@ inline EsdfIntegrator::Config getEsdfIntegratorConfigFromRosParam(
   }
 
   return esdf_integrator_config;
+}
+
+inline MeshIntegratorConfig getMeshIntegratorConfigFromRosParam(
+    const ros::NodeHandle& nh_private) {
+  MeshIntegratorConfig mesh_integrator_config;
+
+  nh_private.param("mesh_min_weight",
+                   mesh_integrator_config.min_weight,
+                   mesh_integrator_config.min_weight);
+  nh_private.param("mesh_use_color", mesh_integrator_config.use_color,
+                   mesh_integrator_config.use_color);
+
+  return mesh_integrator_config;
 }
 
 }  // namespace voxblox

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -40,7 +40,8 @@ class TsdfServer {
   TsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
   TsdfServer(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private,
              const TsdfMap::Config& config,
-             const TsdfIntegratorBase::Config& integrator_config);
+             const TsdfIntegratorBase::Config& integrator_config,
+             const MeshIntegratorConfig& mesh_config);
   virtual ~TsdfServer() {}
 
   void getServerConfigFromRosParam(const ros::NodeHandle& nh_private);

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -10,15 +10,18 @@ EsdfServer::EsdfServer(const ros::NodeHandle& nh,
     : EsdfServer(nh, nh_private, getEsdfMapConfigFromRosParam(nh_private),
                  getEsdfIntegratorConfigFromRosParam(nh_private),
                  getTsdfMapConfigFromRosParam(nh_private),
-                 getTsdfIntegratorConfigFromRosParam(nh_private)) {}
+                 getTsdfIntegratorConfigFromRosParam(nh_private),
+                 getMeshIntegratorConfigFromRosParam(nh_private)) {}
 
 EsdfServer::EsdfServer(const ros::NodeHandle& nh,
                        const ros::NodeHandle& nh_private,
                        const EsdfMap::Config& esdf_config,
                        const EsdfIntegrator::Config& esdf_integrator_config,
                        const TsdfMap::Config& tsdf_config,
-                       const TsdfIntegratorBase::Config& tsdf_integrator_config)
-    : TsdfServer(nh, nh_private, tsdf_config, tsdf_integrator_config),
+                       const TsdfIntegratorBase::Config& tsdf_integrator_config,
+                       const MeshIntegratorConfig& mesh_config)
+    : TsdfServer(nh, nh_private, tsdf_config, tsdf_integrator_config,
+                 mesh_config),
       clear_sphere_for_planning_(false),
       publish_esdf_map_(false),
       publish_traversable_(false),

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -69,12 +69,14 @@ void TsdfServer::getServerConfigFromRosParam(
 TsdfServer::TsdfServer(const ros::NodeHandle& nh,
                        const ros::NodeHandle& nh_private)
     : TsdfServer(nh, nh_private, getTsdfMapConfigFromRosParam(nh_private),
-                 getTsdfIntegratorConfigFromRosParam(nh_private)) {}
+                 getTsdfIntegratorConfigFromRosParam(nh_private),
+                 getMeshIntegratorConfigFromRosParam(nh_private)) {}
 
 TsdfServer::TsdfServer(const ros::NodeHandle& nh,
                        const ros::NodeHandle& nh_private,
                        const TsdfMap::Config& config,
-                       const TsdfIntegratorBase::Config& integrator_config)
+                       const TsdfIntegratorBase::Config& integrator_config,
+                       const MeshIntegratorConfig& mesh_config)
     : nh_(nh),
       nh_private_(nh_private),
       verbose_(true),
@@ -159,10 +161,6 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
     tsdf_integrator_.reset(new SimpleTsdfIntegrator(
         integrator_config, tsdf_map_->getTsdfLayerPtr()));
   }
-
-  MeshIntegratorConfig mesh_config;
-  nh_private_.param("mesh_min_weight", mesh_config.min_weight,
-                    mesh_config.min_weight);
 
   mesh_layer_.reset(new MeshLayer(tsdf_map_->block_size()));
 


### PR DESCRIPTION
Adds a function for retrieving mesh integrator params from the ros_param server. The justification is the same as the other functions in this file, it stops library clients having to rewrite parameter fetching code. 