### PR TITLE
Send ESDF and TSDF maps as incremental updates.

### DIFF
--- a/voxblox_ros/include/voxblox_ros/conversions_inl.h
+++ b/voxblox_ros/include/voxblox_ros/conversions_inl.h
@@ -66,6 +66,7 @@ bool deserializeMsgToLayer(const voxblox_msgs::Layer& msg,
   }
 
   if (action == MapDerializationAction::kReset) {
+    LOG(INFO) << "Resetting current layer.";
     layer->removeAllBlocks();
   }
 

--- a/voxblox_ros/include/voxblox_ros/esdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/esdf_server.h
@@ -35,7 +35,7 @@ class EsdfServer : public TsdfServer {
   virtual void updateMesh();
   virtual void publishPointclouds();
   virtual void newPoseCallback(const Transformation& T_G_C);
-  virtual void publishMap(const bool reset_remote_map = false);
+  virtual void publishMap(bool reset_remote_map = false);
   virtual bool saveMap(const std::string& file_path);
   virtual bool loadMap(const std::string& file_path);
 
@@ -97,6 +97,7 @@ class EsdfServer : public TsdfServer {
   bool publish_traversable_;
   float traversability_radius_;
   bool incremental_update_;
+  int num_subscribers_esdf_map_;
 
   // ESDF maps.
   std::shared_ptr<EsdfMap> esdf_map_;

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -74,7 +74,7 @@ class TsdfServer {
   // Publishes all available pointclouds.
   virtual void publishPointclouds();
   // Publishes the complete map
-  virtual void publishMap(const bool reset_remote_map = false);
+  virtual void publishMap(bool reset_remote_map = false);
   virtual bool saveMap(const std::string& file_path);
   virtual bool loadMap(const std::string& file_path);
 
@@ -194,6 +194,7 @@ class TsdfServer {
 
   /// Subscriber settings.
   int pointcloud_queue_size_;
+  int num_subscribers_tsdf_map_;
 
   // Publish markers for visualization.
   ros::Publisher mesh_pub_;

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -148,7 +148,7 @@ void EsdfServer::publishTraversable() {
 
 void EsdfServer::publishMap(const bool reset_remote_map) {
   if (this->esdf_map_pub_.getNumSubscribers() > 0) {
-    const bool only_updated = false;
+    const bool only_updated = !reset_remote_map;
     timing::Timer publish_map_timer("map/publish_esdf");
     voxblox_msgs::Layer layer_msg;
     serializeLayerAsMsg<EsdfVoxel>(this->esdf_map_->getEsdfLayer(),

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -34,6 +34,12 @@ EsdfServer::EsdfServer(const ros::NodeHandle& nh,
                                             esdf_map_->getEsdfLayerPtr()));
 
   setupRos();
+
+  // Clear remote map just in case.
+  if (publish_esdf_map_) {
+    constexpr bool kResetRemoteMap = true;
+    publishMap(true);
+  }
 }
 
 void EsdfServer::setupRos() {

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -34,12 +34,6 @@ EsdfServer::EsdfServer(const ros::NodeHandle& nh,
                                             esdf_map_->getEsdfLayerPtr()));
 
   setupRos();
-
-  // Clear remote map just in case.
-  if (publish_esdf_map_) {
-    constexpr bool kResetRemoteMap = true;
-    publishMap(true);
-  }
 }
 
 void EsdfServer::setupRos() {
@@ -231,6 +225,8 @@ void EsdfServer::newPoseCallback(const Transformation& T_G_C) {
 }
 
 void EsdfServer::esdfMapCallback(const voxblox_msgs::Layer& layer_msg) {
+  timing::Timer receive_map_timer("map/receive_esdf");
+
   bool success =
       deserializeMsgToLayer<EsdfVoxel>(layer_msg, esdf_map_->getEsdfLayerPtr());
 

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -193,6 +193,12 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
         nh_private_.createTimer(ros::Duration(update_mesh_every_n_sec),
                                 &TsdfServer::updateMeshEvent, this);
   }
+
+  // Clear remote map just in case.
+  if (publish_tsdf_map_) {
+    constexpr bool kResetRemoteMap = true;
+    publishMap(true);
+  }
 }
 
 // Check if all coordinates in the point are finite

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -193,19 +193,13 @@ TsdfServer::TsdfServer(const ros::NodeHandle& nh,
         nh_private_.createTimer(ros::Duration(update_mesh_every_n_sec),
                                 &TsdfServer::updateMeshEvent, this);
   }
-
-  // Clear remote map just in case.
-  if (publish_tsdf_map_) {
-    constexpr bool kResetRemoteMap = true;
-    publishMap(true);
-  }
 }
 
 // Check if all coordinates in the point are finite
-template<typename Point>
+template <typename Point>
 bool isPointFinite(const Point& point) {
-    return std::isfinite(point.x) && std::isfinite(point.y) &&
-           std::isfinite(point.z);
+  return std::isfinite(point.x) && std::isfinite(point.y) &&
+         std::isfinite(point.z);
 }
 
 void TsdfServer::processPointCloudMessageAndInsert(
@@ -656,6 +650,8 @@ void TsdfServer::clear() {
 }
 
 void TsdfServer::tsdfMapCallback(const voxblox_msgs::Layer& layer_msg) {
+  timing::Timer receive_map_timer("map/receive_tsdf");
+
   bool success =
       deserializeMsgToLayer<TsdfVoxel>(layer_msg, tsdf_map_->getTsdfLayerPtr());
 

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -485,7 +485,7 @@ void TsdfServer::publishSlices() {
 
 void TsdfServer::publishMap(const bool reset_remote_map) {
   if (this->tsdf_map_pub_.getNumSubscribers() > 0) {
-    const bool only_updated = false;
+    const bool only_updated = !reset_remote_map;
     timing::Timer publish_map_timer("map/publish_tsdf");
     voxblox_msgs::Layer layer_msg;
     serializeLayerAsMsg<TsdfVoxel>(this->tsdf_map_->getTsdfLayer(),


### PR DESCRIPTION
In quick testing in simulation (in a quite small environment), seems to cut down the de-serialization time on the receiving time by 2x. :) (Not as big of a change as I hoped for, but the ESDF does tend to propagate pretty far per update).

```
# Before
SM Timing
-----------
map/receive_esdf	    592	42.112377	(00.071136 +- 00.012223)	[00.000031,00.154489]
map/receive_tsdf	    342	07.308545	(00.021370 +- 00.005281)	[00.000014,00.041215]


# After

SM Timing
-----------
map/receive_esdf	    841	29.314446	(00.034857 +- 00.009474)	[00.000022,00.091914]
map/receive_tsdf	    483	04.858298	(00.010059 +- 00.003844)	[00.000004,00.026494]
```

Will also reset the map any time a new subscriber subscribes, hopefully allowing starting the nodes at different times but still keeping a consistent map.