### PR TITLE
Improved tsdf voxel merging and forEachVoxelInLayer(...) method.

### DIFF
--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -28,8 +28,7 @@ class Block {
   typedef std::shared_ptr<const Block<VoxelType> > ConstPtr;
 
   Block(size_t voxels_per_side, FloatingPoint voxel_size, const Point& origin)
-      : has_data_(false),
-        voxels_per_side_(voxels_per_side),
+      : voxels_per_side_(voxels_per_side),
         voxel_size_(voxel_size),
         origin_(origin),
         updated_(false) {
@@ -167,16 +166,12 @@ class Block {
   void setOrigin(const Point& new_origin) { origin_ = new_origin; }
   FloatingPoint block_size() const { return block_size_; }
 
-  bool has_data() const { return has_data_; }
-
   const std::bitset<Update::kCount>& updated() const { return updated_; }
   std::bitset<Update::kCount>& updated() { return updated_; }
-  bool& has_data() { return has_data_; }
 
   void set_updated(const std::bitset<Update::kCount>& updated) {
     updated_ = updated;
   }
-  void set_has_data(bool has_data) { has_data_ = has_data; }
 
   // Serialization.
   void getProto(BlockProto* proto) const;
@@ -192,9 +187,6 @@ class Block {
 
   // Derived, cached parameters.
   size_t num_voxels_;
-
-  /// Is set to true if any one of the voxels in this block received an update.
-  bool has_data_;
 
  private:
   void deserializeProto(const BlockProto& proto);

--- a/voxblox/include/voxblox/core/block_inl.h
+++ b/voxblox/include/voxblox/core/block_inl.h
@@ -96,10 +96,6 @@ void Block<VoxelType>::getProto(BlockProto* proto) const {
   proto->set_origin_y(origin_.y());
   proto->set_origin_z(origin_.z());
 
-  // This member does not exist within the block class definition anymore, but
-  // it will remain in the protobuf definition to maintain compatibility.
-  proto->set_has_data(true);
-
   std::vector<uint32_t> data;
   serializeToIntegers(&data);
   // Not quite actually a word since we're in a 64-bit age now, but whatever.

--- a/voxblox/include/voxblox/core/block_inl.h
+++ b/voxblox/include/voxblox/core/block_inl.h
@@ -112,15 +112,19 @@ template <typename VoxelType>
 void Block<VoxelType>::mergeBlock(const Block<VoxelType>& other_block) {
   CHECK_EQ(other_block.voxel_size(), voxel_size());
   CHECK_EQ(other_block.voxels_per_side(), voxels_per_side());
+  // LOG(INFO) << "before has_data(...) check.";
 
-  if (!other_block.has_data()) {
+  // if (!other_block.has_data()) {
+  if (false) {
     return;
   } else {
     has_data() = true;
     updated().set();
 
+    // LOG(INFO) << "before mergeVoxelAIntoVoxelB";
     for (IndexElement voxel_idx = 0;
          voxel_idx < static_cast<IndexElement>(num_voxels()); ++voxel_idx) {
+      // LOG(INFO) << "in mergeVoxelAIntoVoxelB";
       mergeVoxelAIntoVoxelB<VoxelType>(
           other_block.getVoxelByLinearIndex(voxel_idx),
           &(getVoxelByLinearIndex(voxel_idx)));

--- a/voxblox/include/voxblox/core/block_inl.h
+++ b/voxblox/include/voxblox/core/block_inl.h
@@ -112,23 +112,14 @@ template <typename VoxelType>
 void Block<VoxelType>::mergeBlock(const Block<VoxelType>& other_block) {
   CHECK_EQ(other_block.voxel_size(), voxel_size());
   CHECK_EQ(other_block.voxels_per_side(), voxels_per_side());
-  // LOG(INFO) << "before has_data(...) check.";
+  has_data() = true;
+  updated().set();
 
-  // if (!other_block.has_data()) {
-  if (false) {
-    return;
-  } else {
-    has_data() = true;
-    updated().set();
-
-    // LOG(INFO) << "before mergeVoxelAIntoVoxelB";
-    for (IndexElement voxel_idx = 0;
-         voxel_idx < static_cast<IndexElement>(num_voxels()); ++voxel_idx) {
-      // LOG(INFO) << "in mergeVoxelAIntoVoxelB";
-      mergeVoxelAIntoVoxelB<VoxelType>(
-          other_block.getVoxelByLinearIndex(voxel_idx),
-          &(getVoxelByLinearIndex(voxel_idx)));
-    }
+  for (IndexElement voxel_idx = 0;
+       voxel_idx < static_cast<IndexElement>(num_voxels()); ++voxel_idx) {
+    mergeVoxelAIntoVoxelB<VoxelType>(
+        other_block.getVoxelByLinearIndex(voxel_idx),
+        &(getVoxelByLinearIndex(voxel_idx)));
   }
 }
 

--- a/voxblox/include/voxblox/core/block_inl.h
+++ b/voxblox/include/voxblox/core/block_inl.h
@@ -74,8 +74,6 @@ template <typename VoxelType>
 Block<VoxelType>::Block(const BlockProto& proto)
     : Block(proto.voxels_per_side(), proto.voxel_size(),
             Point(proto.origin_x(), proto.origin_y(), proto.origin_z())) {
-  has_data_ = proto.has_data();
-
   // Convert the data into a vector of integers.
   std::vector<uint32_t> data;
   data.reserve(proto.voxel_data_size());
@@ -98,7 +96,9 @@ void Block<VoxelType>::getProto(BlockProto* proto) const {
   proto->set_origin_y(origin_.y());
   proto->set_origin_z(origin_.z());
 
-  proto->set_has_data(has_data_);
+  // This member does not exist within the block class definition anymore, but
+  // it will remain in the protobuf definition to maintain compatibility.
+  proto->set_has_data(true);
 
   std::vector<uint32_t> data;
   serializeToIntegers(&data);
@@ -112,7 +112,6 @@ template <typename VoxelType>
 void Block<VoxelType>::mergeBlock(const Block<VoxelType>& other_block) {
   CHECK_EQ(other_block.voxel_size(), voxel_size());
   CHECK_EQ(other_block.voxels_per_side(), voxels_per_side());
-  has_data() = true;
   updated().set();
 
   for (IndexElement voxel_idx = 0;
@@ -135,7 +134,6 @@ size_t Block<VoxelType>::getMemorySize() const {
   size += sizeof(voxel_size_inv_);
   size += sizeof(block_size_);
 
-  size += sizeof(has_data_);
   size += sizeof(updated_);
 
   if (num_voxels_ > 0u) {

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -30,12 +30,14 @@ class Layer {
   using BlockHashMap =
       typename AnyIndexHashMapType<typename BlockType::Ptr>::type;
   using BlockMapPair = typename std::pair<BlockIndex, typename BlockType::Ptr>;
-  using VoxelAction = std::function<void(const BlockIndex& /*block_index*/,
-                                         size_t /*linear_voxel_index*/,
-                                         const VoxelType& /*voxel*/)>;
+
+  // TODO(fabianbl): Output parameters have to change to pointers.
+  using VoxelAction = std::function<void(
+      const BlockIndex& /*block_index*/, const BlockType& /*block*/,
+      size_t /*linear_voxel_index*/, const VoxelType& /*voxel*/)>;
   using MutableVoxelAction = std::function<void(
-      const BlockIndex& /*block_index*/, size_t /*linear_voxel_index*/,
-      VoxelType& /*voxel*/)>;
+      const BlockIndex& /*block_index*/, BlockType* /*block*/,
+      size_t /*linear_voxel_index*/, VoxelType* /*voxel*/)>;
 
   explicit Layer(FloatingPoint voxel_size, size_t voxels_per_side)
       : voxel_size_(voxel_size), voxels_per_side_(voxels_per_side) {

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -244,33 +244,8 @@ class Layer {
     return &block.getVoxelByVoxelIndex(local_voxel_index);
   }
 
-  inline void forEachVoxelInLayer(const VoxelAction& voxel_action) const {
-    voxblox::BlockIndexList all_blocks;
-    getAllAllocatedBlocks(&all_blocks);
-    for (const voxblox::BlockIndex& block_index : all_blocks) {
-      const BlockType& block = getBlockByIndex(block_index);
-      for (size_t linear_voxel_index = 0u;
-           linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
-        const VoxelType& voxel =
-            block.getVoxelByLinearIndex(linear_voxel_index);
-        voxel_action(block_index, linear_voxel_index, voxel);
-      }
-    }
-  }
-
-  inline void forEachVoxelInLayer(const MutableVoxelAction& voxel_action) {
-    voxblox::BlockIndexList all_blocks;
-    getAllAllocatedBlocks(&all_blocks);
-    for (const voxblox::BlockIndex& block_index : all_blocks) {
-      BlockType& block = *CHECK_NOTNULL(getBlockPtrByIndex(block_index));
-      for (size_t linear_voxel_index = 0u;
-           linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
-        VoxelType& voxel =
-            block.getVoxelByLinearIndex(linear_voxel_index);
-        voxel_action(block_index, linear_voxel_index, voxel);
-      }
-    }
-  }
+  inline void forEachVoxelInLayer(const VoxelAction& voxel_action) const;
+  inline void forEachVoxelInLayer(const MutableVoxelAction& voxel_action);
 
   inline const VoxelType* getVoxelPtrByCoordinates(const Point& coords) const {
     typename Block<VoxelType>::ConstPtr block_ptr =

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -31,13 +31,12 @@ class Layer {
       typename AnyIndexHashMapType<typename BlockType::Ptr>::type;
   using BlockMapPair = typename std::pair<BlockIndex, typename BlockType::Ptr>;
 
-  // TODO(fabianbl): Output parameters have to change to pointers.
   using VoxelAction = std::function<void(
       const BlockIndex& /*block_index*/, const BlockType& /*block*/,
-      size_t /*linear_voxel_index*/, const VoxelType& /*voxel*/)>;
+      const size_t /*linear_voxel_index*/, const VoxelType& /*voxel*/)>;
   using MutableVoxelAction = std::function<void(
       const BlockIndex& /*block_index*/, BlockType* /*block*/,
-      size_t /*linear_voxel_index*/, VoxelType* /*voxel*/)>;
+      const size_t /*linear_voxel_index*/, VoxelType* /*voxel*/)>;
 
   explicit Layer(FloatingPoint voxel_size, size_t voxels_per_side)
       : voxel_size_(voxel_size), voxels_per_side_(voxels_per_side) {

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -1,11 +1,12 @@
 #ifndef VOXBLOX_CORE_LAYER_H_
 #define VOXBLOX_CORE_LAYER_H_
 
-#include <glog/logging.h>
 #include <functional>
 #include <memory>
 #include <string>
 #include <utility>
+
+#include <glog/logging.h>
 
 #include "./Block.pb.h"
 #include "./Layer.pb.h"
@@ -32,11 +33,11 @@ class Layer {
   using BlockMapPair = typename std::pair<BlockIndex, typename BlockType::Ptr>;
 
   using VoxelAction = std::function<void(
-      const BlockIndex& /*block_index*/, const BlockType& /*block*/,
-      const size_t /*linear_voxel_index*/, const VoxelType& /*voxel*/)>;
+      const BlockIndex& /*block_index*/, const size_t /*linear_voxel_index*/,
+      const BlockType& /*block*/, const VoxelType& /*voxel*/)>;
   using MutableVoxelAction = std::function<void(
-      const BlockIndex& /*block_index*/, BlockType* /*block*/,
-      const size_t /*linear_voxel_index*/, VoxelType* /*voxel*/)>;
+      const BlockIndex& /*block_index*/, const size_t /*linear_voxel_index*/,
+      BlockType* /*block*/, VoxelType* /*voxel*/)>;
 
   explicit Layer(FloatingPoint voxel_size, size_t voxels_per_side)
       : voxel_size_(voxel_size), voxels_per_side_(voxels_per_side) {

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -49,7 +49,7 @@ void Layer<VoxelType>::forEachVoxelInLayer(
     for (size_t linear_voxel_index = 0u;
          linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
       const VoxelType& voxel = block.getVoxelByLinearIndex(linear_voxel_index);
-      voxel_action(block_index, linear_voxel_index, voxel);
+      voxel_action(block_index, block, linear_voxel_index, voxel);
     }
   }
 }
@@ -64,7 +64,7 @@ void Layer<VoxelType>::forEachVoxelInLayer(
     for (size_t linear_voxel_index = 0u;
          linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
       VoxelType& voxel = block.getVoxelByLinearIndex(linear_voxel_index);
-      voxel_action(block_index, linear_voxel_index, voxel);
+      voxel_action(block_index, &block, linear_voxel_index, &voxel);
     }
   }
 }

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -49,7 +49,7 @@ void Layer<VoxelType>::forEachVoxelInLayer(
     for (size_t linear_voxel_index = 0u;
          linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
       const VoxelType& voxel = block.getVoxelByLinearIndex(linear_voxel_index);
-      voxel_action(block_index, block, linear_voxel_index, voxel);
+      voxel_action(block_index, linear_voxel_index, block, voxel);
     }
   }
 }
@@ -64,7 +64,7 @@ void Layer<VoxelType>::forEachVoxelInLayer(
     for (size_t linear_voxel_index = 0u;
          linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
       VoxelType& voxel = block.getVoxelByLinearIndex(linear_voxel_index);
-      voxel_action(block_index, &block, linear_voxel_index, &voxel);
+      voxel_action(block_index, linear_voxel_index, &block, &voxel);
     }
   }
 }

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -40,6 +40,21 @@ Layer<VoxelType>::Layer(const LayerProto& proto)
 }
 
 template <typename VoxelType>
+  const Layer<VoxelType>::VoxelType* getVoxelPtrByGlobalIndex(
+      const GlobalIndex& global_voxel_index) const {
+    const BlockIndex block_index = getBlockIndexFromGlobalVoxelIndex(
+        global_voxel_index, voxels_per_side_inv_);
+    if (!hasBlock(block_index)) {
+      return nullptr;
+    }
+    const VoxelIndex local_voxel_index =
+        getLocalFromGlobalVoxelIndex(global_voxel_index, voxels_per_side_);
+    const Block<VoxelType>& block = getBlockByIndex(block_index);
+    return &block.getVoxelByVoxelIndex(local_voxel_index);
+  }
+
+
+template <typename VoxelType>
 void Layer<VoxelType>::getProto(LayerProto* proto) const {
   CHECK_NOTNULL(proto);
 

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -60,7 +60,7 @@ void Layer<VoxelType>::forEachVoxelInLayer(
   voxblox::BlockIndexList all_blocks;
   getAllAllocatedBlocks(&all_blocks);
   for (const voxblox::BlockIndex& block_index : all_blocks) {
-    BlockType& block = *CHECK_NOTNULL(getBlockPtrByIndex(block_index));
+    BlockType& block = getBlockByIndex(block_index);
     for (size_t linear_voxel_index = 0u;
          linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
       VoxelType& voxel = block.getVoxelByLinearIndex(linear_voxel_index);

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -40,19 +40,34 @@ Layer<VoxelType>::Layer(const LayerProto& proto)
 }
 
 template <typename VoxelType>
-  const Layer<VoxelType>::VoxelType* getVoxelPtrByGlobalIndex(
-      const GlobalIndex& global_voxel_index) const {
-    const BlockIndex block_index = getBlockIndexFromGlobalVoxelIndex(
-        global_voxel_index, voxels_per_side_inv_);
-    if (!hasBlock(block_index)) {
-      return nullptr;
+void Layer<VoxelType>::forEachVoxelInLayer(
+    const VoxelAction& voxel_action) const {
+  voxblox::BlockIndexList all_blocks;
+  getAllAllocatedBlocks(&all_blocks);
+  for (const voxblox::BlockIndex& block_index : all_blocks) {
+    const BlockType& block = getBlockByIndex(block_index);
+    for (size_t linear_voxel_index = 0u;
+         linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
+      const VoxelType& voxel = block.getVoxelByLinearIndex(linear_voxel_index);
+      voxel_action(block_index, linear_voxel_index, voxel);
     }
-    const VoxelIndex local_voxel_index =
-        getLocalFromGlobalVoxelIndex(global_voxel_index, voxels_per_side_);
-    const Block<VoxelType>& block = getBlockByIndex(block_index);
-    return &block.getVoxelByVoxelIndex(local_voxel_index);
   }
+}
 
+template <typename VoxelType>
+void Layer<VoxelType>::forEachVoxelInLayer(
+    const MutableVoxelAction& voxel_action) {
+  voxblox::BlockIndexList all_blocks;
+  getAllAllocatedBlocks(&all_blocks);
+  for (const voxblox::BlockIndex& block_index : all_blocks) {
+    BlockType& block = *CHECK_NOTNULL(getBlockPtrByIndex(block_index));
+    for (size_t linear_voxel_index = 0u;
+         linear_voxel_index < block.num_voxels(); ++linear_voxel_index) {
+      VoxelType& voxel = block.getVoxelByLinearIndex(linear_voxel_index);
+      voxel_action(block_index, linear_voxel_index, voxel);
+    }
+  }
+}
 
 template <typename VoxelType>
 void Layer<VoxelType>::getProto(LayerProto* proto) const {

--- a/voxblox/include/voxblox/integrator/merge_integration.h
+++ b/voxblox/include/voxblox/integrator/merge_integration.h
@@ -130,6 +130,8 @@ void naiveTransformLayer(const Layer<VoxelType>& layer_in,
       VoxelType& output_voxel =
           output_block->getVoxelByVoxelIndex(getLocalFromGlobalVoxelIndex(
               global_output_voxel_idx, layer_out->voxels_per_side()));
+
+      interpolator.getVoxel(voxel_center, &output_voxel, /*interpolate*/ false);
     }
   }
 }
@@ -199,6 +201,12 @@ void transformLayer(const Layer<VoxelType>& layer_in,
       // find voxel centers location in the input
       const Point voxel_center =
           T_in_out * block->computeCoordinatesFromLinearIndex(voxel_idx);
+
+      // interpolate voxel
+      if (!interpolator.getVoxel(voxel_center, &voxel, /*interpolate*/ true)) {
+        // If interpolated value fails use nearest.
+        interpolator.getVoxel(voxel_center, &voxel, /*interpolate*/ false);
+      }
     }
   }
 }

--- a/voxblox/include/voxblox/integrator/merge_integration.h
+++ b/voxblox/include/voxblox/integrator/merge_integration.h
@@ -130,10 +130,6 @@ void naiveTransformLayer(const Layer<VoxelType>& layer_in,
       VoxelType& output_voxel =
           output_block->getVoxelByVoxelIndex(getLocalFromGlobalVoxelIndex(
               global_output_voxel_idx, layer_out->voxels_per_side()));
-
-      if (interpolator.getVoxel(voxel_center, &output_voxel, false)) {
-        output_block->has_data() = true;
-      }
     }
   }
 }
@@ -203,19 +199,6 @@ void transformLayer(const Layer<VoxelType>& layer_in,
       // find voxel centers location in the input
       const Point voxel_center =
           T_in_out * block->computeCoordinatesFromLinearIndex(voxel_idx);
-
-      // interpolate voxel
-      if (interpolator.getVoxel(voxel_center, &voxel, true)) {
-        block->has_data() = true;
-
-        // if interpolated value fails use nearest
-      } else if (interpolator.getVoxel(voxel_center, &voxel, false)) {
-        block->has_data() = true;
-      }
-    }
-
-    if (!block->has_data()) {
-      layer_out->removeBlock(block_idx);
     }
   }
 }

--- a/voxblox/include/voxblox/interpolator/interpolator_inl.h
+++ b/voxblox/include/voxblox/interpolator/interpolator_inl.h
@@ -437,6 +437,15 @@ inline TsdfVoxel Interpolator<TsdfVoxel>::interpVoxel(
   return voxel;
 }
 
+template <>
+inline EsdfVoxel Interpolator<EsdfVoxel>::interpVoxel(
+    const InterpVector& q_vector, const EsdfVoxel** voxels) {
+  EsdfVoxel voxel;
+  voxel.distance = interpMember(q_vector, voxels, &getVoxelSdf);
+  voxel.observed = interpMember(q_vector, voxels, &getVoxelWeight);
+  return voxel;
+}
+
 }  // namespace voxblox
 
 #endif  // VOXBLOX_INTERPOLATOR_INTERPOLATOR_INL_H_

--- a/voxblox/include/voxblox/test/layer_test_utils.h
+++ b/voxblox/include/voxblox/test/layer_test_utils.h
@@ -157,8 +157,6 @@ void SetUpTestLayer(const IndexElement block_volume_diameter,
             (x * z + y) % layer->voxels_per_side());
 
         fillVoxelWithTestData(x, y, z, &voxel);
-
-        block->has_data() = true;
       }
     }
   }

--- a/voxblox/include/voxblox/utils/planning_utils_inl.h
+++ b/voxblox/include/voxblox/utils/planning_utils_inl.h
@@ -92,7 +92,6 @@ void fillSphereAroundPoint(const Point& center, const FloatingPoint radius,
         voxel.hallucinated = true;
         voxel.fixed = true;
         block_ptr->updated().set();
-        block_ptr->has_data() = true;
       }
     }
   }
@@ -127,7 +126,6 @@ void clearSphereAroundPoint(const Point& center, const FloatingPoint radius,
         voxel.hallucinated = true;
         voxel.fixed = true;
         block_ptr->updated().set();
-        block_ptr->has_data() = true;
       }
     }
   }

--- a/voxblox/proto/voxblox/Block.proto
+++ b/voxblox/proto/voxblox/Block.proto
@@ -10,6 +10,8 @@ message BlockProto {
   optional double origin_y = 4;
   optional double origin_z = 5;
 
+  // Note: the has_data attribute is no longer a member of the block class, but
+  // will stay here to avoid compatibility issues.
   optional bool has_data = 6;
 
   repeated uint32 voxel_data = 7;

--- a/voxblox/src/core/tsdf_map.cc
+++ b/voxblox/src/core/tsdf_map.cc
@@ -31,10 +31,6 @@ unsigned int TsdfMap::coordPlaneSliceGetDistanceWeight(
     // Iterate over all voxels in said blocks.
     const Block<TsdfVoxel>& block = tsdf_layer_->getBlockByIndex(index);
 
-    if (!block.has_data()) {
-      continue;
-    }
-
     const Point origin = block.origin();
     if (std::abs(origin(free_plane_index) - free_plane_val) >
         block.block_size()) {

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -119,6 +119,16 @@ void EsdfIntegrator::updateFromTsdfLayer(bool clear_updated_flag) {
       }
     }
   }
+
+  // Clear all esdf blocks which are no longer allocated in the corresponding
+  // tsdf layer.
+  BlockIndexList allocated_esdf_blocks;
+  esdf_layer_->getAllAllocatedBlocks(&allocated_esdf_blocks);
+  for (const BlockIndex& esdf_block_index : allocated_esdf_blocks) {
+    if (!tsdf_layer_->hasBlock(esdf_block_index)) {
+      esdf_layer_->removeBlock(esdf_block_index);
+    }
+  }
 }
 
 void EsdfIntegrator::updateFromTsdfBlocks(const BlockIndexList& tsdf_blocks,

--- a/voxblox/src/utils/voxel_utils.cc
+++ b/voxblox/src/utils/voxel_utils.cc
@@ -31,7 +31,7 @@ void mergeVoxelAIntoVoxelB(const TsdfVoxel& voxel_A, TsdfVoxel* voxel_B) {
   } else {
     // If the combined voxel weight is smaller or equal to 0, and one of voxel
     // weights is smaller than 0, this means that we try to substract the two
-    // (e.g. an integrated point cloud that we want remove again). In this
+    // (e.g. an integrated point cloud that we want to remove again). In this
     // case, we just reset the voxel.
     *voxel_B = TsdfVoxel();
   }

--- a/voxblox/src/utils/voxel_utils.cc
+++ b/voxblox/src/utils/voxel_utils.cc
@@ -17,7 +17,6 @@ void mergeVoxelAIntoVoxelB(const TsdfVoxel& voxel_A, TsdfVoxel* voxel_B) {
   float combined_weight = voxel_A.weight + voxel_B->weight;
   // Check for overflow and reset the combined weight in this case.
   if (!std::isfinite(combined_weight)) {
-    LOG(WARNING) << "overflow";
     combined_weight = std::numeric_limits<float>::max();
   }
   if (combined_weight > 0) {

--- a/voxblox/src/utils/voxel_utils.cc
+++ b/voxblox/src/utils/voxel_utils.cc
@@ -1,5 +1,10 @@
 #include "voxblox/utils/voxel_utils.h"
 
+#include <cmath>
+#include <limits>
+
+#include <glog/logging.h>
+
 #include "voxblox/core/color.h"
 #include "voxblox/core/common.h"
 #include "voxblox/core/voxel.h"
@@ -8,7 +13,13 @@ namespace voxblox {
 
 template <>
 void mergeVoxelAIntoVoxelB(const TsdfVoxel& voxel_A, TsdfVoxel* voxel_B) {
+  CHECK_NOTNULL(voxel_B);
   float combined_weight = voxel_A.weight + voxel_B->weight;
+  // Check for overflow and reset the combined weight in this case.
+  if (!std::isfinite(combined_weight)) {
+    LOG(WARNING) << "overflow";
+    combined_weight = std::numeric_limits<float>::max();
+  }
   if (combined_weight > 0) {
     voxel_B->distance = (voxel_A.distance * voxel_A.weight +
                          voxel_B->distance * voxel_B->weight) /
@@ -18,6 +29,12 @@ void mergeVoxelAIntoVoxelB(const TsdfVoxel& voxel_A, TsdfVoxel* voxel_B) {
                                            voxel_B->color, voxel_B->weight);
 
     voxel_B->weight = combined_weight;
+  } else {
+    // If the combined voxel weight is smaller or equal to 0, and one of voxel
+    // weights is smaller than 0, this means that we try to substract the two
+    // (e.g. an integrated point cloud that we want remove again). In this
+    // case, we just reset the voxel.
+    *voxel_B = TsdfVoxel();
   }
 }
 

--- a/voxblox/src/utils/voxel_utils.cc
+++ b/voxblox/src/utils/voxel_utils.cc
@@ -29,10 +29,10 @@ void mergeVoxelAIntoVoxelB(const TsdfVoxel& voxel_A, TsdfVoxel* voxel_B) {
 
     voxel_B->weight = combined_weight;
   } else {
-    // If the combined voxel weight is smaller or equal to 0, and one of voxel
-    // weights is smaller than 0, this means that we try to substract the two
-    // (e.g. an integrated point cloud that we want to remove again). In this
-    // case, we just reset the voxel.
+    // If the combined voxel weight is smaller or equal to 0, this means that
+    // at least one of the voxel weights is smaller than 0 and we try to
+    // substract the two (e.g. an integrated point cloud that we want to remove
+    // again). In this case, we just reset the voxel.
     *voxel_B = TsdfVoxel();
   }
 }

--- a/voxblox/test/test_tsdf_interpolator.cc
+++ b/voxblox/test/test_tsdf_interpolator.cc
@@ -2,7 +2,6 @@
 #include <eigen-checks/gtest.h>
 #include <gtest/gtest.h>
 
-//#include "voxblox/core/tsdf_map.h"
 #include "voxblox/core/common.h"
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"
@@ -37,15 +36,12 @@ class TsdfMergeIntegratorTest : public ::testing::Test {
         }
       }
     }
-    // Setting has data flag
-    block_ptr->has_data() = true;
-  }
+    }
 };
 
 TEST_F(TsdfMergeIntegratorTest, WithinBlock) {
   // New layer
-  Layer<TsdfVoxel> tsdf_layer(tsdf_voxel_size_,
-                              tsdf_voxels_per_side_);
+  Layer<TsdfVoxel> tsdf_layer(tsdf_voxel_size_, tsdf_voxels_per_side_);
 
   // Allocating the block;
   Point origin(0.0, 0.0, 0.0);
@@ -63,7 +59,6 @@ TEST_F(TsdfMergeIntegratorTest, WithinBlock) {
         // Setting voxel
         voxel_ref.distance = z;
         voxel_ref.weight = 1.0;
-        block_ptr->has_data() = true;
       }
     }
   }
