### PR TITLE
include gflags header

### DIFF
--- a/voxblox_ros/src/esdf_server_node.cc
+++ b/voxblox_ros/src/esdf_server_node.cc
@@ -1,4 +1,5 @@
 #include "voxblox_ros/esdf_server.h"
+#include <gflags/gflags.h>
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "voxblox");

--- a/voxblox_ros/src/intensity_server_node.cc
+++ b/voxblox_ros/src/intensity_server_node.cc
@@ -1,4 +1,5 @@
 #include "voxblox_ros/intensity_server.h"
+#include <gflags/gflags.h>
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "voxblox");

--- a/voxblox_ros/src/tsdf_server_node.cc
+++ b/voxblox_ros/src/tsdf_server_node.cc
@@ -1,4 +1,5 @@
 #include "voxblox_ros/tsdf_server.h"
+#include <gflags/gflags.h>
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "voxblox");

--- a/voxblox_ros/src/voxblox_eval.cc
+++ b/voxblox_ros/src/voxblox_eval.cc
@@ -9,6 +9,7 @@
 #include <pcl_ros/point_cloud.h>
 #include <pcl_ros/transforms.h>
 #include <ros/ros.h>
+#include <gflags/gflags.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <std_srvs/Empty.h>
 #include <tf/transform_listener.h>


### PR DESCRIPTION
Added gflags include statement to nodes, otherwise voxblox_ros won't compile on a clean system setup with 
`error: ‘ParseCommandLineFlags’ is not a member of ‘google’`