### PR TITLE
WIP: fixing incremental ESDF integration with dynamic obstacles

### DIFF
--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -221,8 +221,10 @@ void EsdfIntegrator::updateFromTsdfBlocks(const BlockIndexList& tsdf_blocks,
                   signum(tsdf_voxel.distance) * config_.default_distance_m;
             }
             esdf_voxel.parent.setZero();
+            raise_.push(global_index);
             esdf_voxel.in_queue = true;
             open_.push(global_index, esdf_voxel.distance);
+            num_raise++;
             num_lower++;
           } else if ((esdf_voxel.distance > 0 &&
                       tsdf_voxel.distance - config_.min_diff_m >


### PR DESCRIPTION
with the incremental esdf update, we realized that the esdf map is not always clearing dynamic obstacles. however, the dynamic obstacles get cleared within the tsdf map:

![Selection_017](https://user-images.githubusercontent.com/14781925/56303330-fac9ba80-613b-11e9-980a-60509a532202.png)

we get the following corresponding esdf map with especially many traces of dynamic obstacles on the upper right side of the map:

![Selection_016](https://user-images.githubusercontent.com/14781925/56303164-a1fa2200-613b-11e9-98d8-42d7239e7fe3.png)

by adding more voxels to the raise queue first, the clearing seems to work in the esdf map as well, but I did not yet exactly find out why:

![Selection_015](https://user-images.githubusercontent.com/14781925/56303180-a9b9c680-613b-11e9-919a-37afce018361.png)

I saw that you mentioned in the paper that in order to reduce bookkeeping, all voxels get raised first, which does not seem to be the case in the current implementation.