### PR TITLE
Initialize all layer attributes in deep copy constructor

### DIFF
--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -53,7 +53,9 @@ void Layer<VoxelType>::getProto(LayerProto* proto) const {
 template <typename VoxelType>
 Layer<VoxelType>::Layer(const Layer& other) {
   voxel_size_ = other.voxel_size_;
+  voxel_size_inv_ = other.voxel_size_inv_;
   voxels_per_side_ = other.voxels_per_side_;
+  voxels_per_side_inv_ = other.voxels_per_side_inv_;
   block_size_ = other.block_size_;
   block_size_inv_ = other.block_size_inv_;
 


### PR DESCRIPTION
This is a very small fix that adds initialization of the `voxel_size_inv_` and `voxels_per_side_inv_` attributes to the `Layer::Layer::Layer(const Layer& other)` deep copy constructor.

Without this fix `layer.voxel_size_inv()` returns `0` for copied layers. I assume this is not intentional, but if I'm missing something - let me know.