### PR TITLE
refactor interfaces for getting/setting the updated bits

### DIFF
--- a/voxblox/include/voxblox/core/block.h
+++ b/voxblox/include/voxblox/core/block.h
@@ -167,15 +167,14 @@ class Block {
   void setOrigin(const Point& new_origin) { origin_ = new_origin; }
   FloatingPoint block_size() const { return block_size_; }
 
+  bool updated(Update::Status status) const { return updated_[status]; }
   bool has_data() const { return has_data_; }
-
-  const std::bitset<Update::kCount>& updated() const { return updated_; }
-  std::bitset<Update::kCount>& updated() { return updated_; }
   bool& has_data() { return has_data_; }
 
-  void set_updated(const std::bitset<Update::kCount>& updated) {
-    updated_ = updated;
+  void setUpdated(Update::Status status, bool value) {
+    updated_[status] = value;
   }
+  void setUpdatedAll() { updated_.set(); }
   void set_has_data(bool has_data) { has_data_ = has_data; }
 
   // Serialization.

--- a/voxblox/include/voxblox/core/block_inl.h
+++ b/voxblox/include/voxblox/core/block_inl.h
@@ -117,7 +117,7 @@ void Block<VoxelType>::mergeBlock(const Block<VoxelType>& other_block) {
     return;
   } else {
     has_data() = true;
-    updated().set();
+    setUpdatedAll();
 
     for (IndexElement voxel_idx = 0;
          voxel_idx < static_cast<IndexElement>(num_voxels()); ++voxel_idx) {

--- a/voxblox/include/voxblox/core/layer.h
+++ b/voxblox/include/voxblox/core/layer.h
@@ -196,7 +196,7 @@ class Layer {
     blocks->clear();
     for (const std::pair<const BlockIndex, typename BlockType::Ptr>& kv :
          block_map_) {
-      if (kv.second->updated()[bit]) {
+      if (kv.second->updated(bit)) {
         blocks->emplace_back(kv.first);
       }
     }

--- a/voxblox/include/voxblox/core/layer_inl.h
+++ b/voxblox/include/voxblox/core/layer_inl.h
@@ -224,7 +224,7 @@ bool Layer<VoxelType>::addBlockFromProto(const BlockProto& block_proto,
         return false;
     }
     // Mark that this block has been updated.
-    block_map_[block_index]->updated().set();
+    block_map_[block_index]->setUpdatedAll();
   } else {
     LOG(ERROR)
         << "The blocks from this protobuf are not compatible with this layer!";

--- a/voxblox/include/voxblox/integrator/occupancy_integrator.h
+++ b/voxblox/include/voxblox/integrator/occupancy_integrator.h
@@ -147,7 +147,7 @@ class OccupancyIntegrator {
 
       if (!block || block_idx != last_block_idx) {
         block = layer_->allocateBlockPtrByIndex(block_idx);
-        block->updated().set();
+        block->setUpdatedAll();
         last_block_idx = block_idx;
       }
 
@@ -165,7 +165,7 @@ class OccupancyIntegrator {
 
       if (!block || block_idx != last_block_idx) {
         block = layer_->allocateBlockPtrByIndex(block_idx);
-        block->updated().set();
+        block->setUpdatedAll();
         last_block_idx = block_idx;
       }
 

--- a/voxblox/include/voxblox/mesh/mesh_integrator.h
+++ b/voxblox/include/voxblox/mesh/mesh_integrator.h
@@ -178,7 +178,7 @@ class MeshIntegrator {
       if (clear_updated_flag) {
         typename Block<VoxelType>::Ptr block =
             sdf_layer_mutable_->getBlockPtrByIndex(block_idx);
-        block->updated().reset(Update::kMesh);
+        block->setUpdated(Update::kMesh, false);
       }
     }
   }

--- a/voxblox/src/integrator/esdf_integrator.cc
+++ b/voxblox/src/integrator/esdf_integrator.cc
@@ -114,8 +114,7 @@ void EsdfIntegrator::updateFromTsdfLayer(bool clear_updated_flag) {
     for (const BlockIndex& block_index : tsdf_blocks) {
       if (tsdf_layer_->hasBlock(block_index)) {
         tsdf_layer_->getBlockByIndex(block_index)
-            .updated()
-            .reset(Update::kEsdf);
+            .setUpdated(Update::kEsdf, false);
       }
     }
   }
@@ -144,7 +143,7 @@ void EsdfIntegrator::updateFromTsdfBlocks(const BlockIndexList& tsdf_blocks,
     // Block indices are the same across all layers.
     Block<EsdfVoxel>::Ptr esdf_block =
         esdf_layer_->allocateBlockPtrByIndex(block_index);
-    esdf_block->set_updated(true);
+    esdf_block->setUpdated(Update::kEsdf, true);
 
     const size_t num_voxels_per_block = tsdf_block->num_voxels();
     for (size_t lin_index = 0u; lin_index < num_voxels_per_block; ++lin_index) {

--- a/voxblox/src/integrator/tsdf_integrator.cc
+++ b/voxblox/src/integrator/tsdf_integrator.cc
@@ -125,7 +125,7 @@ TsdfVoxel* TsdfIntegratorBase::allocateStorageAndGetVoxelPtr(
     }
   }
 
-  (*last_block)->updated().set();
+  (*last_block)->setUpdatedAll();
 
   const VoxelIndex local_voxel_idx =
       getLocalFromGlobalVoxelIndex(global_voxel_idx, voxels_per_side_);


### PR DESCRIPTION
Change the interfaces to get/set the 'updated' bits to avoid confusion and accidental overwriting of data.