### PR TITLE
Update dependency version tag for catkin_grpc

### DIFF
--- a/voxblox_https.rosinstall
+++ b/voxblox_https.rosinstall
@@ -31,4 +31,3 @@
 - git:
     local-name: catkin_grpc
     uri: https://github.com/CogRob/catkin_grpc.git
-    version: ea5247b21ac885ca483b1f12052e37bfa1494220

--- a/voxblox_ssh.rosinstall
+++ b/voxblox_ssh.rosinstall
@@ -31,4 +31,3 @@
 - git:
     local-name: catkin_grpc
     uri: git@github.com:CogRob/catkin_grpc.git
-    version: ea5247b21ac885ca483b1f12052e37bfa1494220


### PR DESCRIPTION
**Problem Description**
Since catkin_grpc was broken, we fixed the version of `catkin_grpc` before the breaking change in https://github.com/ethz-asl/voxblox/pull/379

Since the fix has been merged in https://github.com/CogRob/catkin_grpc/pull/45 I think it makes sense to go back to using latest `catkin_grpc`
