### PR TITLE
README: remove broken link to a youtube video

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Voxblox is a volumetric mapping library based mainly on Truncated Signed Distanc
 
 # Paper and Video
 A video showing sample output from voxblox can be seen [here](https://www.youtube.com/watch?v=PlqT5zNsvwM).
-A video of voxblox being used for online planning on-board a multicopter can be seen [here](https://youtu.be/lrGSwAPzMOQ).
 
 If using voxblox for scientific publications, please cite the following paper, available [here](http://helenol.github.io/publications/iros_2017_voxblox.pdf):
 


### PR DESCRIPTION
I was not sure if to remove the link or if it should actually point to a different video.