### PR TITLE
Introduced a tsdf voxel weight and other additional options.

### DIFF
--- a/voxblox/include/voxblox/core/common.h
+++ b/voxblox/include/voxblox/core/common.h
@@ -91,6 +91,8 @@ typedef Eigen::Matrix<FloatingPoint, 1, 8> InterpVector;
 // Type must allow negatives:
 typedef Eigen::Array<IndexElement, 3, 8> InterpIndexes;
 
+enum class CoordinateAxis { kX = 0, kY = 1, kZ = 2 };
+
 struct Color {
   Color() : r(0), g(0), b(0), a(0) {}
   Color(uint8_t _r, uint8_t _g, uint8_t _b) : Color(_r, _g, _b, 255) {}

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -68,9 +68,9 @@ class TsdfIntegratorBase {
     bool use_sparsity_compensation_factor = false;
     float sparsity_compensation_factor = 1.0f;
 
-    // The coordinate axis convention used for the optical axis. This is used
-    // when computing the voxel weights w.r.t. to their depth and will have no
-    // influence when using a constant voxel weight.
+    // The coordinate axis that goes forward along the optical axis of the
+    // sensor. This is used when computing the voxel weights w.r.t. to their
+    // depth and will have no influence when using a constant voxel weight.
     CoordinateAxis optical_axis_convention = CoordinateAxis::kZ;
 
     size_t integrator_threads = std::thread::hardware_concurrency();
@@ -79,8 +79,13 @@ class TsdfIntegratorBase {
     /// rays. Options: "mixed", "sorted"
     std::string integration_order_mode = "mixed";
 
-    /// merge integrator specific
+    /// Merge integrator specific.
     bool enable_anti_grazing = false;
+
+    // Merge integrator specific. If set to true, this does the following: When
+    // computing the merged point coordinate/weight/color, this only takes into
+    // account the first point of all points contained in a voxel to speed up
+    // the procress, but also this will decrease the impact of clearing rays.
     bool use_only_first_point_for_clearing = true;
 
     /// fast integrator specific

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -71,7 +71,7 @@ class TsdfIntegratorBase {
     // The coordinate axis that goes forward along the optical axis of the
     // sensor. This is used when computing the voxel weights w.r.t. to their
     // depth and will have no influence when using a constant voxel weight.
-    CoordinateAxis optical_axis_convention = CoordinateAxis::kZ;
+    CoordinateAxis sensor_depth_direction_axis = CoordinateAxis::kZ;
 
     size_t integrator_threads = std::thread::hardware_concurrency();
 

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -68,6 +68,11 @@ class TsdfIntegratorBase {
     bool use_sparsity_compensation_factor = false;
     float sparsity_compensation_factor = 1.0f;
 
+    // The coordinate axis convention used for the optical axis. This is used
+    // when computing the voxel weights w.r.t. to their depth and will have no
+    // influence when using a constant voxel weight.
+    CoordinateAxis optical_axis_convention = CoordinateAxis::kZ;
+
     size_t integrator_threads = std::thread::hardware_concurrency();
 
     /// Mode of the ThreadSafeIndex, determines the integration order of the
@@ -76,7 +81,8 @@ class TsdfIntegratorBase {
 
     /// merge integrator specific
     bool enable_anti_grazing = false;
-    bool use_only_first_point_for_clearing = true;
+    // TODO(fabianbl): Set this to its default value again (true).
+    bool use_only_first_point_for_clearing = false;
 
     /// fast integrator specific
     float start_voxel_subsampling_factor = 2.0f;

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -81,8 +81,7 @@ class TsdfIntegratorBase {
 
     /// merge integrator specific
     bool enable_anti_grazing = false;
-    // TODO(fabianbl): Set this to its default value again (true).
-    bool use_only_first_point_for_clearing = false;
+    bool use_only_first_point_for_clearing = true;
 
     /// fast integrator specific
     float start_voxel_subsampling_factor = 2.0f;

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -56,11 +56,12 @@ class TsdfIntegratorBase {
   struct Config {
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-    float default_truncation_distance = 0.1;
-    float max_weight = 10000.0;
+    float default_truncation_distance = 0.1f;
+    float max_weight = 10000.0f;
     bool voxel_carving_enabled = true;
     FloatingPoint min_ray_length_m = 0.1;
     FloatingPoint max_ray_length_m = 5.0;
+    float voxel_weight_factor = 1.0f;
     bool use_const_weight = false;
     bool allow_clear = true;
     bool use_weight_dropoff = true;
@@ -75,6 +76,7 @@ class TsdfIntegratorBase {
 
     /// merge integrator specific
     bool enable_anti_grazing = false;
+    bool use_only_first_point_for_clearing = true;
 
     /// fast integrator specific
     float start_voxel_subsampling_factor = 2.0f;
@@ -110,7 +112,7 @@ class TsdfIntegratorBase {
  protected:
   /// Thread safe.
   inline bool isPointValid(const Point& point_C, const bool freespace_point,
-                    bool* is_clearing) const {
+                           bool* is_clearing) const {
     DCHECK(is_clearing != nullptr);
     const FloatingPoint ray_distance = point_C.norm();
     if (ray_distance < config_.min_ray_length_m) {
@@ -254,7 +256,8 @@ class MergedTsdfIntegrator : public TsdfIntegratorBase {
   void integrateVoxel(
       const Transformation& T_G_C, const Pointcloud& points_C,
       const Colors& colors, bool enable_anti_grazing, bool clearing_ray,
-      const std::pair<GlobalIndex, AlignedVector<size_t>>& kv,
+      const GlobalIndex& voxel_index,
+      const AlignedVector<size_t>& point_C_indices,
       const LongIndexHashMapType<AlignedVector<size_t>>::type& voxel_map);
 
   void integrateVoxels(

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -250,7 +250,7 @@ float TsdfIntegratorBase::getVoxelWeight(const Point& point_C) const {
     return config_.voxel_weight_factor / (point_depth * point_depth);
   }
   return 0.0f;
-}  // namespace voxblox
+}
 
 void SimpleTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
                                                const Pointcloud& points_C,

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -398,7 +398,9 @@ void MergedTsdfIntegrator::integrateVoxel(
   Point merged_point_C = Point::Zero();
   FloatingPoint merged_weight = 0.0;
 
+  const size_t num_points = points_C.size();
   for (const size_t point_idx : point_C_indices) {
+    CHECK_LT(point_idx, num_points);
     const Point& point_C = points_C[point_idx];
     const Color& color = colors[point_idx];
 

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -233,7 +233,7 @@ float TsdfIntegratorBase::getVoxelWeight(const Point& point_C) const {
     return config_.voxel_weight_factor;
   }
   FloatingPoint point_depth = 0.0f;
-  switch (config_.optical_axis_convention) {
+  switch (config_.sensor_depth_direction_axis) {
     case CoordinateAxis::kX:
       point_depth = std::abs(point_C.x());
       break;

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -234,25 +234,23 @@ float TsdfIntegratorBase::getVoxelWeight(const Point& point_C) const {
   }
   FloatingPoint point_depth = 0.0f;
   switch (config_.optical_axis_convention) {
-    case CoordinateAxis::kX: {
+    case CoordinateAxis::kX:
       point_depth = std::abs(point_C.x());
       break;
-      case CoordinateAxis::kY:
-        point_depth = std::abs(point_C.y());
-        break;
-      case CoordinateAxis::kZ:
-        point_depth = std::abs(point_C.z());
-        break;
-      default:
-        LOG(FATAL)
-            << "Coordinate axis convention for optical axis is not valid.";
-    }
+    case CoordinateAxis::kY:
+      point_depth = std::abs(point_C.y());
+      break;
+    case CoordinateAxis::kZ:
+      point_depth = std::abs(point_C.z());
+      break;
+    default:
+      LOG(FATAL) << "Coordinate axis convention for optical axis is not valid.";
   }
   if (point_depth > kEpsilon) {
     return config_.voxel_weight_factor / (point_depth * point_depth);
   }
   return 0.0f;
-}
+}  // namespace voxblox
 
 void SimpleTsdfIntegrator::integratePointCloud(const Transformation& T_G_C,
                                                const Pointcloud& points_C,

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -232,9 +232,24 @@ float TsdfIntegratorBase::getVoxelWeight(const Point& point_C) const {
   if (config_.use_const_weight) {
     return config_.voxel_weight_factor;
   }
-  const FloatingPoint dist_z = std::abs(point_C.z());
-  if (dist_z > kEpsilon) {
-    return config_.voxel_weight_factor / (dist_z * dist_z);
+  FloatingPoint point_depth = 0.0f;
+  switch (config_.optical_axis_convention) {
+    case CoordinateAxis::kX: {
+      point_depth = std::abs(point_C.x());
+      break;
+      case CoordinateAxis::kY:
+        point_depth = std::abs(point_C.y());
+        break;
+      case CoordinateAxis::kZ:
+        point_depth = std::abs(point_C.z());
+        break;
+      default:
+        LOG(FATAL)
+            << "Coordinate axis convention for optical axis is not valid.";
+    }
+  }
+  if (point_depth > kEpsilon) {
+    return config_.voxel_weight_factor / (point_depth * point_depth);
   }
   return 0.0f;
 }


### PR DESCRIPTION
Note: As discussed with @victorreijgwart, this PR will go into `devel/7s` in a first stage.

The changes introduced in this PR do not change the default behavior of the tsdf integration.

The following parameters were added to the `TsdfIntegratorBase::Config`:

- `voxel_weight_factor`: allows to give an integrator a specific weight on voxels. this factor will either be divided by the squared point depth, or - if constant weight is enabled - be set as the voxel weight.
- `optical_axis_convention`: by default uses z as this is the most commonly used convention. however, it is now also possible to set another axis as the default one
- `use_only_first_point_for_clearing` (only `MergedTsdfIntegrator` specific): this was already enabled, but might not be the desired behavior in all cases as the overall weight on clearing rays will be much weaker, obviously depending on the number of points