### PR TITLE
Fix/protobuf indexing limits

### DIFF
--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -33,9 +33,10 @@ bool LoadBlocksFromFile(
 
 template <typename VoxelType>
 bool LoadBlocksFromStream(
-    const size_t num_blocks, typename Layer<VoxelType>::BlockMergingStrategy strategy,
+    const size_t num_blocks,
+    typename Layer<VoxelType>::BlockMergingStrategy strategy,
     std::fstream* proto_file_ptr, Layer<VoxelType>* layer_ptr,
-    uint32_t* tmp_byte_offset_ptr);
+    uint64_t* tmp_byte_offset_ptr);
 
 /**
 * Unlike LoadBlocks above, this actually allocates the layer as well.

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -1,7 +1,8 @@
-#ifndef VOXBLOX_CORE_IO_LAYER_IO_INL_H_
-#define VOXBLOX_CORE_IO_LAYER_IO_INL_H_
+#ifndef VOXBLOX_IO_LAYER_IO_INL_H_
+#define VOXBLOX_IO_LAYER_IO_INL_H_
 
 #include <fstream>
+#include <string>
 
 #include "voxblox/Block.pb.h"
 #include "voxblox/Layer.pb.h"
@@ -244,4 +245,4 @@ bool SaveLayerSubset(const Layer<VoxelType>& layer,
 }  // namespace io
 }  // namespace voxblox
 
-#endif  // VOXBLOX_CORE_IO_LAYER_IO_INL_H_
+#endif  // VOXBLOX_IO_LAYER_IO_INL_H_

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -29,7 +29,7 @@ bool LoadBlocksFromFile(
 
   // Byte offset result, used to keep track where we are in the file if
   // necessary.
-  uint32_t tmp_byte_offset = 0;
+  uint64_t tmp_byte_offset = 0;
 
   bool layer_found = false;
 
@@ -105,7 +105,7 @@ bool LoadBlocksFromStream(
     const size_t num_blocks,
     typename Layer<VoxelType>::BlockMergingStrategy strategy,
     std::fstream* proto_file_ptr, Layer<VoxelType>* layer_ptr,
-    uint32_t* tmp_byte_offset_ptr) {
+    uint64_t* tmp_byte_offset_ptr) {
   CHECK_NOTNULL(proto_file_ptr);
   CHECK_NOTNULL(layer_ptr);
   CHECK_NOTNULL(tmp_byte_offset_ptr);
@@ -143,7 +143,7 @@ bool LoadLayer(const std::string& file_path, const bool multiple_layer_support,
 
   // Byte offset result, used to keep track where we are in the file if
   // necessary.
-  uint32_t tmp_byte_offset = 0;
+  uint64_t tmp_byte_offset = 0;
 
   bool layer_found = false;
 

--- a/voxblox/include/voxblox/utils/protobuf_utils.h
+++ b/voxblox/include/voxblox/utils/protobuf_utils.h
@@ -10,14 +10,14 @@ namespace voxblox {
 
 namespace utils {
 bool readProtoMsgCountToStream(std::fstream* stream_in, uint32_t* message_count,
-                               uint32_t* byte_offset);
+                               uint64_t* byte_offset);
 
 bool writeProtoMsgCountToStream(uint32_t message_count,
                                 std::fstream* stream_out);
 
 bool readProtoMsgFromStream(std::fstream* stream_in,
                             google::protobuf::Message* message,
-                            uint32_t* byte_offset);
+                            uint64_t* byte_offset);
 
 bool writeProtoMsgToStream(const google::protobuf::Message& message,
                            std::fstream* stream_out);

--- a/voxblox/src/utils/protobuf_utils.cc
+++ b/voxblox/src/utils/protobuf_utils.cc
@@ -8,7 +8,7 @@ namespace voxblox {
 
 namespace utils {
 bool readProtoMsgCountToStream(std::fstream* stream_in, uint32_t* message_count,
-                               uint32_t* byte_offset) {
+                               uint64_t* byte_offset) {
   CHECK_NOTNULL(stream_in);
   CHECK_NOTNULL(message_count);
   CHECK_NOTNULL(byte_offset);
@@ -39,7 +39,7 @@ bool writeProtoMsgCountToStream(uint32_t message_count,
 
 bool readProtoMsgFromStream(std::fstream* stream_in,
                             google::protobuf::Message* message,
-                            uint32_t* byte_offset) {
+                            uint64_t* byte_offset) {
   CHECK_NOTNULL(stream_in);
   CHECK_NOTNULL(message);
   CHECK_NOTNULL(byte_offset);


### PR DESCRIPTION
We were indexing saved maps (protobuf streams) with a 32bit variable implicitly limiting our map size to ~4Gbs, and causing a very difficult to debug error if they were more.

The indexing variable is now 64bit.

~Note: I've branched off #313 inadvertently. We should probably merge that anyway.~