### PR TITLE
Fix style by running clang-format once and updating include order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,7 @@
 Language: Cpp
 BasedOnStyle: Google
 ColumnLimit: 80
+IncludeBlocks: Preserve
 ---
 Language: Proto
 BasedOnStyle: Google

--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -15,7 +15,7 @@ namespace voxblox {
 namespace Update {
 /// Status of which derived things still need to be updated.
 enum Status { kMap, kMesh, kEsdf, kCount };
-}
+}  // namespace Update
 
 /** An n x n x n container holding VoxelType. It is aware of its 3D position and
  * contains functions for accessing voxels by position and index */

--- a/voxblox/include/voxblox/core/esdf_map.h
+++ b/voxblox/include/voxblox/core/esdf_map.h
@@ -1,16 +1,16 @@
 #ifndef VOXBLOX_CORE_ESDF_MAP_H_
 #define VOXBLOX_CORE_ESDF_MAP_H_
 
-#include <glog/logging.h>
 #include <memory>
 #include <string>
 #include <utility>
+
+#include <glog/logging.h>
 
 #include "voxblox/core/common.h"
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"
 #include "voxblox/interpolator/interpolator.h"
-
 #include "voxblox/io/layer_io.h"
 
 namespace voxblox {

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -1,10 +1,11 @@
 #ifndef VOXBLOX_CORE_LAYER_H_
 #define VOXBLOX_CORE_LAYER_H_
 
-#include <glog/logging.h>
 #include <memory>
 #include <string>
 #include <utility>
+
+#include <glog/logging.h>
 
 #include "voxblox/Block.pb.h"
 #include "voxblox/Layer.pb.h"

--- a/voxblox/include/voxblox/core/occupancy_map.h
+++ b/voxblox/include/voxblox/core/occupancy_map.h
@@ -1,9 +1,10 @@
 #ifndef VOXBLOX_CORE_OCCUPANCY_MAP_H_
 #define VOXBLOX_CORE_OCCUPANCY_MAP_H_
 
-#include <glog/logging.h>
 #include <memory>
 #include <utility>
+
+#include <glog/logging.h>
 
 #include "voxblox/core/common.h"
 #include "voxblox/core/layer.h"

--- a/voxblox/include/voxblox/core/tsdf_map.h
+++ b/voxblox/include/voxblox/core/tsdf_map.h
@@ -1,10 +1,11 @@
 #ifndef VOXBLOX_CORE_TSDF_MAP_H_
 #define VOXBLOX_CORE_TSDF_MAP_H_
 
-#include <glog/logging.h>
 #include <memory>
 #include <string>
 #include <utility>
+
+#include <glog/logging.h>
 
 #include "voxblox/core/common.h"
 #include "voxblox/core/layer.h"
@@ -44,8 +45,7 @@ class TsdfMap {
 
   /// Creates a new TsdfMap that contains this layer.
   explicit TsdfMap(Layer<TsdfVoxel>::Ptr layer)
-      : tsdf_layer_(layer),
-        interpolator_(tsdf_layer_.get()) {
+      : tsdf_layer_(layer), interpolator_(tsdf_layer_.get()) {
     if (!layer) {
       /* NOTE(mereweth@jpl.nasa.gov) - throw std exception for Python to catch
        * This is idiomatic when wrapping C++ code for Python, especially with
@@ -62,7 +62,9 @@ class TsdfMap {
   virtual ~TsdfMap() {}
 
   Layer<TsdfVoxel>* getTsdfLayerPtr() { return tsdf_layer_.get(); }
-  const Layer<TsdfVoxel>* getTsdfLayerConstPtr() const { return tsdf_layer_.get(); }
+  const Layer<TsdfVoxel>* getTsdfLayerConstPtr() const {
+    return tsdf_layer_.get();
+  }
   const Layer<TsdfVoxel>& getTsdfLayer() const { return *tsdf_layer_; }
 
   FloatingPoint block_size() const { return block_size_; }
@@ -91,8 +93,8 @@ class TsdfMap {
 
   bool getWeightAtPosition(const Eigen::Vector3d& position,
                            double* weight) const;
-  bool getWeightAtPosition(const Eigen::Vector3d& position,
-                           bool interpolate, double* weight) const;
+  bool getWeightAtPosition(const Eigen::Vector3d& position, bool interpolate,
+                           double* weight) const;
 
  protected:
   FloatingPoint block_size_;

--- a/voxblox/include/voxblox/core/tsdf_map.h
+++ b/voxblox/include/voxblox/core/tsdf_map.h
@@ -93,8 +93,8 @@ class TsdfMap {
 
   bool getWeightAtPosition(const Eigen::Vector3d& position,
                            double* weight) const;
-  bool getWeightAtPosition(const Eigen::Vector3d& position, bool interpolate,
-                           double* weight) const;
+  bool getWeightAtPosition(const Eigen::Vector3d& position,
+                           const bool interpolate, double* weight) const;
 
  protected:
   FloatingPoint block_size_;

--- a/voxblox/include/voxblox/integrator/esdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_integrator.h
@@ -1,12 +1,13 @@
 #ifndef VOXBLOX_INTEGRATOR_ESDF_INTEGRATOR_H_
 #define VOXBLOX_INTEGRATOR_ESDF_INTEGRATOR_H_
 
-#include <glog/logging.h>
-#include <Eigen/Core>
 #include <algorithm>
 #include <queue>
 #include <utility>
 #include <vector>
+
+#include <glog/logging.h>
+#include <Eigen/Core>
 
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"

--- a/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
+++ b/voxblox/include/voxblox/integrator/esdf_occ_integrator.h
@@ -1,12 +1,13 @@
 #ifndef VOXBLOX_INTEGRATOR_ESDF_OCC_INTEGRATOR_H_
 #define VOXBLOX_INTEGRATOR_ESDF_OCC_INTEGRATOR_H_
 
-#include <glog/logging.h>
-#include <Eigen/Core>
 #include <algorithm>
 #include <queue>
 #include <utility>
 #include <vector>
+
+#include <glog/logging.h>
+#include <Eigen/Core>
 
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"

--- a/voxblox/include/voxblox/integrator/intensity_integrator.h
+++ b/voxblox/include/voxblox/integrator/intensity_integrator.h
@@ -1,12 +1,13 @@
 #ifndef VOXBLOX_INTEGRATOR_INTENSITY_INTEGRATOR_H_
 #define VOXBLOX_INTEGRATOR_INTENSITY_INTEGRATOR_H_
 
-#include <glog/logging.h>
-#include <Eigen/Core>
 #include <algorithm>
 #include <queue>
 #include <utility>
 #include <vector>
+
+#include <glog/logging.h>
+#include <Eigen/Core>
 
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"

--- a/voxblox/include/voxblox/integrator/merge_integration.h
+++ b/voxblox/include/voxblox/integrator/merge_integration.h
@@ -7,11 +7,10 @@
 
 #include <glog/logging.h>
 
-#include "voxblox/interpolator/interpolator.h"
-
 #include "voxblox/core/common.h"
 #include "voxblox/core/layer.h"
 #include "voxblox/core/voxel.h"
+#include "voxblox/interpolator/interpolator.h"
 
 namespace voxblox {
 

--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -110,7 +110,7 @@ class TsdfIntegratorBase {
  protected:
   /// Thread safe.
   inline bool isPointValid(const Point& point_C, const bool freespace_point,
-                    bool* is_clearing) const {
+                           bool* is_clearing) const {
     DCHECK(is_clearing != nullptr);
     const FloatingPoint ray_distance = point_C.norm();
     if (ray_distance < config_.min_ray_length_m) {

--- a/voxblox/include/voxblox/interpolator/interpolator_inl.h
+++ b/voxblox/include/voxblox/interpolator/interpolator_inl.h
@@ -23,8 +23,7 @@ bool Interpolator<VoxelType>::getDistance(const Point& pos,
 }
 
 template <typename VoxelType>
-bool Interpolator<VoxelType>::getWeight(const Point& pos,
-                                        FloatingPoint* weight,
+bool Interpolator<VoxelType>::getWeight(const Point& pos, FloatingPoint* weight,
                                         bool interpolate) const {
   CHECK_NOTNULL(weight);
   if (interpolate) {
@@ -334,8 +333,8 @@ bool Interpolator<VoxelType>::getInterpWeight(const Point& pos,
 }
 
 template <typename VoxelType>
-bool Interpolator<VoxelType>::getNearestWeight(
-    const Point& pos, FloatingPoint* weight) const {
+bool Interpolator<VoxelType>::getNearestWeight(const Point& pos,
+                                               FloatingPoint* weight) const {
   CHECK_NOTNULL(weight);
 
   typename Layer<VoxelType>::BlockType::ConstPtr block_ptr =
@@ -411,7 +410,8 @@ inline float Interpolator<EsdfVoxel>::getVoxelSdf(const EsdfVoxel& voxel) {
 }
 
 template <typename VoxelType>
-inline float Interpolator<VoxelType>::getVoxelWeight(const VoxelType& /*voxel*/) {
+inline float Interpolator<VoxelType>::getVoxelWeight(
+    const VoxelType& /*voxel*/) {
   return 0.0;
 }
 

--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -39,10 +39,10 @@ bool LoadBlocksFromStream(
     uint64_t* tmp_byte_offset_ptr);
 
 /**
-* Unlike LoadBlocks above, this actually allocates the layer as well.
-* By default loads without multiple layer support (i.e., only checks the first
-* layer in the file).
-*/
+ * Unlike LoadBlocks above, this actually allocates the layer as well.
+ * By default loads without multiple layer support (i.e., only checks the first
+ * layer in the file).
+ */
 template <typename VoxelType>
 bool LoadLayer(const std::string& file_path,
                typename Layer<VoxelType>::Ptr* layer_ptr);

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -6,7 +6,6 @@
 
 #include "voxblox/Block.pb.h"
 #include "voxblox/Layer.pb.h"
-
 #include "voxblox/utils/protobuf_utils.h"
 
 namespace voxblox {

--- a/voxblox/include/voxblox/io/mesh_ply.h
+++ b/voxblox/include/voxblox/io/mesh_ply.h
@@ -23,11 +23,11 @@
 #ifndef VOXBLOX_IO_MESH_PLY_H_
 #define VOXBLOX_IO_MESH_PLY_H_
 
-#include "voxblox/mesh/mesh_layer.h"
-
 #include <fstream>
 #include <iostream>
 #include <string>
+
+#include "voxblox/mesh/mesh_layer.h"
 
 namespace voxblox {
 

--- a/voxblox/include/voxblox/test/layer_test_utils.h
+++ b/voxblox/include/voxblox/test/layer_test_utils.h
@@ -7,6 +7,7 @@
 #include "voxblox/core/voxel.h"
 
 namespace voxblox {
+
 namespace test {
 
 /**

--- a/voxblox/include/voxblox/utils/approx_hash_array.h
+++ b/voxblox/include/voxblox/utils/approx_hash_array.h
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <limits>
 #include <vector>
+
 #include "voxblox/core/common.h"
 
 /**

--- a/voxblox/include/voxblox/utils/bucket_queue.h
+++ b/voxblox/include/voxblox/utils/bucket_queue.h
@@ -1,10 +1,11 @@
 #ifndef VOXBLOX_UTILS_BUCKET_QUEUE_H_
 #define VOXBLOX_UTILS_BUCKET_QUEUE_H_
 
-#include <glog/logging.h>
 #include <deque>
 #include <queue>
 #include <vector>
+
+#include <glog/logging.h>
 
 #include "voxblox/core/common.h"
 

--- a/voxblox/include/voxblox/utils/color_maps.h
+++ b/voxblox/include/voxblox/utils/color_maps.h
@@ -4,8 +4,8 @@
 #include <algorithm>
 #include <vector>
 
-#include "voxblox/core/common.h"
 #include "voxblox/core/color.h"
+#include "voxblox/core/common.h"
 
 namespace voxblox {
 

--- a/voxblox/include/voxblox/utils/distance_utils.h
+++ b/voxblox/include/voxblox/utils/distance_utils.h
@@ -1,10 +1,10 @@
 #ifndef VOXBLOX_UTILS_DISTANCE_UTILS_H_
 #define VOXBLOX_UTILS_DISTANCE_UTILS_H_
 
-#include <voxblox/core/block.h>
-#include <voxblox/core/common.h>
-#include <voxblox/core/layer.h>
-#include <voxblox/core/voxel.h>
+#include "voxblox/core/block.h"
+#include "voxblox/core/common.h"
+#include "voxblox/core/layer.h"
+#include "voxblox/core/voxel.h"
 
 namespace voxblox {
 

--- a/voxblox/include/voxblox/utils/evaluation_utils.h
+++ b/voxblox/include/voxblox/utils/evaluation_utils.h
@@ -8,6 +8,7 @@
 #include "voxblox/core/voxel.h"
 
 namespace voxblox {
+
 namespace utils {
 
 enum class VoxelEvaluationResult { kNoOverlap, kIgnored, kEvaluated };

--- a/voxblox/include/voxblox/utils/layer_utils.h
+++ b/voxblox/include/voxblox/utils/layer_utils.h
@@ -10,6 +10,7 @@
 #include "voxblox/core/voxel.h"
 
 namespace voxblox {
+
 namespace utils {
 
 template <typename VoxelType>

--- a/voxblox/include/voxblox/utils/meshing_utils.h
+++ b/voxblox/include/voxblox/utils/meshing_utils.h
@@ -5,6 +5,7 @@
 #include "voxblox/core/voxel.h"
 
 namespace voxblox {
+
 namespace utils {
 
 template <typename VoxelType>

--- a/voxblox/include/voxblox/utils/planning_utils.h
+++ b/voxblox/include/voxblox/utils/planning_utils.h
@@ -5,6 +5,7 @@
 #include "voxblox/core/voxel.h"
 
 namespace voxblox {
+
 namespace utils {
 
 /// Gets the indices of all points within the sphere.

--- a/voxblox/include/voxblox/utils/planning_utils_inl.h
+++ b/voxblox/include/voxblox/utils/planning_utils_inl.h
@@ -7,6 +7,7 @@
 #include "voxblox/core/voxel.h"
 
 namespace voxblox {
+
 namespace utils {
 
 template <typename VoxelType>

--- a/voxblox/include/voxblox/utils/protobuf_utils.h
+++ b/voxblox/include/voxblox/utils/protobuf_utils.h
@@ -2,6 +2,7 @@
 #define VOXBLOX_UTILS_PROTOBUF_UTILS_H_
 
 #include <fstream>
+
 #include <glog/logging.h>
 #include <google/protobuf/message.h>
 #include <google/protobuf/message_lite.h>

--- a/voxblox/src/alignment/icp.cc
+++ b/voxblox/src/alignment/icp.cc
@@ -37,10 +37,9 @@
  * $Id$
  *
  */
+#include "voxblox/alignment/icp.h"
 
 #include <random>
-
-#include "voxblox/alignment/icp.h"
 
 namespace voxblox {
 

--- a/voxblox/src/core/block.cc
+++ b/voxblox/src/core/block.cc
@@ -1,4 +1,5 @@
 #include "voxblox/core/block.h"
+
 #include "voxblox/core/voxel.h"
 
 namespace voxblox {

--- a/voxblox/src/core/tsdf_map.cc
+++ b/voxblox/src/core/tsdf_map.cc
@@ -78,7 +78,6 @@ unsigned int TsdfMap::coordPlaneSliceGetDistanceWeight(
   return count;
 }
 
-
 bool TsdfMap::getWeightAtPosition(const Eigen::Vector3d& position,
                                   double* weight) const {
   constexpr bool interpolate = true;

--- a/voxblox/src/core/tsdf_map.cc
+++ b/voxblox/src/core/tsdf_map.cc
@@ -85,7 +85,8 @@ bool TsdfMap::getWeightAtPosition(const Eigen::Vector3d& position,
 }
 
 bool TsdfMap::getWeightAtPosition(const Eigen::Vector3d& position,
-                                  bool interpolate, double* weight) const {
+                                  const bool interpolate,
+                                  double* weight) const {
   FloatingPoint weight_fp;
   bool success = interpolator_.getWeight(position.cast<FloatingPoint>(),
                                          &weight_fp, interpolate);

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -1,6 +1,6 @@
-#include <voxblox/utils/planning_utils.h>
-
 #include "voxblox/integrator/esdf_integrator.h"
+
+#include "voxblox/utils/planning_utils.h"
 
 namespace voxblox {
 

--- a/voxblox/src/integrator/esdf_occ_integrator.cc
+++ b/voxblox/src/integrator/esdf_occ_integrator.cc
@@ -158,9 +158,8 @@ void EsdfOccIntegrator::processOpenSet() {
       const FloatingPoint distance_to_neighbor =
           distances[i] * esdf_voxel_size_;
 
-      if (!neighbor_voxel.fixed &&
-          esdf_voxel.distance + distance_to_neighbor <
-              neighbor_voxel.distance) {
+      if (!neighbor_voxel.fixed && esdf_voxel.distance + distance_to_neighbor <
+                                       neighbor_voxel.distance) {
         neighbor_voxel.distance = esdf_voxel.distance + distance_to_neighbor;
         // Also update parent.
         neighbor_voxel.parent = -directions[i];
@@ -173,9 +172,8 @@ void EsdfOccIntegrator::processOpenSet() {
         }
       }
 
-      if (neighbor_voxel.fixed &&
-          esdf_voxel.distance - distance_to_neighbor >
-              neighbor_voxel.distance) {
+      if (neighbor_voxel.fixed && esdf_voxel.distance - distance_to_neighbor >
+                                      neighbor_voxel.distance) {
         neighbor_voxel.distance = esdf_voxel.distance - distance_to_neighbor;
         // Also update parent.
         neighbor_voxel.parent = -directions[i];

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -1,4 +1,5 @@
 #include "voxblox/integrator/tsdf_integrator.h"
+
 #include <iostream>
 #include <list>
 

--- a/voxblox/src/io/mesh_ply.cc
+++ b/voxblox/src/io/mesh_ply.cc
@@ -86,7 +86,9 @@ bool outputMeshAsPly(const std::string& filename, const Mesh& mesh) {
   }
   if (mesh.hasTriangles()) {
     stream << "element face " << mesh.indices.size() / 3 << std::endl;
-    stream << "property list uchar int vertex_indices" << std::endl;  // pcl-1.7(ros::kinetic) breaks ply convention by not using "vertex_index"
+    stream << "property list uchar int vertex_indices"
+           << std::endl;  // pcl-1.7(ros::kinetic) breaks ply convention by not
+                          // using "vertex_index"
   }
   stream << "end_header" << std::endl;
   size_t vert_idx = 0;

--- a/voxblox/src/utils/camera_model.cc
+++ b/voxblox/src/utils/camera_model.cc
@@ -159,7 +159,8 @@ void CameraModel::calculateBoundingPlanes() {
     }
   }
 
-  VLOG(5) << "AABB min:\n" << aabb_min_.transpose() << "\nAABB max:\n"
+  VLOG(5) << "AABB min:\n"
+          << aabb_min_.transpose() << "\nAABB max:\n"
           << aabb_max_.transpose();
 }
 

--- a/voxblox/src/utils/evaluation_utils.cc
+++ b/voxblox/src/utils/evaluation_utils.cc
@@ -4,6 +4,7 @@
 #include "voxblox/core/voxel.h"
 
 namespace voxblox {
+
 namespace utils {
 
 template <>

--- a/voxblox/src/utils/layer_utils.cc
+++ b/voxblox/src/utils/layer_utils.cc
@@ -1,6 +1,7 @@
 #include "voxblox/utils/layer_utils.h"
 
 namespace voxblox {
+
 namespace utils {
 
 template <>

--- a/voxblox/src/utils/protobuf_utils.cc
+++ b/voxblox/src/utils/protobuf_utils.cc
@@ -1,8 +1,8 @@
+#include "voxblox/utils/protobuf_utils.h"
+
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
-
-#include "voxblox/utils/protobuf_utils.h"
 
 namespace voxblox {
 

--- a/voxblox/src/utils/timing.cc
+++ b/voxblox/src/utils/timing.cc
@@ -17,18 +17,19 @@
 
 /* Adapted from Paul Furgale Schweizer Messer sm_timing*/
 
+#include <math.h>
+#include <stdio.h>
 #include <algorithm>
 #include <ostream>
 #include <sstream>
-#include <stdio.h>
 #include <string>
-#include <math.h>
 
 #include <glog/logging.h>
 
 #include "voxblox/utils/timing.h"
 
 namespace voxblox {
+
 namespace timing {
 
 const double kNumSecondsPerNanosecond = 1.e-9;

--- a/voxblox/test/test_approx_hash_array.cc
+++ b/voxblox/test/test_approx_hash_array.cc
@@ -1,6 +1,7 @@
-#include <gtest/gtest.h>
-#include <random>
 #include <limits>
+#include <random>
+
+#include <gtest/gtest.h>
 
 #include "voxblox/core/block_hash.h"
 #include "voxblox/core/common.h"

--- a/voxblox/test/test_load_esdf.cc
+++ b/voxblox/test/test_load_esdf.cc
@@ -1,5 +1,5 @@
-#include <string>
 #include <memory>
+#include <string>
 
 #include <glog/logging.h>
 

--- a/voxblox/test/test_tsdf_interpolator.cc
+++ b/voxblox/test/test_tsdf_interpolator.cc
@@ -44,8 +44,7 @@ class TsdfMergeIntegratorTest : public ::testing::Test {
 
 TEST_F(TsdfMergeIntegratorTest, WithinBlock) {
   // New layer
-  Layer<TsdfVoxel> tsdf_layer(tsdf_voxel_size_,
-                              tsdf_voxels_per_side_);
+  Layer<TsdfVoxel> tsdf_layer(tsdf_voxel_size_, tsdf_voxels_per_side_);
 
   // Allocating the block;
   Point origin(0.0, 0.0, 0.0);
@@ -107,8 +106,7 @@ TEST_F(TsdfMergeIntegratorTest, WithinBlock) {
 
 TEST_F(TsdfMergeIntegratorTest, BetweenBlocks) {
   // New layer
-  Layer<TsdfVoxel> tsdf_layer(tsdf_voxel_size_,
-                              tsdf_voxels_per_side_);
+  Layer<TsdfVoxel> tsdf_layer(tsdf_voxel_size_, tsdf_voxels_per_side_);
 
   // Allocating some blocks (in a sort of 3D plus pattern)
   Block<TsdfVoxel>::Ptr block_ptr_0 =
@@ -163,7 +161,8 @@ TEST_F(TsdfMergeIntegratorTest, BetweenBlocks) {
     Point point = points_below[point_index];
     interpolator.getVoxel(point, &voxel, true);
     // Testing
-    EXPECT_NEAR(voxel.distance, expected_answers_below[point_index], compare_tol_);
+    EXPECT_NEAR(voxel.distance, expected_answers_below[point_index],
+                compare_tol_);
   }
 }
 

--- a/voxblox/test/tsdf_to_esdf.cc
+++ b/voxblox/test/tsdf_to_esdf.cc
@@ -1,6 +1,6 @@
-#include <string>
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 #include <glog/logging.h>
 
@@ -34,8 +34,7 @@ int main(int argc, char** argv) {
 
   LOG(INFO) << "Layer memory size: " << layer_from_file->getMemorySize();
   LOG(INFO) << "Layer voxel size: " << layer_from_file->voxel_size();
-  LOG(INFO) << "Layer voxels per side: "
-               << layer_from_file->voxels_per_side();
+  LOG(INFO) << "Layer voxels per side: " << layer_from_file->voxels_per_side();
 
   // ESDF maps.
   EsdfMap::Config esdf_config;

--- a/voxblox_ros/include/voxblox_ros/conversions.h
+++ b/voxblox_ros/include/voxblox_ros/conversions.h
@@ -1,12 +1,13 @@
 #ifndef VOXBLOX_ROS_CONVERSIONS_H_
 #define VOXBLOX_ROS_CONVERSIONS_H_
 
-#include <pcl/point_types.h>
-#include <pcl_ros/point_cloud.h>
-#include <std_msgs/ColorRGBA.h>
 #include <algorithm>
 #include <memory>
 #include <vector>
+
+#include <pcl/point_types.h>
+#include <pcl_ros/point_cloud.h>
+#include <std_msgs/ColorRGBA.h>
 
 #include <voxblox/core/common.h>
 #include <voxblox/core/layer.h>

--- a/voxblox_ros/include/voxblox_ros/intensity_server.h
+++ b/voxblox_ros/include/voxblox_ros/intensity_server.h
@@ -1,9 +1,10 @@
 #ifndef VOXBLOX_ROS_INTENSITY_SERVER_H_
 #define VOXBLOX_ROS_INTENSITY_SERVER_H_
 
+#include <memory>
+
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/Image.h>
-#include <memory>
 
 #include <voxblox/core/voxel.h>
 #include <voxblox/integrator/intensity_integrator.h>

--- a/voxblox_ros/include/voxblox_ros/interactive_slider.h
+++ b/voxblox_ros/include/voxblox_ros/interactive_slider.h
@@ -6,6 +6,7 @@
 
 #include <interactive_markers/interactive_marker_server.h>
 #include <visualization_msgs/InteractiveMarkerFeedback.h>
+
 #include <voxblox/core/common.h>
 
 namespace voxblox {

--- a/voxblox_ros/include/voxblox_ros/mesh_pcl.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_pcl.h
@@ -50,7 +50,7 @@ inline void toPCLPolygonMesh(
 
   Mesh mesh;
   convertMeshLayerToMesh(mesh_layer, &mesh, simplify_and_connect_mesh,
-                             vertex_proximity_threshold);
+                         vertex_proximity_threshold);
 
   // add points
   pointcloud.reserve(mesh.vertices.size());

--- a/voxblox_ros/include/voxblox_ros/mesh_vis.h
+++ b/voxblox_ros/include/voxblox_ros/mesh_vis.h
@@ -24,10 +24,11 @@
 #ifndef VOXBLOX_ROS_MESH_VIS_H_
 #define VOXBLOX_ROS_MESH_VIS_H_
 
-#include <eigen_conversions/eigen_msg.h>
-#include <visualization_msgs/Marker.h>
 #include <algorithm>
 #include <limits>
+
+#include <eigen_conversions/eigen_msg.h>
+#include <visualization_msgs/Marker.h>
 
 #include <voxblox/core/common.h>
 #include <voxblox/integrator/esdf_integrator.h>

--- a/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
+++ b/voxblox_ros/include/voxblox_ros/ptcloud_vis.h
@@ -319,8 +319,9 @@ inline void createSurfacePointcloudFromTsdfLayer(
     pcl::PointCloud<pcl::PointXYZRGB>* pointcloud) {
   CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(
-      layer, std::bind(&visualizeNearSurfaceTsdfVoxels, ph::_1, ph::_2,
-                       surface_distance, ph::_3),
+      layer,
+      std::bind(&visualizeNearSurfaceTsdfVoxels, ph::_1, ph::_2,
+                surface_distance, ph::_3),
       pointcloud);
 }
 
@@ -357,8 +358,9 @@ inline void createSurfaceDistancePointcloudFromTsdfLayer(
     pcl::PointCloud<pcl::PointXYZI>* pointcloud) {
   CHECK_NOTNULL(pointcloud);
   createColorPointcloudFromLayer<TsdfVoxel>(
-      layer, std::bind(&visualizeDistanceIntensityTsdfVoxelsNearSurface, ph::_1,
-                       ph::_2, surface_distance, ph::_3),
+      layer,
+      std::bind(&visualizeDistanceIntensityTsdfVoxelsNearSurface, ph::_1,
+                ph::_2, surface_distance, ph::_3),
       pointcloud);
 }
 
@@ -431,8 +433,9 @@ inline void createOccupancyBlocksFromTsdfLayer(
     visualization_msgs::MarkerArray* marker_array) {
   CHECK_NOTNULL(marker_array);
   createOccupancyBlocksFromLayer<TsdfVoxel>(
-      layer, std::bind(visualizeOccupiedTsdfVoxels, std::placeholders::_1,
-                       std::placeholders::_2, layer.voxel_size()),
+      layer,
+      std::bind(visualizeOccupiedTsdfVoxels, std::placeholders::_1,
+                std::placeholders::_2, layer.voxel_size()),
       frame_id, marker_array);
 }
 

--- a/voxblox_ros/include/voxblox_ros/simulation_server.h
+++ b/voxblox_ros/include/voxblox_ros/simulation_server.h
@@ -1,9 +1,10 @@
 #ifndef VOXBLOX_ROS_SIMULATION_SERVER_H_
 #define VOXBLOX_ROS_SIMULATION_SERVER_H_
 
-#include <ros/ros.h>
 #include <memory>
 #include <string>
+
+#include <ros/ros.h>
 
 #include <voxblox/core/esdf_map.h>
 #include <voxblox/core/tsdf_map.h>

--- a/voxblox_ros/include/voxblox_ros/transformer.h
+++ b/voxblox_ros/include/voxblox_ros/transformer.h
@@ -1,9 +1,10 @@
 #ifndef VOXBLOX_ROS_TRANSFORMER_H_
 #define VOXBLOX_ROS_TRANSFORMER_H_
 
+#include <string>
+
 #include <geometry_msgs/TransformStamped.h>
 #include <tf/transform_listener.h>
-#include <string>
 
 #include <voxblox/core/common.h>
 

--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -1,6 +1,10 @@
 #ifndef VOXBLOX_ROS_TSDF_SERVER_H_
 #define VOXBLOX_ROS_TSDF_SERVER_H_
 
+#include <memory>
+#include <queue>
+#include <string>
+
 #include <pcl/conversions.h>
 #include <pcl/filters/filter.h>
 #include <pcl/point_types.h>
@@ -11,9 +15,6 @@
 #include <std_srvs/Empty.h>
 #include <tf/transform_broadcaster.h>
 #include <visualization_msgs/MarkerArray.h>
-#include <memory>
-#include <queue>
-#include <string>
 
 #include <voxblox/alignment/icp.h>
 #include <voxblox/core/tsdf_map.h>
@@ -222,7 +223,6 @@ class TsdfServer {
    * iteration.
    */
   bool accumulate_icp_corrections_;
-
 
   /// Subscriber settings.
   int pointcloud_queue_size_;

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -1,6 +1,7 @@
+#include "voxblox_ros/esdf_server.h"
+
 #include <voxblox_ros/conversions.h>
 
-#include "voxblox_ros/esdf_server.h"
 #include "voxblox_ros/ros_params.h"
 
 namespace voxblox {

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -1,7 +1,6 @@
 #include "voxblox_ros/esdf_server.h"
 
-#include <voxblox_ros/conversions.h>
-
+#include "voxblox_ros/conversions.h"
 #include "voxblox_ros/ros_params.h"
 
 namespace voxblox {

--- a/voxblox_ros/src/esdf_server_node.cc
+++ b/voxblox_ros/src/esdf_server_node.cc
@@ -1,4 +1,5 @@
 #include "voxblox_ros/esdf_server.h"
+
 #include <gflags/gflags.h>
 
 int main(int argc, char** argv) {

--- a/voxblox_ros/src/intensity_server_node.cc
+++ b/voxblox_ros/src/intensity_server_node.cc
@@ -1,4 +1,5 @@
 #include "voxblox_ros/intensity_server.h"
+
 #include <gflags/gflags.h>
 
 int main(int argc, char** argv) {

--- a/voxblox_ros/src/interactive_slider.cc
+++ b/voxblox_ros/src/interactive_slider.cc
@@ -8,8 +8,7 @@ namespace voxblox {
 InteractiveSlider::InteractiveSlider(
     const std::string& slider_name,
     const std::function<void(const double& slice_level)>& slider_callback,
-    const Point& initial_position,
-    const unsigned int free_plane_index,
+    const Point& initial_position, const unsigned int free_plane_index,
     const float marker_scale_meters)
     : free_plane_index_(free_plane_index),
       interactive_marker_server_(slider_name) {

--- a/voxblox_ros/src/simulation_server.cc
+++ b/voxblox_ros/src/simulation_server.cc
@@ -220,8 +220,8 @@ void SimulationServer::generateSDF() {
 
     CHECK_NOTNULL(world_);
     world_->getPointcloudFromViewpoint(view_origin, view_direction,
-                                      depth_camera_resolution_, fov_h_rad_,
-                                      max_dist_, &ptcloud, &colors);
+                                       depth_camera_resolution_, fov_h_rad_,
+                                       max_dist_, &ptcloud, &colors);
 
     // Get T_G_C from ray origin and ray direction.
     Transformation T_G_C(view_origin,

--- a/voxblox_ros/src/tsdf_server.cc
+++ b/voxblox_ros/src/tsdf_server.cc
@@ -1,9 +1,10 @@
+#include "voxblox_ros/tsdf_server.h"
+
 #include <minkindr_conversions/kindr_msg.h>
 #include <minkindr_conversions/kindr_tf.h>
+
 #include "voxblox_ros/conversions.h"
 #include "voxblox_ros/ros_params.h"
-
-#include "voxblox_ros/tsdf_server.h"
 
 namespace voxblox {
 
@@ -208,7 +209,6 @@ void TsdfServer::getServerConfigFromRosParam(
   }
   color_map_->setMaxValue(intensity_max_value);
 }
-
 
 void TsdfServer::processPointCloudMessageAndInsert(
     const sensor_msgs::PointCloud2::Ptr& pointcloud_msg,

--- a/voxblox_ros/src/tsdf_server_node.cc
+++ b/voxblox_ros/src/tsdf_server_node.cc
@@ -1,4 +1,5 @@
 #include "voxblox_ros/tsdf_server.h"
+
 #include <gflags/gflags.h>
 
 int main(int argc, char** argv) {

--- a/voxblox_ros/src/voxblox_eval.cc
+++ b/voxblox_ros/src/voxblox_eval.cc
@@ -1,3 +1,6 @@
+#include <deque>
+
+#include <gflags/gflags.h>
 #include <minkindr_conversions/kindr_msg.h>
 #include <minkindr_conversions/kindr_tf.h>
 #include <minkindr_conversions/kindr_xml.h>
@@ -9,12 +12,10 @@
 #include <pcl_ros/point_cloud.h>
 #include <pcl_ros/transforms.h>
 #include <ros/ros.h>
-#include <gflags/gflags.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <std_srvs/Empty.h>
 #include <tf/transform_listener.h>
 #include <visualization_msgs/MarkerArray.h>
-#include <deque>
 
 #include <voxblox/core/esdf_map.h>
 #include <voxblox/core/occupancy_map.h>

--- a/voxblox_rviz_plugin/include/voxblox_rviz_plugin/voxblox_mesh_display.h
+++ b/voxblox_rviz_plugin/include/voxblox_rviz_plugin/voxblox_mesh_display.h
@@ -1,9 +1,10 @@
 #ifndef VOXBLOX_RVIZ_PLUGIN_VOXBLOX_MESH_DISPLAY_H_
 #define VOXBLOX_RVIZ_PLUGIN_VOXBLOX_MESH_DISPLAY_H_
 
+#include <memory>
+
 #include <rviz/message_filter_display.h>
 #include <voxblox_msgs/Mesh.h>
-#include <memory>
 
 #include "voxblox_rviz_plugin/voxblox_mesh_visual.h"
 

--- a/voxblox_rviz_plugin/src/voxblox_mesh_display.cc
+++ b/voxblox_rviz_plugin/src/voxblox_mesh_display.cc
@@ -1,3 +1,5 @@
+#include "voxblox_rviz_plugin/voxblox_mesh_display.h"
+
 #include <OGRE/OgreSceneManager.h>
 #include <OGRE/OgreSceneNode.h>
 
@@ -5,8 +7,6 @@
 
 #include <rviz/frame_manager.h>
 #include <rviz/visualization_manager.h>
-
-#include "voxblox_rviz_plugin/voxblox_mesh_display.h"
 
 namespace voxblox_rviz_plugin {
 

--- a/voxblox_rviz_plugin/src/voxblox_mesh_visual.cc
+++ b/voxblox_rviz_plugin/src/voxblox_mesh_visual.cc
@@ -1,10 +1,11 @@
+#include "voxblox_rviz_plugin/voxblox_mesh_visual.h"
+
 #include <limits>
 
 #include <OGRE/OgreSceneManager.h>
 #include <OGRE/OgreSceneNode.h>
-#include <voxblox/mesh/mesh_utils.h>
 
-#include "voxblox_rviz_plugin/voxblox_mesh_visual.h"
+#include <voxblox/mesh/mesh_utils.h>
 
 namespace voxblox_rviz_plugin {
 


### PR DESCRIPTION
There is no functionality change in here, just running clang-format over everything once.
clang-format file is updated to preserve the order of the include blocks.
Include order has been updated such that it is consistent over the whole repo.