@@ -107,8 +102,7 @@ TEST_F(TsdfMergeIntegratorTest, WithinBlock) {
 
 TEST_F(TsdfMergeIntegratorTest, BetweenBlocks) {
   // New layer
-  Layer<TsdfVoxel> tsdf_layer(tsdf_voxel_size_,
-                              tsdf_voxels_per_side_);
+  Layer<TsdfVoxel> tsdf_layer(tsdf_voxel_size_, tsdf_voxels_per_side_);
 
   // Allocating some blocks (in a sort of 3D plus pattern)
   Block<TsdfVoxel>::Ptr block_ptr_0 =

--- a/voxblox/test/test_tsdf_interpolator.cc
+++ b/voxblox/test/test_tsdf_interpolator.cc
@@ -36,7 +36,7 @@ class TsdfMergeIntegratorTest : public ::testing::Test {
         }
       }
     }
-    }
+  }
 };
 
 TEST_F(TsdfMergeIntegratorTest, WithinBlock) {
@@ -157,7 +157,8 @@ TEST_F(TsdfMergeIntegratorTest, BetweenBlocks) {
     Point point = points_below[point_index];
     interpolator.getVoxel(point, &voxel, true);
     // Testing
-    EXPECT_NEAR(voxel.distance, expected_answers_below[point_index], compare_tol_);
+    EXPECT_NEAR(voxel.distance, expected_answers_below[point_index],
+                compare_tol_);
   }
 }
 


