### PR TITLE
Added getter for const ptr.

### DIFF
--- a/voxblox/include/voxblox/core/esdf_map.h
+++ b/voxblox/include/voxblox/core/esdf_map.h
@@ -51,6 +51,10 @@ class EsdfMap {
   virtual ~EsdfMap() {}
 
   Layer<EsdfVoxel>* getEsdfLayerPtr() { return esdf_layer_.get(); }
+  const Layer<EsdfVoxel>* getEsdfLayerConstPtr() const {
+    return esdf_layer_.get();
+  }
+
   const Layer<EsdfVoxel>& getEsdfLayer() const { return *esdf_layer_; }
 
   FloatingPoint block_size() const { return block_size_; }


### PR DESCRIPTION
An analgoue to the function available for tsdf maps here:

https://github.com/ethz-asl/voxblox/blob/master/voxblox/include/voxblox/core/tsdf_map.h#L65