### PR TITLE
make publish_pointclouds param grip for external map updates

### DIFF
--- a/voxblox_ros/src/esdf_server.cc
+++ b/voxblox_ros/src/esdf_server.cc
@@ -240,7 +240,9 @@ void EsdfServer::esdfMapCallback(const voxblox_msgs::Layer& layer_msg) {
     ROS_ERROR_THROTTLE(10, "Got an invalid ESDF map message!");
   } else {
     ROS_INFO_ONCE("Got an ESDF map from ROS topic!");
-    publishPointclouds();
+    if (publish_pointclouds_) {
+      publishPointclouds();
+    }
   }
 }
 


### PR DESCRIPTION
Minor fix to prevent pointclouds from being published all the time if they are disabled, draining a lot of compute.