### PR TITLE
Occupancy visualization change

### DIFF
--- a/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
+++ b/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
@@ -228,9 +228,11 @@ inline bool visualizeDistanceIntensityTsdfVoxelsSlice(
     const TsdfVoxel& voxel, const Point& coord, unsigned int free_plane_index,
     FloatingPoint free_plane_val, FloatingPoint voxel_size, double* intensity) {
   CHECK_NOTNULL(intensity);
+  constexpr float kMinWeight = 1e-3;
+
   if (std::abs(coord(free_plane_index) - free_plane_val) <=
       (voxel_size / 2.0 + kFloatEpsilon)) {
-    if (voxel.weight > 1e-3) {
+    if (voxel.weight > kMinWeight) {
       *intensity = voxel.distance;
       return true;
     }
@@ -252,8 +254,10 @@ inline bool visualizeDistanceIntensityEsdfVoxels(const EsdfVoxel& voxel,
 inline bool visualizeIntensityVoxels(const IntensityVoxel& voxel,
                                      const Point& /*coord*/,
                                      double* intensity) {
+  constexpr float kMinWeight = 1e-3;
+
   CHECK_NOTNULL(intensity);
-  if (voxel.weight > 0.0) {
+  if (voxel.weight > kMinWeight) {
     *intensity = voxel.intensity;
     return true;
   }
@@ -278,7 +282,8 @@ inline bool visualizeDistanceIntensityEsdfVoxelsSlice(
 inline bool visualizeOccupiedTsdfVoxels(const TsdfVoxel& voxel,
                                         const Point& /*coord*/,
                                         const float min_distance = 0.0) {
-  if (voxel.weight > 1e-3 && voxel.distance <= min_distance) {
+  constexpr float kMinWeight = 1e-3;
+  if (voxel.weight > kMinWeight && voxel.distance <= min_distance) {
     return true;
   }
   return false;

--- a/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
+++ b/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
@@ -276,8 +276,9 @@ inline bool visualizeDistanceIntensityEsdfVoxelsSlice(
 }
 
 inline bool visualizeOccupiedTsdfVoxels(const TsdfVoxel& voxel,
-                                        const Point& /*coord*/) {
-  if (voxel.weight > 1e-3 && voxel.distance <= 0) {
+                                        const Point& /*coord*/,
+                                        const float min_distance = 0.0) {
+  if (voxel.weight > 1e-3 && voxel.distance <= min_distance) {
     return true;
   }
   return false;
@@ -313,9 +314,8 @@ inline void createSurfacePointcloudFromTsdfLayer(
     pcl::PointCloud<pcl::PointXYZRGB>* pointcloud) {
   CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(
-      layer,
-      std::bind(&visualizeNearSurfaceTsdfVoxels, ph::_1, ph::_2,
-                surface_distance, ph::_3),
+      layer, std::bind(&visualizeNearSurfaceTsdfVoxels, ph::_1, ph::_2,
+                       surface_distance, ph::_3),
       pointcloud);
 }
 
@@ -352,9 +352,8 @@ inline void createSurfaceDistancePointcloudFromTsdfLayer(
     pcl::PointCloud<pcl::PointXYZI>* pointcloud) {
   CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(
-      layer,
-      std::bind(&visualizeDistanceIntensityTsdfVoxelsNearSurface, ph::_1,
-                ph::_2, surface_distance, ph::_3),
+      layer, std::bind(&visualizeDistanceIntensityTsdfVoxelsNearSurface, ph::_1,
+                       ph::_2, surface_distance, ph::_3),
       pointcloud);
 }
 
@@ -426,8 +425,10 @@ inline void createOccupancyBlocksFromTsdfLayer(
     const Layer<TsdfVoxel>& layer, const std::string& frame_id,
     visualization_msgs::MarkerArray* marker_array) {
   CHECK_NOTNULL(marker_array);
-  createOccupancyBlocksFromLayer<TsdfVoxel>(layer, &visualizeOccupiedTsdfVoxels,
-                                            frame_id, marker_array);
+  createOccupancyBlocksFromLayer<TsdfVoxel>(
+      layer, std::bind(visualizeOccupiedTsdfVoxels, std::placeholders::_1,
+                       std::placeholders::_2, layer.voxel_size()),
+      frame_id, marker_array);
 }
 
 inline void createOccupancyBlocksFromOccupancyLayer(


### PR DESCRIPTION
Changes occupancy visualization to show all voxels whose distance is ``<= voxel_size`` as these voxels will contain the surface crossing.