### PR TITLE
Fixes for MSVC compatibility

### DIFF
--- a/voxblox/include/voxblox/integrator/integrator_utils.h
+++ b/voxblox/include/voxblox/integrator/integrator_utils.h
@@ -121,8 +121,8 @@ class RayCaster {
   AnyIndex ray_step_signs_;
   Ray t_step_size_;
 
-  uint ray_length_in_steps_;
-  uint current_step_;
+  uint32_t ray_length_in_steps_;
+  uint32_t current_step_;
 };
 
 /**

--- a/voxblox/src/core/block.cc
+++ b/voxblox/src/core/block.cc
@@ -25,11 +25,11 @@ void serializeDirection(const Eigen::Vector3i& parent_direction,
   // need to be truncated in the ESDF integrator or we need to use more bytes to
   // serialize the ESDF voxel.
   const int8_t parent_direction_x =
-      std::min(INT8_MAX, std::max(parent_direction.x(), INT8_MIN));
+      std::min<int>(INT8_MAX, std::max<int>(parent_direction.x(), INT8_MIN));
   const int8_t parent_direction_y =
-      std::min(INT8_MAX, std::max(parent_direction.y(), INT8_MIN));
+      std::min<int>(INT8_MAX, std::max<int>(parent_direction.y(), INT8_MIN));
   const int8_t parent_direction_z =
-      std::min(INT8_MAX, std::max(parent_direction.z(), INT8_MIN));
+      std::min<int>(INT8_MAX, std::max<int>(parent_direction.z(), INT8_MIN));
 
   // Layout:
   // | 3x8bit (int8_t) for parent (X,Y,Z) | 8bit ESDF |


### PR DESCRIPTION
Compiling voxblox under MSVC leads to a few compilation errors. This fixes the issues and should be compatible with any other common compilers (gcc, clang, ...).