### PR TITLE
Fix memory leak observed by ARL

### DIFF
--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -23,6 +23,13 @@ class ThreadSafeIndex {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+  // NOTE: The ThreadSafeIndex base destructor must be marked virtual.
+  //       Otherwise the destructors of derived classes don't get called when
+  //       derived class instances are destructed through base class pointers.
+  //       This would result leaking memory due to derived class member
+  //       variables not being freed.
+  virtual ~ThreadSafeIndex() = default;
+
   /// returns true if index is valid, false otherwise
   bool getNextIndex(size_t* idx);
 


### PR DESCRIPTION
This fix should solve the memory leak observed by ARL, in which the memory usage steadily increases to 6GB on a 6 minute dataset.

The bug shows up when using `integration_order_mode: "sorted"` instead of `"mixed"` and first appears between commits 49213973a5ba0cbc126262b6709debba72855b58 and 32f8bc127253dcc1b39acb5c6b02dfe3924f85b2.

It seems to come from the `indices_and_squared_norms_` member variable of `SortedThreadSafeIndex` not being freed. The reason is probably that the `SortedThreadSafeIndex` instances are destructed through pointers to their `ThreadSafeIndex` base class, but the base class destructor is not marked virtual.

Declaring a virtual base destructor brings the memory usage down to 420MB peak, 360MB final.