### PR TITLE
Add distance getters to tsdf map

### DIFF
--- a/voxblox/include/voxblox/core/tsdf_map.h
+++ b/voxblox/include/voxblox/core/tsdf_map.h
@@ -79,6 +79,13 @@ class TsdfMap {
   template <typename MatrixType>
   using EigenDRef = Eigen::Ref<MatrixType, 0, EigenDStride>;
 
+  bool getDistanceAtPosition(const Eigen::Vector3d& position,
+                             double* distance) const;
+  bool getDistanceAtPosition(const Eigen::Vector3d& position, bool interpolate,
+                             double* distance) const;
+
+  bool isObserved(const Eigen::Vector3d& position) const;
+
   /**
    *  Extract all voxels on a slice plane that is parallel to one of the
    * axis-aligned planes. free_plane_index specifies the free coordinate


### PR DESCRIPTION
Allows to directly access the distance in a TSDF map without first computing the ESDF map. This is useful for ground robots which are only interested in the environment near the surfaces.