### PR TITLE
Add missing getter

### DIFF
--- a/voxblox/include/voxblox/integrator/tsdf_integrator.h
+++ b/voxblox/include/voxblox/integrator/tsdf_integrator.h
@@ -105,6 +105,9 @@ class TsdfIntegratorBase {
   /// Returns a CONST ref of the config.
   const Config& getConfig() const { return config_; }
 
+  /// Returns a CONST ref to the current layer
+  const Layer<TsdfVoxel>* getLayer() const { return layer_; }
+
   void setLayer(Layer<TsdfVoxel>* layer);
 
  protected:


### PR DESCRIPTION
If the member is protected it should be a way of accessing it at least as
a const reference. The other option would be to create a wrapper class
that inherits from TSDFIntegrator, and provide the missing getter... but
this is an overkill.