### PR TITLE
Add github actions build test for ROS Noetic

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         config:
           - {rosdistro: 'melodic', container: 'ros:melodic-ros-base-bionic'}
-          # - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
+          - {rosdistro: 'noetic', container: 'ros:noetic-ros-base-focal'}
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v1
@@ -56,3 +56,4 @@ jobs:
         rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
         catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release
         catkin build -j$(nproc) -l$(nproc) voxblox_ros
+      shell: bash


### PR DESCRIPTION
**Problem Description**
This PR enables a build test for ROS Noetic using github actions.

In a previous attempt, builds for ROS Noetic was broken due to a broken dependency in `protobuf_catkin`
- The fix for `protobuf_catkin` was made in https://github.com/ethz-asl/protobuf_catkin/pull/38 
- Since the fix is still in form of a PR, the dependency is temporarily switched to the PR branch so that the build test runs in this repo. Once the PR is merged, the dependency should be switched back

**Additional Context**
- This is a follow up PR of https://github.com/ethz-asl/voxblox/pull/380