### PR TITLE
Add distance getters to tsdf map

### DIFF
--- a/voxblox/include/voxblox/core/tsdf_map.h
+++ b/voxblox/include/voxblox/core/tsdf_map.h
@@ -79,6 +79,13 @@ class TsdfMap {
   template <typename MatrixType>
   using EigenDRef = Eigen::Ref<MatrixType, 0, EigenDStride>;
 
+  bool getDistanceAtPosition(const Eigen::Vector3d& position,
+                             double* distance) const;
+  bool getDistanceAtPosition(const Eigen::Vector3d& position, bool interpolate,
+                             double* distance) const;
+
+  bool isObserved(const Eigen::Vector3d& position) const;
+
   /**
    *  Extract all voxels on a slice plane that is parallel to one of the
    * axis-aligned planes. free_plane_index specifies the free coordinate

--- a/voxblox/src/core/tsdf_map.cc
+++ b/voxblox/src/core/tsdf_map.cc
@@ -2,6 +2,35 @@
 
 namespace voxblox {
 
+bool TsdfMap::getDistanceAtPosition(const Eigen::Vector3d& position,
+                                    double* distance) const {
+  constexpr bool kInterpolate = true;
+  return getDistanceAtPosition(position, interpolate, distance);
+}
+
+bool TsdfMap::getDistanceAtPosition(const Eigen::Vector3d& position,
+                                    bool interpolate, double* distance) const {
+  FloatingPoint distance_fp;
+  const bool success = interpolator_.getDistance(position.cast<FloatingPoint>(),
+                                                 &distance_fp, interpolate);
+  if (success) {
+    *distance = static_cast<double>(distance_fp);
+  }
+  return success;
+}
+
+bool TsdfMap::isObserved(const Eigen::Vector3d& position) const {
+  constexpr double kMinWeight = 1e-6;
+  Block<TsdfVoxel>::Ptr block_ptr =
+      tsdf_layer_->getBlockPtrByCoordinates(position.cast<FloatingPoint>());
+  if (block_ptr) {
+    const TsdfVoxel& voxel =
+        block_ptr->getVoxelByCoordinates(position.cast<FloatingPoint>());
+    return voxel.weight > kMinWeight;
+  }
+  return false;
+}
+
 unsigned int TsdfMap::coordPlaneSliceGetDistanceWeight(
     unsigned int free_plane_index, double free_plane_val,
     EigenDRef<Eigen::Matrix<double, 3, Eigen::Dynamic>>& positions,


### PR DESCRIPTION
Allows to directly access the distance in a TSDF map without first computing the ESDF map. This is useful for ground robots which are only interested in the environment near the surfaces.