### PR TITLE
Feature/read from general stream

### DIFF
--- a/voxblox/include/voxblox/io/layer_io.h
+++ b/voxblox/include/voxblox/io/layer_io.h
@@ -35,7 +35,7 @@ template <typename VoxelType>
 bool LoadBlocksFromStream(
     const size_t num_blocks,
     typename Layer<VoxelType>::BlockMergingStrategy strategy,
-    std::fstream* proto_file_ptr, Layer<VoxelType>* layer_ptr,
+    std::istream* proto_file_ptr, Layer<VoxelType>* layer_ptr,
     uint64_t* tmp_byte_offset_ptr);
 
 /**

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -36,8 +36,8 @@ bool LoadBlocksFromFile(
   do {
     // Get number of messages
     uint32_t num_protos;
-    if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
-                                          &tmp_byte_offset)) {
+    if (!utils::readProtoMsgCountFromStream(&proto_file, &num_protos,
+                                            &tmp_byte_offset)) {
       LOG(ERROR) << "Could not read number of messages.";
       return false;
     }
@@ -150,8 +150,8 @@ bool LoadLayer(const std::string& file_path, const bool multiple_layer_support,
   do {
     // Get number of messages
     uint32_t num_protos;
-    if (!utils::readProtoMsgCountToStream(&proto_file, &num_protos,
-                                          &tmp_byte_offset)) {
+    if (!utils::readProtoMsgCountFromStream(&proto_file, &num_protos,
+                                            &tmp_byte_offset)) {
       LOG(ERROR) << "Could not read number of messages.";
       return false;
     }

--- a/voxblox/include/voxblox/io/layer_io_inl.h
+++ b/voxblox/include/voxblox/io/layer_io_inl.h
@@ -104,7 +104,7 @@ template <typename VoxelType>
 bool LoadBlocksFromStream(
     const size_t num_blocks,
     typename Layer<VoxelType>::BlockMergingStrategy strategy,
-    std::fstream* proto_file_ptr, Layer<VoxelType>* layer_ptr,
+    std::istream* proto_file_ptr, Layer<VoxelType>* layer_ptr,
     uint64_t* tmp_byte_offset_ptr) {
   CHECK_NOTNULL(proto_file_ptr);
   CHECK_NOTNULL(layer_ptr);

--- a/voxblox/include/voxblox/mesh/marching_cubes.h
+++ b/voxblox/include/voxblox/mesh/marching_cubes.h
@@ -36,8 +36,8 @@ class MarchingCubes {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  static int kTriangleTable[256][16];
-  static int kEdgeIndexPairs[12][2];
+  static const int kTriangleTable[256][16];
+  static const int kEdgeIndexPairs[12][2];
 
   MarchingCubes() {}
   virtual ~MarchingCubes() {}

--- a/voxblox/include/voxblox/utils/protobuf_utils.h
+++ b/voxblox/include/voxblox/utils/protobuf_utils.h
@@ -2,6 +2,7 @@
 #define VOXBLOX_UTILS_PROTOBUF_UTILS_H_
 
 #include <fstream>
+#include <istream>
 
 #include <glog/logging.h>
 #include <google/protobuf/message.h>
@@ -10,14 +11,14 @@
 namespace voxblox {
 
 namespace utils {
-bool readProtoMsgCountFromStream(std::fstream* stream_in,
+bool readProtoMsgCountFromStream(std::istream* stream_in,
                                  uint32_t* message_count,
                                  uint64_t* byte_offset);
 
 bool writeProtoMsgCountToStream(uint32_t message_count,
                                 std::fstream* stream_out);
 
-bool readProtoMsgFromStream(std::fstream* stream_in,
+bool readProtoMsgFromStream(std::istream* stream_in,
                             google::protobuf::Message* message,
                             uint64_t* byte_offset);
 

--- a/voxblox/include/voxblox/utils/protobuf_utils.h
+++ b/voxblox/include/voxblox/utils/protobuf_utils.h
@@ -10,8 +10,9 @@
 namespace voxblox {
 
 namespace utils {
-bool readProtoMsgCountToStream(std::fstream* stream_in, uint32_t* message_count,
-                               uint64_t* byte_offset);
+bool readProtoMsgCountFromStream(std::fstream* stream_in,
+                                 uint32_t* message_count,
+                                 uint64_t* byte_offset);
 
 bool writeProtoMsgCountToStream(uint32_t message_count,
                                 std::fstream* stream_out);

--- a/voxblox/src/mesh/marching_cubes.cc
+++ b/voxblox/src/mesh/marching_cubes.cc
@@ -26,7 +26,7 @@ namespace voxblox {
 // Lookup table from the 256 possible cube configurations from
 // CalculateVertexConfigurationIndex() to the 0-5 triplets the give the edges
 // where the triangle vertices lie.
-int MarchingCubes::kTriangleTable[256][16] = {
+const int MarchingCubes::kTriangleTable[256][16] = {
     {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
     {0, 8, 3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
     {0, 1, 9, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
@@ -286,8 +286,8 @@ int MarchingCubes::kTriangleTable[256][16] = {
 
 // Lookup table from the 12 cube edge indices to their corresponding corner
 // indices.
-int MarchingCubes::kEdgeIndexPairs[12][2] = {{0, 1}, {1, 2}, {2, 3}, {3, 0},
-                                             {4, 5}, {5, 6}, {6, 7}, {7, 4},
-                                             {0, 4}, {1, 5}, {2, 6}, {3, 7}};
+const int MarchingCubes::kEdgeIndexPairs[12][2] = {
+    {0, 1}, {1, 2}, {2, 3}, {3, 0}, {4, 5}, {5, 6},
+    {6, 7}, {7, 4}, {0, 4}, {1, 5}, {2, 6}, {3, 7}};
 
 }  // namespace voxblox

--- a/voxblox/src/utils/protobuf_utils.cc
+++ b/voxblox/src/utils/protobuf_utils.cc
@@ -7,13 +7,12 @@
 namespace voxblox {
 
 namespace utils {
-bool readProtoMsgCountFromStream(std::fstream* stream_in,
+bool readProtoMsgCountFromStream(std::istream* stream_in,
                                  uint32_t* message_count,
                                  uint64_t* byte_offset) {
   CHECK_NOTNULL(stream_in);
   CHECK_NOTNULL(message_count);
   CHECK_NOTNULL(byte_offset);
-  CHECK(stream_in->is_open());
   stream_in->clear();
   stream_in->seekg(*byte_offset, std::ios::beg);
   google::protobuf::io::IstreamInputStream raw_in(stream_in);
@@ -38,13 +37,12 @@ bool writeProtoMsgCountToStream(uint32_t message_count,
   return true;
 }
 
-bool readProtoMsgFromStream(std::fstream* stream_in,
+bool readProtoMsgFromStream(std::istream* stream_in,
                             google::protobuf::Message* message,
                             uint64_t* byte_offset) {
   CHECK_NOTNULL(stream_in);
   CHECK_NOTNULL(message);
   CHECK_NOTNULL(byte_offset);
-  CHECK(stream_in->is_open());
 
   stream_in->clear();
   stream_in->seekg(*byte_offset, std::ios::beg);

--- a/voxblox/src/utils/protobuf_utils.cc
+++ b/voxblox/src/utils/protobuf_utils.cc
@@ -7,8 +7,9 @@
 namespace voxblox {
 
 namespace utils {
-bool readProtoMsgCountToStream(std::fstream* stream_in, uint32_t* message_count,
-                               uint64_t* byte_offset) {
+bool readProtoMsgCountFromStream(std::fstream* stream_in,
+                                 uint32_t* message_count,
+                                 uint64_t* byte_offset) {
   CHECK_NOTNULL(stream_in);
   CHECK_NOTNULL(message_count);
   CHECK_NOTNULL(byte_offset);


### PR DESCRIPTION
I needed to read protobuf messages from a stream of data in memory (as opposed to in a file). I swapped loading function inputs from `fstream*` to `istream*`. They were being implicitly cast to those types anyway, when passed to protobuf functions. 

I also corrected a naming typo... This is a breaking change for anyone depending on this function... But it was quite confusing.

on top of #332 