### PR TITLE
Add build tests using github actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -37,6 +37,8 @@ jobs:
         apt update && apt install -y python3-wstool python3-catkin-tools
     - name: release_build_test
       working-directory: 
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
         apt update
         apt install -y python3-wstool autoconf libtool git

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,56 @@
+
+name: Build Test
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {rosdistro: 'melodic', container: 'ros:melodic-ros-base-bionic'}
+          - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
+    container: ${{ matrix.config.container }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install catkin-tools on melodic
+      if: ${{ matrix.config.container == 'ros:melodic-ros-base-bionic' }}
+      run: |
+        apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+        apt update && apt install -y python3-wstool python-catkin-tools 
+    - name: Install catkin-tools on Noetic
+      if: ${{ matrix.config.container == 'ros:noetic-ros-base-focal' }}
+      run: |
+        apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+        apt update && apt install -y python3-pip
+        pip3 install osrf-pycommon
+        apt update && apt install -y python3-wstool python3-catkin-tools
+    - name: release_build_test
+      working-directory: 
+      run: |
+        apt update
+        apt install -y python3-wstool autoconf libtool git
+        mkdir -p $HOME/catkin_ws/src;
+        cd $HOME/catkin_ws
+        catkin init
+        catkin config --extend "/opt/ros/${{matrix.config.rosdistro}}"
+        catkin config --merge-devel
+        cd $HOME/catkin_ws/src
+        ln -s $GITHUB_WORKSPACE
+        cd $HOME/catkin_ws
+        wstool init src src/voxblox/voxblox_https.rosinstall
+        wstool update -t src -j4
+        rosdep update
+        rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
+        catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
+        catkin build -j$(nproc) -l$(nproc) voxblox_ros

--- a/voxblox_https.rosinstall
+++ b/voxblox_https.rosinstall
@@ -28,3 +28,6 @@
 - git:
     local-name: catkin_boost_python_buildtool
     uri: https://github.com/ethz-asl/catkin_boost_python_buildtool.git
+- git:
+    local-name: catkin_grpc
+    uri: https://github.com/CogRob/catkin_grpc.git

--- a/voxblox_https.rosinstall
+++ b/voxblox_https.rosinstall
@@ -23,6 +23,8 @@
     local-name: protobuf_catkin
     uri: https://github.com/ethz-asl/protobuf_catkin.git
 - git:
-    local-name: voxblox
-    uri: https://github.com/ethz-asl/voxblox.git
-
+    local-name: numpy_eigen
+    uri: https://github.com/ethz-asl/numpy_eigen.git
+- git:
+    local-name: catkin_boost_python_buildtool
+    uri: https://github.com/ethz-asl/catkin_boost_python_buildtool.git

--- a/voxblox_ros/CMakeLists.txt
+++ b/voxblox_ros/CMakeLists.txt
@@ -4,7 +4,7 @@ project(voxblox_ros)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
-add_definitions(-std=c++11 -Wall -Wextra)
+add_definitions(-std=c++14 -Wall -Wextra)
 
 #############
 # LIBRARIES #

--- a/voxblox_ssh.rosinstall
+++ b/voxblox_ssh.rosinstall
@@ -22,3 +22,12 @@
 - git:
     local-name: protobuf_catkin
     uri: git@github.com:ethz-asl/protobuf_catkin.git
+- git:
+    local-name: numpy_eigen
+    uri: git@github.com:ethz-asl/numpy_eigen.git
+- git:
+    local-name: catkin_boost_python_buildtool
+    uri: git@github.com:ethz-asl/catkin_boost_python_buildtool.git
+- git:
+    local-name: catkin_grpc
+    uri: git@github.com:CogRob/catkin_grpc.git

--- a/voxblox_ssh.rosinstall
+++ b/voxblox_ssh.rosinstall
@@ -22,7 +22,3 @@
 - git:
     local-name: protobuf_catkin
     uri: git@github.com:ethz-asl/protobuf_catkin.git
-- git:
-    local-name: voxblox
-    uri: git@github.com:ethz-asl/voxblox.git
-


### PR DESCRIPTION
**Problem Description**
The Jenkins CI that is currently being used doesn't seem to be transparent and does not support Ubuntu Focal.
Most PR's build test appear to be broken therefore does not give very useful feedback on evaluating PRs

**Proposed Solution**
This PR adds a build test using [github actions](https://github.com/features/actions) of this package for the following ROS versions
- ROS Noetic (Ubuntu 20.04 Focal)
- ROS Melodic (Ubuntu 18.04 Bionic)

By adding the build tests some of the dependencies that were either missing or self including (voxblox was also part of the dependency of this package) has been fixed.

**Testing**
Since github actions are not being triggered before this PR getting merged, the output can be found running on the fork: https://github.com/Jaeyoung-Lim/voxblox/pull/1

@alexmillane Is there anychance that the github actions are disabled in this repo?

**Additional Context**
- https://github.com/ethz-asl/voxblox/pull/379 was included to show that this can be used to verify build testing in ROS Noetic