### PR TITLE
Added a getter to a const pointer.

### DIFF
--- a/voxblox/include/voxblox/core/tsdf_map.h
+++ b/voxblox/include/voxblox/core/tsdf_map.h
@@ -58,6 +58,7 @@ class TsdfMap {
   virtual ~TsdfMap() {}
 
   Layer<TsdfVoxel>* getTsdfLayerPtr() { return tsdf_layer_.get(); }
+  const Layer<TsdfVoxel>* getTsdfLayerConstPtr() const { return tsdf_layer_.get(); }
   const Layer<TsdfVoxel>& getTsdfLayer() const { return *tsdf_layer_; }
 
   FloatingPoint block_size() const { return block_size_; }


### PR DESCRIPTION
This function is useful if you are holding a const reference to a TSDF map and need to operate on it through pointer-based access. In particular, because our interpolators take interpolated layers as const pointers rather than references (not sure why) this function is necessary to interpolate on a const tsdf_map.