### PR TITLE
expose incremental pub via param, stop publishing pointclouds on map reception.

### DIFF
--- a/voxblox_ros/include/voxblox_ros/tsdf_server.h
+++ b/voxblox_ros/include/voxblox_ros/tsdf_server.h
@@ -171,6 +171,7 @@ class TsdfServer {
   bool publish_slices_;
   bool publish_pointclouds_;
   bool publish_tsdf_map_;
+  bool publish_map_incremental_;  // true: only publish updated blocks, false: publish whole map
 
   /// Whether to save the latest mesh message sent (for inheriting classes).
   bool cache_mesh_;

--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -148,7 +148,7 @@ void EsdfServer::publishTraversable() {
 
 void EsdfServer::publishMap(const bool reset_remote_map) {
   if (this->esdf_map_pub_.getNumSubscribers() > 0) {
-    const bool only_updated = false;
+    const bool only_updated = publish_map_incremental_;
     timing::Timer publish_map_timer("map/publish_esdf");
     voxblox_msgs::Layer layer_msg;
     serializeLayerAsMsg<EsdfVoxel>(this->esdf_map_->getEsdfLayer(),
@@ -232,7 +232,9 @@ void EsdfServer::esdfMapCallback(const voxblox_msgs::Layer& layer_msg) {
     ROS_ERROR_THROTTLE(10, "Got an invalid ESDF map message!");
   } else {
     ROS_INFO_ONCE("Got an ESDF map from ROS topic!");
-    publishPointclouds();
+    if (publish_pointclouds_) {
+      publishPointclouds();
+    }
   }
 }
 


### PR DESCRIPTION
* Add a parameter that allows to publish only updated blocks if multiple servers are used.
* Pointclouds are only produced if the publish_pointclouds is true. This consumes a lot of unnecessary compute otherwise.
