### PR TITLE
avoid zero division in RayCaster::setupRayCaster

### DIFF
--- a/voxblox/src/integrator/integrator_utils.cc
+++ b/voxblox/src/integrator/integrator_utils.cc
@@ -157,24 +157,24 @@ void RayCaster::setupRayCaster(const Point& start_scaled,
   Ray distance_to_boundaries(corrected_step.cast<FloatingPoint>() -
                              start_scaled_shifted);
 
-  t_to_next_boundary_ = Ray((std::abs(ray_scaled.x()) < 0.0)
+  t_to_next_boundary_ = Ray((std::abs(ray_scaled.x()) <= 0.0)
                                 ? 2.0
                                 : distance_to_boundaries.x() / ray_scaled.x(),
-                            (std::abs(ray_scaled.y()) < 0.0)
+                            (std::abs(ray_scaled.y()) <= 0.0)
                                 ? 2.0
                                 : distance_to_boundaries.y() / ray_scaled.y(),
-                            (std::abs(ray_scaled.z()) < 0.0)
+                            (std::abs(ray_scaled.z()) <= 0.0)
                                 ? 2.0
                                 : distance_to_boundaries.z() / ray_scaled.z());
 
   // Distance to cross one grid cell along the ray in t.
   // Same as absolute inverse value of delta_coord.
   t_step_size_ = Ray(
-      (std::abs(ray_scaled.x()) < 0.0) ? 2.0
+      (std::abs(ray_scaled.x()) <= 0.0) ? 2.0
                                        : ray_step_signs_.x() / ray_scaled.x(),
-      (std::abs(ray_scaled.y()) < 0.0) ? 2.0
+      (std::abs(ray_scaled.y()) <= 0.0) ? 2.0
                                        : ray_step_signs_.y() / ray_scaled.y(),
-      (std::abs(ray_scaled.z()) < 0.0) ? 2.0
+      (std::abs(ray_scaled.z()) <= 0.0) ? 2.0
                                        : ray_step_signs_.z() / ray_scaled.z());
 }
 


### PR DESCRIPTION
When I executed the following code, I got a strange result. 
```c++
GlobalIndex global_voxel_idx;
RayCaster ray_caster(Point(0.0,0.0,0.0), Point(0.0,1.0,0.0), false,
                     true,
                     5.0, 1 / 0.2,
                     0.1, false);
while (ray_caster.nextRayIndex(&global_voxel_idx)) {
  std::cout << global_voxel_idx.transpose() << std::endl;
 }
```
```
# result
0 5 0
0 5 0
0 5 0
0 5 0
0 5 0
0 5 0
```

The expected result is
```
0 5 0
0 4 0
0 3 0
0 2 0
0 1 0
0 0 0
```

This is because there are zero divisions in `RayCaster::setupRayCaster`. 
This Pull Request fixes this problem.