### PR TITLE
Make names of classes derived from IdColorMap consistent

### DIFF
--- a/voxblox/include/voxblox/utils/color_maps.h
+++ b/voxblox/include/voxblox/utils/color_maps.h
@@ -124,9 +124,9 @@ class IrrationalIdColorMap : IdColorMap {
  * An important advantage of this color map is that the colors are independent
  * of the max ID value, e.g. previous colors don't change when adding new IDs.
  */
-class ExponentialOffsetColorMap : IdColorMap {
+class ExponentialOffsetIdColorMap : IdColorMap {
  public:
-  ExponentialOffsetColorMap() : items_per_revolution_(10u) {}
+  ExponentialOffsetIdColorMap() : items_per_revolution_(10u) {}
 
   void setItemsPerRevolution(uint value) { items_per_revolution_ = value; }
 


### PR DESCRIPTION
@Schmluk thanks for pointing this out