### PR DESCRIPTION
This PR contains the following main changes:

- When using the `mergeLayerAintoLayerB`, we don't check if the `has_data` flag of the blocks is set to true. As far as I could see, this doesn't make much sense though as we never set it in any of the tsdf integrators. The other option would obviously be to set this flag directly in the integrators, but then this is also hard to maintain as we would need a mechanism to detect when a block is empty again. So I suggest to skip the `has_data()` check when merging the tsdf blocks. (`grep` output for `has_data` is printed at the bottom.
- Added two `forEachVoxelInLayer(...)` methods which allow to iterate through all voxels in the corresponding layer. One of them has a mutable callback, so we can modify the content of the voxels there.
- Added a `EsdfVoxel` interpolation as otherwise, calling layer subsampling in `mergeLayerAintoLayerB` would result in undefined references.
- In the incremental esdf update, deleted tsdf blocks would not be detected, but we would want to keep the number of esdf blocks bounded. Therefore, there is now an additional step which checks if all allocated esdf blocks have a counterpart in the tsdf map, otherwise they get deleted.





grep output for `has_data`:
```
./voxblox/proto/voxblox/Block.proto:  optional bool has_data = 6;
./voxblox/src/core/tsdf_map.cc:    if (!block.has_data()) {
./voxblox/test/test_tsdf_interpolator.cc:    block_ptr->has_data() = true;
./voxblox/test/test_tsdf_interpolator.cc:        block_ptr->has_data() = true;
./voxblox/include/voxblox/utils/planning_utils_inl.h:        block_ptr->has_data() = true;
./voxblox/include/voxblox/utils/planning_utils_inl.h:        block_ptr->has_data() = true;
./voxblox/include/voxblox/core/block_inl.h:  has_data_ = proto.has_data();
./voxblox/include/voxblox/core/block_inl.h:  proto->set_has_data(has_data_);
./voxblox/include/voxblox/core/block_inl.h:  has_data() = true;
./voxblox/include/voxblox/core/block_inl.h:  size += sizeof(has_data_);
./voxblox/include/voxblox/core/block.h:      : has_data_(false),
./voxblox/include/voxblox/core/block.h:  bool has_data() const { return has_data_; }
./voxblox/include/voxblox/core/block.h:  bool& has_data() { return has_data_; }
./voxblox/include/voxblox/core/block.h:  void set_has_data(bool has_data) { has_data_ = has_data; }
./voxblox/include/voxblox/core/block.h:  bool has_data_;
./voxblox/include/voxblox/integrator/merge_integration.h:        output_block->has_data() = true;
./voxblox/include/voxblox/integrator/merge_integration.h:        block->has_data() = true;
./voxblox/include/voxblox/integrator/merge_integration.h:        block->has_data() = true;
./voxblox/include/voxblox/integrator/merge_integration.h:    if (!block->has_data()) {
./voxblox/include/voxblox/test/layer_test_utils.h:        block->has_data() = true;
```