### PR TITLE
Add build test status badge to the readme

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         config:
           - {rosdistro: 'melodic', container: 'ros:melodic-ros-base-bionic'}
-          - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
+          # - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Voxblox
 
+[![Build Test](https://github.com/ethz-asl/voxblox/actions/workflows/build_test.yml/badge.svg)](https://github.com/ethz-asl/voxblox/actions/workflows/build_test.yml)
+
 ![voxblox_small](https://cloud.githubusercontent.com/assets/5616392/15180357/536a8776-1781-11e6-8c1d-f2dfa34b1408.gif)
 
 Voxblox is a volumetric mapping library based mainly on Truncated Signed Distance Fields (TSDFs). It varies from other SDF libraries in the following ways:


### PR DESCRIPTION
**Problem Description**
This PR adds a build status badge to the read me, which will automatically show the build status (Badge shown below)

[![Build Test](https://github.com/ethz-asl/voxblox/actions/workflows/build_test.yml/badge.svg)](https://github.com/ethz-asl/voxblox/actions/workflows/build_test.yml)

Currently it appears as broken since the build test is broken for ROS Noetic.

Therefore disabling build test for ROS Noetic is temporarily for now