### PR TITLE
Add dedicated color maps for unique IDs

### DIFF
--- a/voxblox/include/voxblox/utils/color_maps.h
+++ b/voxblox/include/voxblox/utils/color_maps.h
@@ -110,7 +110,7 @@ class IrrationalIdColorMap : IdColorMap {
 
   void setIrrationalBase(float value) { irrational_base_ = value; }
 
-  virtual Color colorLookup(size_t value) const {
+  virtual Color colorLookup(const size_t value) const {
     const float normalized_color = std::fmod(value / irrational_base_, 1.f);
     return rainbowColorMap(normalized_color);
   }
@@ -130,7 +130,7 @@ class ExponentialOffsetColorMap : IdColorMap {
 
   void setItemsPerRevolution(uint value) { items_per_revolution_ = value; }
 
-  virtual Color colorLookup(size_t value) const {
+  virtual Color colorLookup(const size_t value) const {
     const size_t revolution = value / items_per_revolution_;
     const float progress_along_revolution =
         std::fmod(value / items_per_revolution_, 1.f);
@@ -154,7 +154,7 @@ class ExponentialOffsetColorMap : IdColorMap {
   }
 
  private:
-    float items_per_revolution_;
+  float items_per_revolution_;
 };
 
 }  // namespace voxblox

--- a/voxblox/include/voxblox/utils/color_maps.h
+++ b/voxblox/include/voxblox/utils/color_maps.h
@@ -91,6 +91,72 @@ class IronbowColorMap : public ColorMap {
   float increment_;
 };
 
+class IdColorMap {
+ public:
+  IdColorMap() {}
+  virtual ~IdColorMap() {}
+
+  virtual Color colorLookup(size_t value) const = 0;
+};
+/**
+ * Map unique IDs from [0, Inf[ to unique colors that have constant (irrational)
+ * spacing and high spread on the color wheel.
+ * An important advantage of this color map is that the colors are independent
+ * of the max ID value, e.g. previous colors don't change when adding new IDs.
+ */
+class IrrationalIdColorMap : IdColorMap {
+ public:
+  IrrationalIdColorMap() : irrational_base_(3.f * M_PI) {}
+
+  void setIrrationalBase(float value) { irrational_base_ = value; }
+
+  virtual Color colorLookup(size_t value) const {
+    const float normalized_color = std::fmod(value / irrational_base_, 1.f);
+    return rainbowColorMap(normalized_color);
+  }
+
+ private:
+  float irrational_base_;
+};
+/**
+ * Map unique IDs from [0, Inf[ to unique colors
+ * with piecewise constant spacing and higher spread on the color wheel.
+ * An important advantage of this color map is that the colors are independent
+ * of the max ID value, e.g. previous colors don't change when adding new IDs.
+ */
+class ExponentialOffsetColorMap : IdColorMap {
+ public:
+  ExponentialOffsetColorMap() : items_per_revolution_(10u) {}
+
+  void setItemsPerRevolution(uint value) { items_per_revolution_ = value; }
+
+  virtual Color colorLookup(size_t value) const {
+    const size_t revolution = value / items_per_revolution_;
+    const float progress_along_revolution =
+        std::fmod(value / items_per_revolution_, 1.f);
+    // NOTE: std::modf could be used to simultaneously get the integer and
+    //       fractional parts, but the above code is assumed to be more readable
+
+    // Calculate the offset if appropriate
+    float offset = 0;
+    if (items_per_revolution_ < value + 1u) {
+      const size_t current_episode = std::floor(std::log2(revolution));
+      const size_t episode_start = std::exp2(current_episode);
+      const size_t episode_num_subdivisions = episode_start;
+      const size_t current_subdivision = revolution - episode_start;
+      const float subdivision_step_size =
+          1 / (items_per_revolution_ * 2 * episode_num_subdivisions);
+      offset = (2 * current_subdivision + 1) * subdivision_step_size;
+    }
+
+    const float normalized_color = progress_along_revolution + offset;
+    return rainbowColorMap(normalized_color);
+  }
+
+ private:
+    float items_per_revolution_;
+};
+
 }  // namespace voxblox
 
 #endif  // VOXBLOX_UTILS_COLOR_MAPS_H_


### PR DESCRIPTION
This PR implements new color maps to make it easier to visualize unique IDs, with the following goals:
- knowledge of the max ID should not be required, such that new IDs can be added without ever having to change the colors of past IDs
- the colors for different IDs should remain as distinguishable as possible, so colors should not repeat and spread well across the color wheel
- the colors should communicate which IDs are subsequent, for example by being (roughly) constantly spaced on the color wheel


Two color maps are implemented, based on
1. Division by an irrational number followed, which results in a fractional left over that never repeats. See the left plot in the gif below.
2. Constant steps that are offset such that the colors on subsequent revolutions always fall in between those of previous revolutions. See the right plot in the gif below.

Illustration:
Note that the colors in question are shown in the bottom row. The colors in the top two rows only illustrate which samples are subsequent.
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/6238939/91461577-78055380-e889-11ea-91f5-332a2a0e3a98.gif)
